### PR TITLE
Drop `PAsData` from TxInfo where it is redundant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 # Unreleased
 
+- Changed fields of `PTxInfo` whose only representation is data to not be wrapped by `PAsData`.
+
+  Module: `Plutarch.Api.V1.Contexts`; `Plutarch.Api.V2.Contexts`
+  
+- Added `plistData` builtin function wrapper.
+
+  Module: `Plutarch.Builtin`
+
 - Added `PEq` superclass constraint to `POrd`
 
   Included by [#326](https://github.com/Plutonomicon/plutarch/pull/326)

--- a/Plutarch/Api/V1/Contexts.hs
+++ b/Plutarch/Api/V1/Contexts.hs
@@ -42,11 +42,11 @@ newtype PTxInfo (s :: S)
       ( Term
           s
           ( PDataRecord
-              '[ "inputs" ':= PBuiltinList (PAsData PTxInInfo) -- Transaction inputs
-               , "outputs" ':= PBuiltinList (PAsData PTxOut) -- Transaction outputs
+              '[ "inputs" ':= PBuiltinList PTxInInfo -- Transaction inputs
+               , "outputs" ':= PBuiltinList PTxOut -- Transaction outputs
                , "fee" ':= PValue 'Sorted 'Positive -- The fee paid by this transaction.
                , "mint" ':= PValue 'Sorted 'NoGuarantees -- The value minted by the transaction.
-               , "dcert" ':= PBuiltinList (PAsData PDCert) -- Digests of the certificates included in this transaction.
+               , "dcert" ':= PBuiltinList PDCert -- Digests of the certificates included in this transaction.
                , "wdrl" ':= PBuiltinList (PAsData (PTuple PStakingCredential PInteger)) -- Staking withdrawals
                , "validRange" ':= PPOSIXTimeRange -- The valid range for the transaction.
                , "signatories" ':= PBuiltinList (PAsData PPubKeyHash) -- Signatories attesting that they all signed the tx.

--- a/Plutarch/Api/V2/Contexts.hs
+++ b/Plutarch/Api/V2/Contexts.hs
@@ -50,12 +50,12 @@ newtype PTxInfo (s :: S)
       ( Term
           s
           ( PDataRecord
-              '[ "inputs" ':= PBuiltinList (PAsData PTxInInfo) -- Transaction inputs
-               , "referenceInputs" ':= PBuiltinList (PAsData PTxInInfo)
-               , "outputs" ':= PBuiltinList (PAsData PTxOut) -- Transaction outputs
+              '[ "inputs" ':= PBuiltinList PTxInInfo -- Transaction inputs
+               , "referenceInputs" ':= PBuiltinList PTxInInfo
+               , "outputs" ':= PBuiltinList PTxOut -- Transaction outputs
                , "fee" ':= V1.PValue 'V1.Sorted 'V1.Positive -- The fee paid by this transaction.
                , "mint" ':= V1.PValue 'V1.Sorted 'V1.NoGuarantees -- The value minted by the transaction.
-               , "dcert" ':= PBuiltinList (PAsData V1.PDCert) -- Digests of the certificates included in this transaction.
+               , "dcert" ':= PBuiltinList V1.PDCert -- Digests of the certificates included in this transaction.
                , "wdrl" ':= V1.PMap 'V1.Unsorted V1.PStakingCredential PInteger -- Staking withdrawals
                , "validRange" ':= V1.PPOSIXTimeRange -- The valid range for the transaction.
                , "signatories" ':= PBuiltinList (PAsData V1.PPubKeyHash) -- Signatories attesting that they all signed the tx.

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -10,6 +10,7 @@ module Plutarch.Builtin (
   pasMap,
   pasList,
   pasInt,
+  plistData,
   pconstantData,
   pconstrBuiltin,
   pasByteStr,
@@ -93,7 +94,7 @@ import Plutarch.List (
  )
 import Plutarch.Show (PShow (pshow'), pshow)
 import Plutarch.TermCont (TermCont (runTermCont), tcont, unTermCont)
-import Plutarch.TryFrom (PSubtype, PTryFrom, PTryFromExcess, ptryFrom, ptryFrom', pupcast)
+import Plutarch.TryFrom (PSubtype, PTryFrom, PTryFromExcess, ptryFrom, ptryFrom', pupcast, pupcastF)
 import Plutarch.Unit (PUnit)
 import Plutarch.Unsafe (punsafeBuiltin, punsafeCoerce, punsafeDowncast)
 import qualified PlutusCore as PLC
@@ -234,6 +235,9 @@ pasConstr = punsafeBuiltin PLC.UnConstrData
 pasMap :: Term s (PData :--> PBuiltinList (PBuiltinPair PData PData))
 pasMap = punsafeBuiltin PLC.UnMapData
 
+plistData :: Term s (PBuiltinList PData :--> PData)
+plistData = punsafeBuiltin PLC.ListData
+
 pasList :: Term s (PData :--> PBuiltinList PData)
 pasList = punsafeBuiltin PLC.UnListData
 
@@ -318,20 +322,14 @@ instance PIsData PData where
   pfromDataImpl = pupcast
   pdataImpl = id
 
-instance PIsData (PBuiltinList (PAsData a)) where
+instance forall (a :: PType). PSubtype PData a => PIsData (PBuiltinList a) where
   pfromDataImpl x = punsafeCoerce $ pasList # pforgetData x
-  pdataImpl x = punsafeBuiltin PLC.ListData # x
+  pdataImpl x = plistData # pupcastF @PData @a (Proxy @PBuiltinList) x
 
 newtype Helper2 f a s = Helper2 (Term s (PAsData (f a)))
   deriving stock (Generic)
   deriving anyclass (PlutusType)
 instance DerivePlutusType (Helper2 f a) where type DPTStrat _ = PlutusTypeNewtype
-
-instance PIsData (PBuiltinList PData) where
-  pfromDataImpl = pforgetData' @PData (Proxy @PBuiltinList) . pfromData . pto . prememberData (Proxy @(Helper2 PBuiltinList)) . pcon . Helper2
-
-  -- pdataImpl = coerce (pforgetData' @PData (Proxy @(Helper2 PBuiltinList))) . pdata . (prememberData (Proxy @PBuiltinList))
-  pdataImpl = punsafeCoerce . pdata . prememberData (Proxy @PBuiltinList) -- FIXME
 
 instance PIsData PInteger where
   pfromDataImpl x = pasInt # pforgetData x

--- a/plutarch-extra/Plutarch/Extra/Api.hs
+++ b/plutarch-extra/Plutarch/Extra/Api.hs
@@ -34,7 +34,7 @@ import Plutarch.Prelude
       pure $ ptraceError "not a spending tx"
   @
 -}
-pgetContinuingOutputs :: Term s (PBuiltinList (PAsData PTxInInfo) :--> PBuiltinList (PAsData PTxOut) :--> PTxOutRef :--> PBuiltinList (PAsData PTxOut))
+pgetContinuingOutputs :: Term s (PBuiltinList PTxInInfo :--> PBuiltinList PTxOut :--> PTxOutRef :--> PBuiltinList PTxOut)
 pgetContinuingOutputs = phoistAcyclic $
   plam $ \inputs outputs outRef ->
     pmatch (pfindOwnInput # inputs # outRef) $ \case
@@ -45,7 +45,7 @@ pgetContinuingOutputs = phoistAcyclic $
       PNothing ->
         ptraceError "can't get any continuing outputs"
   where
-    matches :: Term s (PAddress :--> PAsData PTxOut :--> PBool)
+    matches :: Term s (PAddress :--> PTxOut :--> PBool)
     matches = phoistAcyclic $
       plam $ \adr txOut ->
         adr #== pfield @"address" # txOut
@@ -67,12 +67,12 @@ pgetContinuingOutputs = phoistAcyclic $
       pure $ ptraceError "not a spending tx"
   @
 -}
-pfindOwnInput :: Term s (PBuiltinList (PAsData PTxInInfo) :--> PTxOutRef :--> PMaybe (PAsData PTxInInfo))
+pfindOwnInput :: Term s (PBuiltinList PTxInInfo :--> PTxOutRef :--> PMaybe PTxInInfo)
 pfindOwnInput = phoistAcyclic $
   plam $ \inputs outRef ->
     pfind # (matches # outRef) # inputs
   where
-    matches :: Term s (PTxOutRef :--> PAsData PTxInInfo :--> PBool)
+    matches :: Term s (PTxOutRef :--> PTxInInfo :--> PBool)
     matches = phoistAcyclic $
       plam $ \outref txininfo ->
         outref #== pfield @"outRef" # txininfo

--- a/plutarch-test/conditional/Plutarch/TryFromSpec.hs
+++ b/plutarch-test/conditional/Plutarch/TryFromSpec.hs
@@ -342,7 +342,7 @@ validator = phoistAcyclic $
         data' :: Term _ (PBuiltinList (PAsData (PTuple PDatumHash PDatum)))
         data' = pfield @"datums" # txInfo
 
-        outputs :: Term _ (PBuiltinList (PAsData PTxOut))
+        outputs :: Term _ (PBuiltinList PTxOut)
         outputs = pfield @"outputs" # txInfo
         -- find the list of the outputs
 
@@ -365,9 +365,9 @@ validator = phoistAcyclic $
         singleOutput :: Term _ PBool
         singleOutput = pnull #$ ptail #$ pfilter # pred # outputs
           where
-            pred :: Term _ (PAsData PTxOut :--> PBool)
+            pred :: Term _ (PTxOut :--> PBool)
             pred = plam $ \out -> unTermCont $ do
-              pure $ pfield @"address" # out #== (pdata $ ownAddress)
+              pure $ pfield @"address" # pdata out #== pdata ownAddress
 
         -- make sure that after filtering the outputs, only one output
         -- remains
@@ -382,18 +382,18 @@ validator = phoistAcyclic $
     pure $
       pif isValid (popaque $ pcon PUnit) (ptraceError "not valid")
 
-pfindOwnInput :: Term s (PScriptContext :--> PMaybe (PAsData PTxInInfo))
+pfindOwnInput :: Term s (PScriptContext :--> PMaybe PTxInInfo)
 pfindOwnInput = phoistAcyclic $
   plam $ \ctx' -> unTermCont $ do
     ctx <- tcont $ pletFields @["txInfo", "purpose"] ctx'
     PSpending txoutRef <- tcont $ pmatch $ ctx.purpose
-    let txInInfos :: Term _ (PBuiltinList (PAsData PTxInInfo))
+    let txInInfos :: Term _ (PBuiltinList PTxInInfo)
         txInInfos = pfield @"inputs" #$ ctx.txInfo
         target :: Term _ PTxOutRef
         target = pfield @"_0" # txoutRef
-        pred :: Term _ (PAsData PTxInInfo :--> PBool)
+        pred :: Term _ (PTxInInfo :--> PBool)
         pred = plam $ \actual ->
-          target #== pfield @"outRef" # pfromData actual
+          target #== pfield @"outRef" # actual
     pure $ pfind # pred # txInInfos
 
 ------------- Helpers --------------------------------------------------------

--- a/plutarch-test/plutarch-base/Plutarch/ApiSpec.hs
+++ b/plutarch-test/plutarch-base/Plutarch/ApiSpec.hs
@@ -362,7 +362,7 @@ getCredentials ctx =
   Get the hash of the Credential in an input, treating
   PubKey & ValidatorHash identically.
 -}
-inputCredentialHash :: Term s (PAsData PTxInInfo :--> PData)
+inputCredentialHash :: Term s (PTxInInfo :--> PData)
 inputCredentialHash =
   phoistAcyclic $
     plam $ \inp ->

--- a/plutarch-test/plutarch-extra/Plutarch/Extra/ApiSpec.hs
+++ b/plutarch-test/plutarch-extra/Plutarch/Extra/ApiSpec.hs
@@ -27,23 +27,27 @@ spec = do
                   pure perror
            )
           @-> \res ->
-            passert $ (pfromData $ pfromJust # res) #== pconstant inp
+            passert (pfromJust # res #== pconstant inp)
       "pgetContinuingOutputs"
         @| ( unTermCont $ do
               ctxF <- tcont $ pletFields @["txInfo", "purpose"] ctx
               pmatchC (getField @"purpose" ctxF) >>= \case
                 PSpending outRef' -> do
                   let outRef = pfield @"_0" # outRef'
-                      inputs = pfield @"inputs" # (getField @"txInfo" ctxF)
-                      outputs = pfield @"outputs" # (getField @"txInfo" ctxF)
+                      inputs = pfield @"inputs" #$ getField @"txInfo" ctxF
+                      outputs = pfield @"outputs" #$ getField @"txInfo" ctxF
                   pure $ pgetContinuingOutputs # inputs # outputs # outRef
                 _ ->
                   pure perror
            )
           @-> \txOuts ->
-            passert $ (pmap # plam pfromData # txOuts) #== pconstant validOutputs0
+            passert $ txOuts #== pconstant validOutputs0
       "pparseDatum"
-        @| ( pparseDatum @(PBuiltinList (PAsData PInteger)) # pconstant "d0" # (pfield @"datums" #$ pfield @"txInfo" # ctx)
+        @| ( pparseDatum @(PBuiltinList (PAsData PInteger))
+              # pconstant "d0"
+                #$ pfield @"datums"
+                #$ pfield @"txInfo"
+              # ctx
            )
           @-> \res ->
             passert $ res #== pcon (PJust $ pdata $ d0DatTerm)


### PR DESCRIPTION
Summary:
- For both V1 and V2 `PTxInfo`, I dropped unnecessary `PAsData`s, since `PSubtype PData a` for those types.
- Replaced all instances of `PIsData (PBuiltinList a)` with one that uses `PSubtype`.
- Added `plistData`, a wrapper for the `ListData` builtin.