### PR TITLE
Remove `PBuiltinMap`

### DIFF
--- a/plutarch-test/conditional/Plutarch/TryFromSpec.hs
+++ b/plutarch-test/conditional/Plutarch/TryFromSpec.hs
@@ -35,7 +35,6 @@ import Plutarch.Api.V1 (
  )
 
 import Plutarch.Builtin (
-  PBuiltinMap,
   pforgetData,
   ppairDataBuiltin,
  )
@@ -71,8 +70,6 @@ spec = do
           @(PDataRecord (("foo" ':= PByteString) ': ("bar" ':= PInteger) ': '[]))
           (pdata (pdcons @"foo" # (pdata $ pconstant "baz") #$ pdcons @"bar" # (pdata $ pconstant 42) # pdnil))
         @-> pfails
-      "Map Int String /= Map Int Int"
-        @| mapTestFails @-> pfails
       "PDataSum constr 2"
         @| checkDeep
           @(PDataSum '[ '["i1" ':= PInteger, "b2" ':= PByteString]])
@@ -116,8 +113,6 @@ spec = do
           @(PDataRecord (("foo" ':= PByteString) ': ("bar" ':= PInteger) ': '[]))
           (pdata (pdcons @"foo" # (pdata $ pconstant "baz") #$ pdcons @"bar" # (pdata $ pconstant 42) # pdnil))
         @-> psucceeds
-      "Map Int String == Map Int String"
-        @| mapTestSucceeds @-> psucceeds
       "PDataSum constr 0"
         @| checkDeep
           @(PDataSum '[ '["i1" ':= PInteger, "b2" ':= PByteString], '["i3" ':= PInteger, "b4" ':= PByteString]])
@@ -360,26 +355,6 @@ toDatadList = pdata . (foldr go pnil)
   where
     go :: Integer -> Term _ (PBuiltinList (PAsData PInteger)) -> Term _ (PBuiltinList (PAsData PInteger))
     go i acc = pcons # (pdata $ pconstant i) # acc
-
-------------------- Special cases for maps -----------------------------------------
-
-mapTestSucceeds :: ClosedTerm (PAsData (PBuiltinMap PByteString PInteger))
-mapTestSucceeds = unTermCont $ do
-  (val, _) <- TermCont $ ptryFrom $ pforgetData sampleMap
-  pure val
-
-mapTestFails :: ClosedTerm (PAsData (PBuiltinMap PInteger PInteger))
-mapTestFails = unTermCont $ do
-  (val, _) <- TermCont $ ptryFrom $ pforgetData sampleMap
-  pure val
-
-sampleMap :: Term _ (PAsData (PBuiltinMap PByteString PInteger))
-sampleMap =
-  pdata $
-    pcons
-      # (ppairDataBuiltin # (pdata $ pconstant "foo") # (pdata $ pconstant 42)) #$ pcons
-      # (ppairDataBuiltin # (pdata $ pconstant "bar") # (pdata $ pconstant 41))
-      # pnil
 
 ------------------- Sample type with PIsDataRepr -----------------------------------
 


### PR DESCRIPTION
This type alias was confusing to users, since it was not clear what the difference
between this and `PMap` was. `PMap` was a newtype of `PBuiltinMap`, but almost in any
case where you have `PBuiltinMap`, you really want the newtype `PBuiltinMap`.

The issue is that there are instances on `PBuiltinMap` that work very differently
from the ones on `PBuiltinList`, even though it's just a type alias!
When these instances are instead made to be instances on the newtype,
then there's not much point in keeping `PBuiltinMap` around, especially
when it only serves to increase confusion.

Closes #513