### PR TITLE
Add PThese, PTheseData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 - `PThese`: Include new `PThese` data type. 
   
-  Started by: [#TBD](https://github.com/Plutonomicon/plutarch/pull/TBD)
+  Started by: [#355](https://github.com/Plutonomicon/plutarch/pull/355)
 
 - `PTheseData`: Include new `PTheseData` data type.
 
-  Started by: [#TBD](https://github.com/Plutonomicon/plutarch/pull/TBD)
+  Started by: [#355](https://github.com/Plutonomicon/plutarch/pull/355)
 
 - `TermCont`: Parametrize by result type; add `MonadFail` instance; etc.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Unreleased
 
+- `PThese`: Include new `PThese` data type. 
+  
+  Started by: [#TBD](https://github.com/Plutonomicon/plutarch/pull/TBD)
+
+- `PTheseData`: Include new `PTheseData` data type.
+
+  Started by: [#TBD](https://github.com/Plutonomicon/plutarch/pull/TBD)
+
 - `TermCont`: Parametrize by result type; add `MonadFail` instance; etc.
 
   Also, export from `Plutarch.TermCont`, and then from `Plutarch.Prelude` (TermCont is no longer exported by `Plutarch.Internal`).

--- a/Plutarch/Api/V1/These.hs
+++ b/Plutarch/Api/V1/These.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+module Plutarch.Api.V1.These (PTheseData (..)) where
+
+import qualified GHC.Generics as GHC
+import Generics.SOP
+import Plutarch.DataRepr (PIsDataReprInstances (PIsDataReprInstances))
+import Plutarch.Lift (
+  PConstantRepr,
+  PConstanted,
+  PLifted,
+  PUnsafeLiftDecl,
+  pconstantFromRepr, 
+  pconstantToRepr
+ )
+import qualified Plutus.V1.Ledger.Api as Plutus
+import qualified PlutusTx.These as PlutusThese
+import Plutarch.Prelude
+
+data PTheseData (a :: PType) (b :: PType) (s :: S)
+  = PDThis (Term s (PDataRecord '["_0" ':= a]))
+  | PDThat (Term s (PDataRecord '["_0" ':= b]))
+  | PDThese (Term s (PDataRecord '["_0" ':= a, "_1" ':= b]))
+  deriving stock (GHC.Generic)
+  deriving anyclass (Generic, PIsDataRepr)
+  deriving
+    (PlutusType, PIsData)
+    via PIsDataReprInstances (PTheseData a b)
+
+-- TODO: Make PTheseData an instance of PConstant.
+
+instance
+  ( Plutus.ToData (PLifted a)
+  , Plutus.ToData (PLifted b)
+  , Plutus.FromData (PLifted a)
+  , Plutus.FromData (PLifted b)
+  , PLift a
+  , PLift b
+  ) =>
+  PUnsafeLiftDecl (PTheseData a b)
+  where
+  type PLifted (PTheseData a b) = PlutusThese.These (PLifted a) (PLifted b)
+
+instance
+  ( PLifted (PConstanted a) ~ a
+  , Plutus.ToData b
+  , Plutus.FromData b
+  , Plutus.ToData a
+  , Plutus.FromData a
+  , PConstant a
+  , PLifted (PConstanted b) ~ b
+  , Plutus.FromData b
+  , Plutus.ToData b
+  , PConstant b
+  ) =>
+  PConstant (PlutusThese.These a b)
+  where
+  type PConstantRepr (PlutusThese.These a b) = [(Plutus.Data, Plutus.Data)]
+  type PConstanted (PlutusThese.These a b) = PTheseData (PConstanted a) (PConstanted b)
+  pconstantToRepr _t = undefined
+  pconstantFromRepr _t = undefined

--- a/Plutarch/These.hs
+++ b/Plutarch/These.hs
@@ -1,0 +1,13 @@
+module Plutarch.These (PThese (..)) where
+
+import qualified GHC.Generics as GHC
+import Generics.SOP
+import Plutarch.Prelude
+
+-- | Plutus These type with Scott-encoded representation.
+data PThese (a :: PType) (b :: PType) (s :: S)
+  = PThis (Term s a)
+  | PThat (Term s b)
+  | PThese (Term s a) (Term s b)
+  deriving stock (GHC.Generic)
+  deriving anyclass (Generic, PlutusType)

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -88,6 +88,7 @@ library
     Plutarch.Api.V1.Interval
     Plutarch.Api.V1.Maybe
     Plutarch.Api.V1.Scripts
+    Plutarch.Api.V1.These
     Plutarch.Api.V1.Time
     Plutarch.Api.V1.Tuple
     Plutarch.Api.V1.Tx
@@ -122,6 +123,7 @@ library
     Plutarch.Rec.TH
     Plutarch.String
     Plutarch.TermCont
+    Plutarch.These
     Plutarch.Trace
     Plutarch.Unit
     Plutarch.Unsafe


### PR DESCRIPTION
This PR implements Plutarch analogues for [Data.These](https://hackage.haskell.org/package/these). Would it be possible to make `PTheseData` an instance of `PUnsafeLiftDecl`? I assume it would be, as `plutus-tx` appears to support `These`. I am unsure as to how to find the underlying PLC implementation. 