### PR TITLE
Add pshow instances

### DIFF
--- a/Plutarch/Api/V1/Address.hs
+++ b/Plutarch/Api/V1/Address.hs
@@ -28,7 +28,7 @@ data PCredential (s :: S)
   = PPubKeyCredential (Term s (PDataRecord '["_0" ':= PPubKeyHash]))
   | PScriptCredential (Term s (PDataRecord '["_0" ':= PValidatorHash]))
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PTryFrom PData)
+  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow, PTryFrom PData)
 instance DerivePlutusType PCredential where type DPTStrat _ = PlutusTypeData
 
 instance PUnsafeLiftDecl PCredential where type PLifted PCredential = Plutus.Credential
@@ -48,7 +48,7 @@ data PStakingCredential (s :: S)
           )
       )
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PTryFrom PData)
+  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow, PTryFrom PData)
 instance DerivePlutusType PStakingCredential where type DPTStrat _ = PlutusTypeData
 
 instance PUnsafeLiftDecl PStakingCredential where type PLifted PStakingCredential = Plutus.StakingCredential
@@ -66,7 +66,7 @@ newtype PAddress (s :: S)
           )
       )
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PPartialOrd, POrd, PTryFrom PData)
+  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PPartialOrd, POrd, PShow, PTryFrom PData)
 instance DerivePlutusType PAddress where type DPTStrat _ = PlutusTypeData
 
 instance PUnsafeLiftDecl PAddress where type PLifted PAddress = Plutus.Address

--- a/Plutarch/Api/V1/AssocMap.hs
+++ b/Plutarch/Api/V1/AssocMap.hs
@@ -70,7 +70,6 @@ import Plutarch.Lift (
 import qualified Plutarch.List as List
 import Plutarch.Prelude hiding (pall, pany, pfilter, pmap, pnull, psingleton)
 import qualified Plutarch.Prelude as PPrelude
-import Plutarch.Show (PShow)
 import Plutarch.TryFrom (PTryFrom (PTryFromExcess, ptryFrom'))
 import Plutarch.Unsafe (punsafeCoerce, punsafeDowncast)
 import qualified PlutusCore as PLC

--- a/Plutarch/Api/V1/Crypto.hs
+++ b/Plutarch/Api/V1/Crypto.hs
@@ -24,7 +24,7 @@ import Plutarch.Unsafe (punsafeCoerce)
 
 newtype PPubKeyHash (s :: S) = PPubKeyHash (Term s PByteString)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow)
 instance DerivePlutusType PPubKeyHash where type DPTStrat _ = PlutusTypeNewtype
 
 instance PUnsafeLiftDecl PPubKeyHash where type PLifted PPubKeyHash = Plutus.PubKeyHash

--- a/Plutarch/Api/V1/Maybe.hs
+++ b/Plutarch/Api/V1/Maybe.hs
@@ -22,7 +22,7 @@ data PMaybeData a (s :: S)
   = PDJust (Term s (PDataRecord '["_0" ':= a]))
   | PDNothing (Term s (PDataRecord '[]))
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq)
+  deriving anyclass (PlutusType, PIsData, PEq, PShow)
 
 instance DerivePlutusType (PMaybeData a) where type DPTStrat _ = PlutusTypeData
 instance PTryFrom PData a => PTryFrom PData (PMaybeData a)

--- a/Plutarch/Api/V1/Scripts.hs
+++ b/Plutarch/Api/V1/Scripts.hs
@@ -28,7 +28,7 @@ import Plutarch.Unsafe (punsafeCoerce)
 
 newtype PDatum (s :: S) = PDatum (Term s PData)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq)
+  deriving anyclass (PlutusType, PIsData, PEq, PShow)
 instance DerivePlutusType PDatum where type DPTStrat _ = PlutusTypeNewtype
 
 instance PUnsafeLiftDecl PDatum where type PLifted PDatum = Plutus.Datum
@@ -44,7 +44,7 @@ deriving via (DerivePConstantViaBuiltin Plutus.Redeemer PRedeemer PData) instanc
 
 newtype PDatumHash (s :: S) = PDatumHash (Term s PByteString)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow)
 instance DerivePlutusType PDatumHash where type DPTStrat _ = PlutusTypeNewtype
 
 instance PUnsafeLiftDecl PDatumHash where type PLifted PDatumHash = Plutus.DatumHash
@@ -74,7 +74,7 @@ deriving via
 
 newtype PValidatorHash (s :: S) = PValidatorHash (Term s PByteString)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow)
 instance DerivePlutusType PValidatorHash where type DPTStrat _ = PlutusTypeNewtype
 
 instance PUnsafeLiftDecl PValidatorHash where type PLifted PValidatorHash = Plutus.ValidatorHash
@@ -104,7 +104,7 @@ deriving via
 
 newtype PScriptHash (s :: S) = PScriptHash (Term s PByteString)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow)
 instance DerivePlutusType PScriptHash where type DPTStrat _ = PlutusTypeNewtype
 
 instance PUnsafeLiftDecl PScriptHash where type PLifted PScriptHash = Plutus.ScriptHash

--- a/Plutarch/Api/V1/Tx.hs
+++ b/Plutarch/Api/V1/Tx.hs
@@ -39,7 +39,7 @@ newtype Flip f a b = Flip (f b a) deriving stock (Generic)
 newtype PTxId (s :: S)
   = PTxId (Term s (PDataRecord '["_0" ':= PByteString]))
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PPartialOrd, POrd, PShow)
 instance DerivePlutusType PTxId where type DPTStrat _ = PlutusTypeData
 
 instance PUnsafeLiftDecl PTxId where type PLifted PTxId = Plutus.TxId
