### PR TITLE
change txid length from 28 to 32

### DIFF
--- a/Plutarch/Api/V1/Tx.hs
+++ b/Plutarch/Api/V1/Tx.hs
@@ -61,7 +61,7 @@ instance PTryFrom PData (PAsData PTxId) where
       pif (pnil #== ptail # flds) (f ()) $ ptraceError "ptryFrom(TxId): constructor fields len > 1"
     unwrapped <- tcont . plet $ ptryFrom @(PAsData PByteString) dataBs snd
     tcont $ \f ->
-      pif (plengthBS # unwrapped #== 28) (f ()) $ ptraceError "ptryFrom(TxId): must be 28 bytes long"
+      pif (plengthBS # unwrapped #== 32) (f ()) $ ptraceError "ptryFrom(TxId): must be 32 bytes long"
     pure (punsafeCoerce opq, unwrapped)
 
 -- | Reference to a transaction output with a index referencing which of the outputs is being referred to.


### PR DESCRIPTION
It seems this 28 should be a 32.

Changing it to 32 locally my code to start working, this included an equality check with a txid from the script context so it seems like the script context must have txids of length 32.