### PR TITLE
Stop building ghc810 plutarch 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -522,9 +522,6 @@
           // {
             formatCheck = formatCheckFor system;
             test-ghc9 = flakeApp2Derivation system "test-ghc9";
-            test-ghc810 = flakeApp2Derivation system "test-ghc810";
-            "ghc810-plutarch:lib:plutarch" = (self.ghc810Flake.${system}).packages."plutarch:lib:plutarch";
-            "ghc810-plutarch:lib:plutarch-test" = (self.ghc810Flake.${system}).packages."plutarch-test:lib:plutarch-test";
             hls = checkedShellScript system "hls" "${self.project.${system}.pkgs.haskell-language-server}/bin/haskell-language-server";
           });
       # Because `nix flake check` does not work with haskell.nix (due to IFD),


### PR DESCRIPTION
- as it has been decided to stop supporting plutarch on 8107, this stops building it in CI to reduce load and make it useful again. 