### PR TITLE
Update README.md for `plutarch-test`

### DIFF
--- a/plutarch-test/README.md
+++ b/plutarch-test/README.md
@@ -5,10 +5,9 @@ To run the tests using Nix:
 ```sh-session
 $ cd $projectroot/plutarch-test
 # Runs tests
-$ nix run .#test-ghc9-nodev
+$ nix run .#test-ghc9
 # To run the above in GHC 8.10 instead:
-$ nix run .#test-ghc810-nodev
-# Replace 'nodev' with 'dev' to run the tests with development flag set
+$ nix run .#test-ghc810
 ```
 
 To run the tests using ghcid (fit for writing tests):


### PR DESCRIPTION
Looks like the `dev`/`no-dev` options were removed. I'm assuming this has to do with the new `compile` `Config`?