### PR TITLE
Interval utils

### DIFF
--- a/plutarch-extra/Plutarch/Extra/Interval.hs
+++ b/plutarch-extra/Plutarch/Extra/Interval.hs
@@ -1,0 +1,426 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE QualifiedDo #-}
+
+module Plutarch.Extra.Interval (
+  member,
+  interval,
+  from,
+  to,
+  always,
+  never,
+  singleton,
+  hull,
+  intersection,
+  contains,
+  before,
+  after,
+) where
+
+import Plutarch.Api.V1.Interval (
+  PClosure,
+  PExtended (PFinite, PNegInf, PPosInf),
+  PInterval (PInterval),
+  PLowerBound (PLowerBound),
+  PUpperBound (PUpperBound),
+ )
+import qualified Plutarch.Monadic as P
+import Plutarch.Prelude
+
+-- check if `a` belongs to interval `i`
+member :: 
+  forall a (s :: S). 
+  (PEq a, POrd a, PIsData a) => 
+  Term s a -> 
+  Term s (PInterval a) -> 
+  Term s PBool
+member a i = i `contains` (singleton a)
+
+{- | create an interval that includes all values that are greater than or equal
+ - to a and smaller than or equal to b
+-}
+interval ::
+  forall a (s :: S).
+  PIsData a =>
+  Term s a ->
+  Term s a ->
+  Term s (PInterval a)
+interval a b = closedInterval start end
+  where
+    start :: Term s (PExtended a)
+    start = pcon $ PFinite $ pdcons @"_0" # (pdata a) # pdnil
+
+    end :: Term s (PExtended a)
+    end = pcon $ PFinite $ pdcons @"_0" # (pdata b) # pdnil
+
+{- | create an interval that includes all values that are greater than or equal
+ - to a
+-}
+from :: forall a s. PIsData a => Term s a -> Term s (PInterval a)
+from a = closedInterval start end
+  where
+    start :: Term s (PExtended a)
+    start = pcon $ PFinite $ pdcons @"_0" # (pdata a) # pdnil
+
+    end :: Term s (PExtended a)
+    end = pcon $ PPosInf pdnil
+
+{- | create an interval that includes all values that are smaller than or equal
+ - to a
+-}
+to :: forall a (s :: S). PIsData a => Term s a -> Term s (PInterval a)
+to a = closedInterval start end
+  where
+    start :: Term s (PExtended a)
+    start = pcon $ PNegInf pdnil
+
+    end :: Term s (PExtended a)
+    end = pcon $ PFinite $ pdcons @"_0" # (pdata a) # pdnil
+
+-- | create an interval that covers every slot
+always :: forall a (s :: S). PIsData a => Term s (PInterval a)
+always = closedInterval start end
+  where
+    start :: Term s (PExtended a)
+    start = pcon $ PNegInf pdnil
+
+    end :: Term s (PExtended a)
+    end = pcon $ PPosInf pdnil
+
+-- | create an interval that is empty
+never :: forall a (s :: S). PIsData a => Term s (PInterval a)
+never = closedInterval start end
+  where
+    start :: Term s (PExtended a)
+    start = pcon $ PPosInf pdnil
+
+    end :: Term s (PExtended a)
+    end = pcon $ PNegInf pdnil
+
+-- | create and interval [a, a]
+singleton :: forall a (s :: S). PIsData a => Term s a -> Term s (PInterval a)
+singleton a = closedInterval start start
+  where
+    start :: Term s (PExtended a)
+    start = pcon $ PFinite $ pdcons @"_0" # (pdata a) # pdnil
+
+-- | `hull i1 i2` is the smallest interval containing `i1` and `i2`
+hull ::
+  forall a (s :: S).
+  (PEq a, POrd a, PIsData a) =>
+  Term s (PInterval a) ->
+  Term s (PInterval a) ->
+  Term s (PInterval a)
+hull x' y' = P.do
+  x <- pletFields @'["from", "to"] x'
+  y <- pletFields @'["from", "to"] y'
+
+  lowerX <- plet x.from
+  upperX <- plet x.to
+
+  lowerY <- plet y.from
+  upperY <- plet y.to
+
+  let lower = pcon $ PLowerBound $ minP (lToE lowerX) (lToE lowerY)
+      upper = pcon $ PUpperBound $ maxP (uToE upperX) (uToE upperY)
+
+  interval' lower upper
+
+-- | `intersecion i1 i2` is the largest interval contained in `i1` and `i2`
+intersection ::
+  forall a (s :: S).
+  (PEq a, POrd a, PIsData a) =>
+  Term s (PInterval a) ->
+  Term s (PInterval a) ->
+  Term s (PInterval a)
+intersection x' y' = P.do
+  x <- pletFields @'["from", "to"] x'
+  y <- pletFields @'["from", "to"] y'
+
+  lowerX <- plet x.from
+  upperX <- plet x.to
+
+  lowerY <- plet y.from
+  upperY <- plet y.to
+
+  let lower = pcon $ PLowerBound $ maxP (lToE lowerX) (lToE lowerY)
+      upper = pcon $ PUpperBound $ minP (uToE upperX) (uToE upperY)
+
+  interval' lower upper
+
+-- | `a` contains `b` is true if the interval `b` is entirely contained in `a`
+contains ::
+  forall a (s :: S).
+  (PEq a, POrd a, PIsData a) =>
+  Term s (PInterval a) ->
+  Term s (PInterval a) ->
+  Term s PBool
+contains x' y' = P.do
+  x <- pletFields @'["from", "to"] x'
+  y <- pletFields @'["from", "to"] y'
+
+  lowerX <- plet x.from
+  upperX <- plet x.to
+
+  lowerY <- plet y.from
+  upperY <- plet y.to
+
+  (leqP (lToE lowerX) (lToE lowerY)) #&& (leqP (uToE upperY) (uToE upperX))
+
+-- | `a` before interval `i` is true if `a` is earlier than the start of `i`
+before ::
+  forall a (s :: S).
+  (PEq a, POrd a, PIsData a) =>
+  Term s a ->
+  Term s (PInterval a) ->
+  Term s PBool
+before a y = P.do
+  lower <- plet $ pfield @"from" # y
+  before' a (lToE lower)
+
+-- | `a` after interval `i` is true if `a` is later than the end of `i`
+after ::
+  forall a s.
+  (PEq a, POrd a, PIsData a) =>
+  Term s a ->
+  Term s (PInterval a) ->
+  Term s PBool
+after a y = P.do
+  upper <- plet $ pfield @"to" # y
+  after' a (uToE upper)
+
+-- | interval from upper and lower
+interval' ::
+  forall a (s :: S).
+  PIsData a =>
+  Term s (PLowerBound a) ->
+  Term s (PUpperBound a) ->
+  Term s (PInterval a)
+interval' lower upper =
+  pcon $
+    PInterval $
+      pdcons @"from" # pdata lower
+        #$ pdcons @"to" # pdata upper # pdnil
+
+-- | closed interval from PExtended
+closedInterval ::
+  forall a (s :: S).
+  PIsData a =>
+  Term s (PExtended a) ->
+  Term s (PExtended a) ->
+  Term s (PInterval a)
+closedInterval start end = interval' lower upper
+  where
+    closure :: Term s PClosure
+    closure = pconstant True
+
+    upper :: Term s (PUpperBound a)
+    upper =
+      pcon $
+        PUpperBound $
+          pdcons @"_0" # pdata end #$ pdcons @"_1"
+            # pdata closure
+            # pdnil
+
+    lower :: Term s (PLowerBound a)
+    lower =
+      pcon $
+        PLowerBound $
+          pdcons @"_0" # pdata start #$ pdcons @"_1"
+            # pdata closure
+            # pdnil
+
+-- | value < endpoint
+before' ::
+  forall a (s :: S).
+  (PIsData a, POrd a, PEq a) =>
+  Term s a ->
+  Term s (EndPoint a) ->
+  Term s PBool
+before' a y' = P.do
+  y <- pletFields @'["_0", "_1"] y'
+  yt <- plet $ y._0
+  yc <- plet $ y._1
+
+  pif
+    yc
+    (pmatch yt (ltE' a))
+    (pmatch yt (leqE' a))
+
+-- | value > endpoint
+after' ::
+  forall a (s :: S).
+  (PIsData a, POrd a, PEq a) =>
+  Term s a ->
+  Term s (EndPoint a) ->
+  Term s PBool
+after' a y' = P.do
+  y <- pletFields @'["_0", "_1"] y'
+  yt <- plet $ y._0
+  yc <- plet $ y._1
+
+  pif
+    yc
+    (pmatch yt (gtE' a))
+    (pmatch yt (geqE' a))
+
+-- | (x :: Term s (EndPoint a)) <= (y :: Term s (EndPoint a))
+leqP ::
+  forall a (s :: S).
+  (PIsData a, POrd a, PEq a) =>
+  Term s (EndPoint a) ->
+  Term s (EndPoint a) ->
+  Term s PBool
+leqP x' y' = P.do
+  x <- pletFields @'["_0", "_1"] x'
+  y <- pletFields @'["_0", "_1"] y'
+
+  xt <- plet $ x._0
+  yt <- plet $ y._0
+
+  xc <- plet $ x._1
+  yc <- plet $ y._1
+
+  pif
+    (xc #&& yc #|| (pnot # xc) #&& (pnot # yc))
+    (leqE xt yt)
+    (ltE xt yt)
+
+minP ::
+  forall a (s :: S).
+  (PIsData a, POrd a, PEq a) =>
+  Term s (EndPoint a) ->
+  Term s (EndPoint a) ->
+  Term s (EndPoint a)
+minP x y = pif (leqP x y) x y
+
+maxP ::
+  forall a (s :: S).
+  (PIsData a, POrd a, PEq a) =>
+  Term s (EndPoint a) ->
+  Term s (EndPoint a) ->
+  Term s (EndPoint a)
+maxP x y = pif (leqP x y) y x
+
+-- | (x :: Term s (PExtended a)) < (y :: Term s (PExtended b))
+ltE ::
+  forall a (s :: S).
+  (POrd a, PIsData a) =>
+  Term s (PExtended a) ->
+  Term s (PExtended a) ->
+  Term s PBool
+ltE x y = pmatch x (cont y)
+  where
+    cont :: Term s (PExtended a) -> PExtended a s -> Term s PBool
+    cont y' x' = case x' of
+      PNegInf _ -> pconstant True
+      PPosInf _ -> pmatch y' isPosInf
+      PFinite l -> P.do
+        a <- plet $ pfield @"_0" # l
+        pmatch y' (ltE' a)
+
+-- | (x :: Term s (PExtended a)) = (y :: Term s (PExtended b))
+eqE ::
+  forall a (s :: S).
+  (PEq a, PIsData a) =>
+  Term s (PExtended a) ->
+  Term s (PExtended a) ->
+  Term s PBool
+eqE x y = pmatch x cont
+  where
+    cont :: PExtended a s -> Term s PBool
+    cont x' = case x' of
+      PNegInf _ -> pmatch y isNegInf
+      PPosInf _ -> pmatch y isPosInf
+      PFinite l -> P.do
+        a <- plet $ pfield @"_0" # l
+        pmatch y (eqE' a)
+
+-- | value < PExtended
+ltE' ::
+  forall a (s :: S).
+  (POrd a, PIsData a) =>
+  Term s a ->
+  PExtended a s ->
+  Term s PBool
+ltE' a y' = case y' of
+  PNegInf _ -> pconstant False
+  PPosInf _ -> pconstant True
+  PFinite r -> P.do
+    b <- plet $ pfield @"_0" # r
+    a #< b
+
+-- | value > PExtended
+gtE' ::
+  forall a (s :: S).
+  (POrd a, PIsData a) =>
+  Term s a ->
+  PExtended a s ->
+  Term s PBool
+gtE' a y' = case y' of
+  PNegInf _ -> pconstant False
+  PPosInf _ -> pconstant True
+  PFinite r -> P.do
+    b <- plet $ pfield @"_0" # r
+    b #< a
+
+-- | value = PExtended
+eqE' ::
+  forall a (s :: S).
+  (PEq a, PIsData a) =>
+  Term s a ->
+  PExtended a s ->
+  Term s PBool
+eqE' a y' = case y' of
+  PFinite r -> P.do
+    b <- plet $ pfield @"_0" # r
+    a #== b
+  _ -> pconstant False
+
+-- | value <= PExtended
+leqE' ::
+  forall a (s :: S).
+  (POrd a, PEq a, PIsData a) =>
+  Term s a ->
+  PExtended a s ->
+  Term s PBool
+leqE' a y = (ltE' a y) #|| (eqE' a y)
+
+-- | value >= PExtended
+geqE' ::
+  forall a (s :: S).
+  (POrd a, PEq a, PIsData a) =>
+  Term s a ->
+  PExtended a s ->
+  Term s PBool
+geqE' a y = (gtE' a y) #|| (eqE' a y)
+
+-- | (x :: Term s (PExtended a)) <= (y :: Term s (PExtended b))
+leqE ::
+  forall a (s :: S).
+  (PEq a, POrd a, PIsData a) =>
+  Term s (PExtended a) ->
+  Term s (PExtended a) ->
+  Term s PBool
+leqE x y = (ltE x y) #|| (eqE x y)
+
+isNegInf :: PExtended a s -> Term s PBool
+isNegInf x = case x of
+  PNegInf _ -> pconstant True
+  _ -> pconstant False
+
+isPosInf :: PExtended a s -> Term s PBool
+isPosInf x = case x of
+  PPosInf _ -> pconstant True
+  _ -> pconstant False
+
+type EndPoint a =
+  PDataRecord
+    '[ "_0" ':= PExtended a
+     , "_1" ':= PClosure
+     ]
+
+uToE :: Term s (PUpperBound a) -> Term s (EndPoint a)
+uToE x = pmatch x (\(PUpperBound a) -> a)
+
+lToE :: Term s (PLowerBound a) -> Term s (EndPoint a)
+lToE x = pmatch x (\(PLowerBound a) -> a)

--- a/plutarch-extra/plutarch-extra.cabal
+++ b/plutarch-extra/plutarch-extra.cabal
@@ -81,6 +81,7 @@ library
   exposed-modules:
     Plutarch.Extra
     Plutarch.Extra.Api
+    Plutarch.Extra.Interval
     Plutarch.Extra.List
     Plutarch.Extra.TermCont
 

--- a/plutarch-test/plutarch-extra/Plutarch/Extra/IntervalSpec.hs
+++ b/plutarch-test/plutarch-extra/Plutarch/Extra/IntervalSpec.hs
@@ -1,0 +1,241 @@
+module Plutarch.Extra.IntervalSpec (spec) where
+
+import Plutarch.Api.V1.Interval (PInterval)
+import Plutarch.Extra.Interval (
+  after,
+  always,
+  before,
+  contains,
+  from,
+  hull,
+  intersection,
+  interval,
+  member,
+  never,
+  to,
+ )
+import Plutarch.Prelude
+
+import Hedgehog (Property, PropertyT, assert, forAll, property)
+import qualified Hedgehog.Gen as Gen (int, list)
+import Hedgehog.Internal.Property (propertyTest)
+import qualified Hedgehog.Range as Range (constantBounded, singleton)
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog)
+
+spec :: Spec
+spec = do
+  describe "extra.intervalutils" $ do
+    describe "member" $ do
+      it "a is a member of [b, c] iff b <= a and a <= c" . hedgehog
+        . propertyTest
+        $ prop_member
+    describe "always" $ do
+      it "always contains everything" . hedgehog . propertyTest $ prop_always
+    describe "never" $ do
+      it "never contains nothing" . hedgehog . propertyTest $ prop_never
+    describe "hull" $ do
+      it "hull of a and b contains a and b" . hedgehog . propertyTest $
+        prop_hull
+    describe "intersection" $ do
+      it "intersection of a and b is contained in a and b" . hedgehog 
+        . propertyTest $ prop_intersection
+    describe "contains" $ do
+      describe "contains on bounded intervals" $ do
+        it "[a, b] contains [c, d] iff a <= c and d <= b" . hedgehog
+          . propertyTest
+          $ prop_containsBounded
+      describe "contains on unbounded (from above) intervals" $ do
+        it "[a, inf] contains [c, d] iff a <= c" . hedgehog
+          . propertyTest
+          $ prop_containsUnboundedUpper
+      describe "contains on unbounded (from below) intervals" $ do
+        it "[-inf, b] contains [c, d] iff d <= b" . hedgehog
+          . propertyTest
+          $ prop_containsUnboundedLower
+    describe "before" $ do
+      it "a is before [b, c] iff a < b" . hedgehog
+        . propertyTest
+        $ prop_before
+    describe "after" $ do
+      it "a is after [b, c] iff c < a" . hedgehog
+        . propertyTest
+        $ prop_after
+
+prop_member :: Property
+prop_member = property $ do
+  [a, b, c] <- genIntegerList 3
+  assert $ checkMember a b c
+
+prop_always :: Property
+prop_always = property $ do
+  [a, b] <- genIntegerList 2
+  assert $ checkAlways a b
+
+prop_never :: Property
+prop_never = property $ do
+  [a, b] <- genIntegerList 2
+  assert $ checkNever a b
+
+prop_hull :: Property
+prop_hull = property $ do
+  [a, b, c, d] <- genIntegerList 4
+  assert $ checkHull a b c d
+
+prop_intersection :: Property
+prop_intersection = property $ do
+  [a, b, c, d] <- genIntegerList 4
+  assert $ checkIntersection a b c d
+
+prop_containsBounded :: Property
+prop_containsBounded = property $ do
+  [a, b, c, d] <- genIntegerList 4
+  assert $ checkBoundedContains a b c d
+
+prop_containsUnboundedUpper :: Property
+prop_containsUnboundedUpper = property $ do
+  [a, b, c] <- genIntegerList 3
+  assert $ checkUnboundedUpperContains a b c
+
+prop_containsUnboundedLower :: Property
+prop_containsUnboundedLower = property $ do
+  [a, b, c] <- genIntegerList 3
+  assert $ checkUnboundedLowerContains a b c
+
+prop_before :: Property
+prop_before = property $ do
+  [a, b, c] <- genIntegerList 3
+  assert $ checkBefore a b c
+
+prop_after :: Property
+prop_after = property $ do
+  [a, b, c] <- genIntegerList 3
+  assert $ checkAfter a b c
+
+checkMember :: Integer -> Integer -> Integer -> Bool
+checkMember a b c = actual == expected
+  where
+    i :: Term s (PInterval PInteger)
+    i = mkInterval b c
+
+    actual = plift $ (pconstant a) `member` i
+    expected = (min b c <= a) && (a <= max b c)
+
+checkAlways :: Integer -> Integer -> Bool
+checkAlways a b = plift $ always `contains` i
+  where
+    i :: Term s (PInterval PInteger)
+    i = mkInterval a b
+
+checkNever :: Integer -> Integer -> Bool
+checkNever a b = not (plift $ never `contains` i)
+  where
+    i :: Term s (PInterval PInteger)
+    i = mkInterval a b
+
+checkHull :: Integer -> Integer -> Integer -> Integer -> Bool
+checkHull a b c d = plift $ (i3 `contains` i1) #&& (i3 `contains` i2)
+  where
+    i1 :: Term s (PInterval PInteger)
+    i1 = mkInterval a b
+
+    i2 :: Term s (PInterval PInteger)
+    i2 = mkInterval c d
+
+    i3 = hull i1 i2
+
+checkIntersection :: Integer -> Integer -> Integer -> Integer -> Bool
+checkIntersection a b c d = plift $ (i1 `contains` i3) #&& (i2 `contains` i3)
+  where
+    i1 :: Term s (PInterval PInteger)
+    i1 = mkInterval a b
+
+    i2 :: Term s (PInterval PInteger)
+    i2 = mkInterval c d
+
+    i3 = intersection i1 i2
+
+checkBoundedContains :: Integer -> Integer -> Integer -> Integer -> Bool
+checkBoundedContains a b c d = actual == expected
+  where
+    i1 :: Term s (PInterval PInteger)
+    i1 = mkInterval a b
+    i2 :: Term s (PInterval PInteger)
+    i2 = mkInterval c d
+
+    expected :: Bool
+    expected = (min a b <= min c d) && (max c d <= max a b)
+
+    actual' :: ClosedTerm PBool
+    actual' = i1 `contains` i2
+    actual = plift actual'
+
+checkUnboundedUpperContains :: Integer -> Integer -> Integer -> Bool
+checkUnboundedUpperContains a b c = actual == expected
+  where
+    i1 :: Term s (PInterval PInteger)
+    i1 = from (pconstant a)
+    i2 :: Term s (PInterval PInteger)
+    i2 = mkInterval b c
+
+    expected :: Bool
+    expected = a <= (min b c)
+
+    actual' :: ClosedTerm PBool
+    actual' = i1 `contains` i2
+    actual = plift actual'
+
+checkUnboundedLowerContains :: Integer -> Integer -> Integer -> Bool
+checkUnboundedLowerContains a b c = actual == expected
+  where
+    i1 :: Term s (PInterval PInteger)
+    i1 = to (pconstant a)
+    i2 :: Term s (PInterval PInteger)
+    i2 = mkInterval b c
+
+    expected :: Bool
+    expected = a >= (max b c)
+
+    actual' :: ClosedTerm PBool
+    actual' = i1 `contains` i2
+    actual = plift actual'
+
+checkBefore :: Integer -> Integer -> Integer -> Bool
+checkBefore a b c = actual == expected
+  where
+    i :: Term s (PInterval PInteger)
+    i = mkInterval b c
+
+    expected :: Bool
+    expected = a < (min b c)
+
+    actual' :: ClosedTerm PBool
+    actual' = (pconstant a) `before` i
+    actual = plift actual'
+
+checkAfter :: Integer -> Integer -> Integer -> Bool
+checkAfter a b c = actual == expected
+  where
+    i :: Term s (PInterval PInteger)
+    i = mkInterval b c
+
+    expected :: Bool
+    expected = (max b c) < a
+
+    actual' :: ClosedTerm PBool
+    actual' = (pconstant a) `after` i
+    actual = plift actual'
+
+mkInterval :: forall s. Integer -> Integer -> Term s (PInterval PInteger)
+mkInterval a' b' = interval (pconstant a) (pconstant b)
+  where
+    a = min a' b'
+    b = max a' b'
+
+genIntegerList :: Monad m => Int -> PropertyT m [Integer]
+genIntegerList n =
+  (fmap . fmap) toInteger $
+    forAll $
+      Gen.list
+        (Range.singleton n)
+        (Gen.int Range.constantBounded)

--- a/plutarch-test/plutarch-test.cabal
+++ b/plutarch-test/plutarch-test.cabal
@@ -156,6 +156,7 @@ executable plutarch-test
     Plutarch.ByteStringSpec
     Plutarch.EitherSpec
     Plutarch.Extra.ApiSpec
+    Plutarch.Extra.IntervalSpec
     Plutarch.Extra.ListSpec
     Plutarch.IntegerSpec
     Plutarch.LiftSpec


### PR DESCRIPTION
Implemented some functions to facilitate working with `PInterval`. All functions from [PlutusTx.V1.Ledger.Interval](https://playground.plutus.iohkdev.io/doc/haddock/plutus-ledger-api/html/Plutus-V1-Ledger-Interval.html) are implemented except `overlaps` and `isEmpty` I don't think we can implement them without having an Enum constraint.

Heads up: tests are running fine with `cabal run` in `plutarch-test`, but running `nix run .#test-ghc9-nodev` gives an error that I don't know the reason behind. A little help with that would be appreciated 
```
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/q6l7vah0j8r7gzk3sv19qwvbsiszlmcw-source-root-plutarch-extra-lib-plutarch-extra-root
source root is source-root-plutarch-extra-lib-plutarch-extra-root
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
Configure flags:
--prefix=/nix/store/q6mmvdxvyl2hbmqwy202v506fdbgxxnx-plutarch-extra-lib-plutarch-extra-1.1.0 lib:plutarch-extra --package-db=clear --package-db=/nix/store/qyp91pd4gfdsavvwgwi4h90w1srnqc90-plutarch-extra-lib-plutarch-extra-1.1.0-config/li>
Configuring library for plutarch-extra-1.1.0..
@nix { "action": "setPhase", "phase": "buildPhase" }
building
Preprocessing library for plutarch-extra-1.1.0..
Setup: can't find source for Plutarch/Extra/Interval in ., dist/build/autogen,
dist/build/global-autogen
```