### PR TITLE
fix broken GUIDE.md links

### DIFF
--- a/docs/DEVGUIDE.md
+++ b/docs/DEVGUIDE.md
@@ -238,7 +238,7 @@ mockCtx =
 Right (Program () (Version () 1 0 0) (Constant () (Some (ValueOf data (Constr 0 [List [Constr 0 [Constr 0 [Constr 0 [B ""],I 1],Constr 0 [Constr 0 [Constr 0 [B "\SOH#"],Constr 1 []],Map [],Constr 1 []]]],List [],Map [],Map [],List [],List [],Constr 0 [Constr 0 [Constr 1 [I 1],Constr 1 []],Constr 0 [Constr 1 [I 2],Constr 1 []]],List [],List [],Constr 0 [B ""]])))))
 ```
 
-> Aside: You can find the definition of `evalWithArgsT` above - [Compiling and Running](./GUIDE.md#compiling-and-running).
+> Aside: You can find the definition of `evalWithArgsT` above - [Compiling and Running](./README.md#compiling-and-running).
 
 But we're not done yet! We want `txInfoInputs`. You may have noticed where exactly it is located on the above output. See that `List …`? Inside the outermost `Constr`'s fields? That's our `txInfoInputs`!
 

--- a/docs/Typeclasses/PIsDataRepr and PDataFields.md
+++ b/docs/Typeclasses/PIsDataRepr and PDataFields.md
@@ -105,7 +105,7 @@ mockCtx =
 Right (Program () (Version () 1 0 0) (Constant () (Some (ValueOf string "It's minting!"))))
 ```
 
-> Aside: You can find the definition of `evalWithArgsT` at [Compiling and Running](../GUIDE.md#compiling-and-running).
+> Aside: You can find the definition of `evalWithArgsT` at [Compiling and Running](../README.md#compiling-and-running).
 
 ## All about extracting fields
 

--- a/docs/examples/BASIC.md
+++ b/docs/examples/BASIC.md
@@ -2,7 +2,7 @@ Basic examples demonstrating Plutarch usage.
 
 > Note: If you spot any mistakes/have any related questions that this guide lacks the answer to, please don't hesitate to raise an issue. The goal is to have high quality documentation for Plutarch users!
 
-> Aside: Be sure to check out [Compiling and Running](./../GUIDE.md#compiling-and-running) first!
+> Aside: Be sure to check out [Compiling and Running](./../README.md#compiling-and-running) first!
 
 # Fibonacci number at given index
 

--- a/docs/examples/VALIDATOR.md
+++ b/docs/examples/VALIDATOR.md
@@ -7,7 +7,7 @@ Examples of validators and minting policies written in Plutarch.
 - [Validator that checks whether a value is present within signatories](#validator-that-checks-whether-a-value-is-present-within-signatories)
 - [Using custom datum/redeemer in your Validator](#using-custom-datumredeemer-in-your-validator)
 
-> Aside: Be sure to check out [Compiling and Running](./../GUIDE.md#compiling-and-running) first!
+> Aside: Be sure to check out [Compiling and Running](./../README.md#compiling-and-running) first!
 
 # Validator that always succeeds
 


### PR DESCRIPTION
`GUIDE.md` has been renamed to `README.md`, but several links were still pointing to the old name.