@@ -76,7 +76,7 @@ newtype PTxOutRef (s :: S)
           )
       )
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PPartialOrd, POrd, PTryFrom PData)
+  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PPartialOrd, POrd, PTryFrom PData, PShow)
 
 instance DerivePlutusType PTxOutRef where type DPTStrat _ = PlutusTypeData
 
@@ -96,7 +96,7 @@ newtype PTxInInfo (s :: S)
           )
       )
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PDataFields, PEq)
+  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PShow)
 
 instance DerivePlutusType PTxInInfo where type DPTStrat _ = PlutusTypeData
 
@@ -116,7 +116,7 @@ newtype PTxOut (s :: S)
           )
       )
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PDataFields, PEq)
+  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PShow)
 
 instance DerivePlutusType PTxOut where type DPTStrat _ = PlutusTypeData
 

--- a/Plutarch/Api/V1/Value.hs
+++ b/Plutarch/Api/V1/Value.hs
@@ -77,7 +77,7 @@ newtype Flip f a b = Flip (f b a) deriving stock (Generic)
 
 newtype PTokenName (s :: S) = PTokenName (Term s PByteString)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow)
 instance DerivePlutusType PTokenName where type DPTStrat _ = PlutusTypeNewtype
 
 instance PUnsafeLiftDecl PTokenName where type PLifted PTokenName = Plutus.TokenName
@@ -96,7 +96,7 @@ instance PTryFrom PData (PAsData PTokenName) where
 
 newtype PCurrencySymbol (s :: S) = PCurrencySymbol (Term s PByteString)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow)
 instance DerivePlutusType PCurrencySymbol where type DPTStrat _ = PlutusTypeNewtype
 
 instance PTryFrom PData (PAsData PCurrencySymbol) where
@@ -120,7 +120,7 @@ type role PValue nominal nominal nominal
 newtype PValue (keys :: KeyGuarantees) (amounts :: AmountGuarantees) (s :: S)
   = PValue (Term s (PMap keys PCurrencySymbol (PMap keys PTokenName PInteger)))
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData)
+  deriving anyclass (PlutusType, PIsData, PShow)
 instance DerivePlutusType (PValue keys amounts) where type DPTStrat _ = PlutusTypeNewtype
 
 instance PUnsafeLiftDecl (PValue 'Unsorted 'NonZero) where

--- a/Plutarch/Api/V2/Tx.hs
+++ b/Plutarch/Api/V2/Tx.hs
@@ -41,7 +41,7 @@ newtype PTxOut (s :: S)
           )
       )
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PDataFields, PEq)
+  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PShow)
 
 instance DerivePlutusType PTxOut where type DPTStrat _ = PlutusTypeData
 
@@ -60,7 +60,7 @@ newtype PTxInInfo (s :: S)
           )
       )
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PDataFields, PEq)
+  deriving anyclass (PlutusType, PIsData, PDataFields, PEq, PShow)
 
 instance DerivePlutusType PTxInInfo where type DPTStrat _ = PlutusTypeData
 
@@ -73,7 +73,7 @@ data POutputDatum (s :: S)
   | POutputDatumHash (Term s (PDataRecord '["datumHash" ':= V1.PDatumHash]))
   | POutputDatum (Term s (PDataRecord '["outputDatum" ':= V1.PDatum]))
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq)
+  deriving anyclass (PlutusType, PIsData, PEq, PShow)
 
 instance DerivePlutusType POutputDatum where type DPTStrat _ = PlutusTypeData
 

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -215,6 +215,10 @@ instance Fc (F a) a => PEq (PBuiltinList a) where
 
 data PData (s :: S) = PData (Term s PData)
 
+-- | Does not show actual data due to non-termination
+instance PShow PData where
+  pshow' _ _ = "<pdata>"
+
 instance PlutusType PData where
   type PInner PData = PData
   type PCovariant' PData = ()

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -131,12 +131,13 @@ module Plutarch.Prelude (
   pletFields,
 
   -- * Tracing
+  PShow,
+  pshow,
   ptrace,
   ptraceShowId,
   ptraceIfFalse,
   ptraceIfTrue,
   ptraceError,
-  pshow,
 
   -- * Cryptographic hashes and signatures
   psha2_256,


### PR DESCRIPTION
Added `PShow` instances to more types. The intention is to add these to `V2`, though most had to also be added to `V1` to prevent orphans.

Example output:
```haskell
-- without parens (pshow)
PTxOut [address = (PAddress [credential = (PPubKeyCredential [_0 = (PPubKeyHash 0x737472)]), stakingCredential = (PDNothing [])]), value = (PValue (PMap [])), datum = (POutputDatumHash [datumHash = (PDatumHash 0x68617368)]), referenceScript = (PDJust [_0 = (PScriptHash 0x7363726970742068617368)])]

-- with parens (pshow' True)
(PTxOut [address = (PAddress [credential = (PPubKeyCredential [_0 = (PPubKeyHash 0x737472)]), stakingCredential = (PDNothing [])]), value = (PValue (PMap [])), datum = (POutputDatumHash [datumHash = (PDatumHash 0x68617368)]), referenceScript = (PDJust [_0 = (PScriptHash 0x7363726970742068617368)])])
```