### PR TITLE
Clearer error from `PSubType`

### DIFF
--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -129,7 +129,7 @@ import Plutarch.Lift (
 import Plutarch.List (PListLike (pnil), pcons, pdrop, phead, ptail, ptryIndex)
 import Plutarch.TermCont (TermCont, hashOpenTerm, runTermCont, tcont, unTermCont)
 import Plutarch.Trace (ptraceError)
-import Plutarch.TryFrom (PSubTypeRelation (SuperType, Unrelated), PSubtype, PSubtype', PTryFrom, PTryFromExcess, ptryFrom, ptryFrom', pupcast)
+import Plutarch.TryFrom (PSubtype, PSubtype', PSubtypeRelation (SuperType, Unrelated), PTryFrom, PTryFromExcess, ptryFrom, ptryFrom', pupcast)
 import Plutarch.Unit (PUnit (PUnit))
 import Plutarch.Unsafe (punsafeCoerce)
 import qualified PlutusLedgerApi.V1 as Ledger
@@ -638,7 +638,7 @@ newtype HRecP (as :: [(Symbol, PType)]) (s :: S) = HRecP (NoReduce (HRecGeneric 
 newtype Flip f a b = Flip (f b a)
   deriving stock (Generic)
 
-class Helper2 (b :: PSubTypeRelation) a where
+class Helper2 (b :: PSubtypeRelation) a where
   type Helper2Excess b a :: PType
   ptryFromData' :: forall s r. Proxy b -> Term s PData -> ((Term s (PAsData a), Reduce (Helper2Excess b a s)) -> Term s r) -> Term s r
 
@@ -653,7 +653,7 @@ instance PTryFrom PData a => Helper2 'SuperType a where
     pure (punsafeCoerce y, exc)
 
 -- We could have a more advanced instance but it's not needed really.
-newtype ExcessForField (b :: PSubTypeRelation) (a :: PType) (s :: S) = ExcessForField (Term s (PAsData a), Reduce (Helper2Excess b a s))
+newtype ExcessForField (b :: PSubtypeRelation) (a :: PType) (s :: S) = ExcessForField (Term s (PAsData a), Reduce (Helper2Excess b a s))
   deriving stock (Generic)
 
 instance PTryFrom (PBuiltinList PData) (PDataRecord '[]) where

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -129,7 +129,7 @@ import Plutarch.Lift (
 import Plutarch.List (PListLike (pnil), pcons, pdrop, phead, ptail, ptryIndex)
 import Plutarch.TermCont (TermCont, hashOpenTerm, runTermCont, tcont, unTermCont)
 import Plutarch.Trace (ptraceError)
-import Plutarch.TryFrom (PSubtype, PSubtype', PTryFrom, PTryFromExcess, ptryFrom, ptryFrom', pupcast)
+import Plutarch.TryFrom (PSubTypeRelation (SuperType, Unrelated), PSubtype, PSubtype', PTryFrom, PTryFromExcess, ptryFrom, ptryFrom', pupcast)
 import Plutarch.Unit (PUnit (PUnit))
 import Plutarch.Unsafe (punsafeCoerce)
 import qualified PlutusLedgerApi.V1 as Ledger
@@ -638,22 +638,22 @@ newtype HRecP (as :: [(Symbol, PType)]) (s :: S) = HRecP (NoReduce (HRecGeneric 
 newtype Flip f a b = Flip (f b a)
   deriving stock (Generic)
 
-class Helper2 (b :: Bool) a where
+class Helper2 (b :: PSubTypeRelation) a where
   type Helper2Excess b a :: PType
   ptryFromData' :: forall s r. Proxy b -> Term s PData -> ((Term s (PAsData a), Reduce (Helper2Excess b a s)) -> Term s r) -> Term s r
 
-instance PTryFrom PData (PAsData a) => Helper2 'False a where
-  type Helper2Excess 'False a = PTryFromExcess PData (PAsData a)
+instance PTryFrom PData (PAsData a) => Helper2 'Unrelated a where
+  type Helper2Excess 'Unrelated a = PTryFromExcess PData (PAsData a)
   ptryFromData' _ = ptryFrom'
 
-instance PTryFrom PData a => Helper2 'True a where
-  type Helper2Excess 'True a = PTryFromExcess PData a
+instance PTryFrom PData a => Helper2 'SuperType a where
+  type Helper2Excess 'SuperType a = PTryFromExcess PData a
   ptryFromData' _ x = runTermCont $ do
     (y, exc) <- tcont $ ptryFrom @a @PData x
     pure (punsafeCoerce y, exc)
 
 -- We could have a more advanced instance but it's not needed really.
-newtype ExcessForField (b :: Bool) (a :: PType) (s :: S) = ExcessForField (Term s (PAsData a), Reduce (Helper2Excess b a s))
+newtype ExcessForField (b :: PSubTypeRelation) (a :: PType) (s :: S) = ExcessForField (Term s (PAsData a), Reduce (Helper2Excess b a s))
   deriving stock (Generic)
 
 instance PTryFrom (PBuiltinList PData) (PDataRecord '[]) where

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -129,7 +129,7 @@ import Plutarch.Lift (
 import Plutarch.List (PListLike (pnil), pcons, pdrop, phead, ptail, ptryIndex)
 import Plutarch.TermCont (TermCont, hashOpenTerm, runTermCont, tcont, unTermCont)
 import Plutarch.Trace (ptraceError)
-import Plutarch.TryFrom (PSubtype, PSubtype', PSubtypeRelation (SuperType, Unrelated), PTryFrom, PTryFromExcess, ptryFrom, ptryFrom', pupcast)
+import Plutarch.TryFrom (PSubtype, PSubtype', PSubtypeRelation (PNoSubtypeRelation, PSubtypeRelation), PTryFrom, PTryFromExcess, ptryFrom, ptryFrom', pupcast)
 import Plutarch.Unit (PUnit (PUnit))
 import Plutarch.Unsafe (punsafeCoerce)
 import qualified PlutusLedgerApi.V1 as Ledger
@@ -642,12 +642,12 @@ class Helper2 (b :: PSubtypeRelation) a where
   type Helper2Excess b a :: PType
   ptryFromData' :: forall s r. Proxy b -> Term s PData -> ((Term s (PAsData a), Reduce (Helper2Excess b a s)) -> Term s r) -> Term s r
 
-instance PTryFrom PData (PAsData a) => Helper2 'Unrelated a where
-  type Helper2Excess 'Unrelated a = PTryFromExcess PData (PAsData a)
+instance PTryFrom PData (PAsData a) => Helper2 'PNoSubtypeRelation a where
+  type Helper2Excess 'PNoSubtypeRelation a = PTryFromExcess PData (PAsData a)
   ptryFromData' _ = ptryFrom'
 
-instance PTryFrom PData a => Helper2 'SuperType a where
-  type Helper2Excess 'SuperType a = PTryFromExcess PData a
+instance PTryFrom PData a => Helper2 'PSubtypeRelation a where
+  type Helper2Excess 'PSubtypeRelation a = PTryFromExcess PData a
   ptryFromData' _ x = runTermCont $ do
     (y, exc) <- tcont $ ptryFrom @a @PData x
     pure (punsafeCoerce y, exc)

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -642,8 +642,8 @@ class Helper2 (b :: PSubTypeRelation) a where
   type Helper2Excess b a :: PType
   ptryFromData' :: forall s r. Proxy b -> Term s PData -> ((Term s (PAsData a), Reduce (Helper2Excess b a s)) -> Term s r) -> Term s r
 
-instance PTryFrom PData (PAsData a) => Helper2 'Unrelated a where
-  type Helper2Excess 'Unrelated a = PTryFromExcess PData (PAsData a)
+instance PTryFrom PData (PAsData a) => Helper2 ( 'Unrelated pa pb) a where
+  type Helper2Excess ( 'Unrelated _ _) a = PTryFromExcess PData (PAsData a)
   ptryFromData' _ = ptryFrom'
 
 instance PTryFrom PData a => Helper2 'SuperType a where

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -642,8 +642,8 @@ class Helper2 (b :: PSubtypeRelation) a where
   type Helper2Excess b a :: PType
   ptryFromData' :: forall s r. Proxy b -> Term s PData -> ((Term s (PAsData a), Reduce (Helper2Excess b a s)) -> Term s r) -> Term s r
 
-instance PTryFrom PData (PAsData a) => Helper2 ( 'Unrelated pa pb) a where
-  type Helper2Excess ( 'Unrelated _ _) a = PTryFromExcess PData (PAsData a)
+instance PTryFrom PData (PAsData a) => Helper2 'Unrelated a where
+  type Helper2Excess 'Unrelated a = PTryFromExcess PData (PAsData a)
   ptryFromData' _ = ptryFrom'
 
 instance PTryFrom PData a => Helper2 'SuperType a where

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -161,7 +161,6 @@ module Plutarch.Prelude (
   ptryFrom,
   PTryFrom,
   PSubtype,
-  PSubtypeRelation (Unrelated, SuperType),
   Generic,
 ) where
 

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -161,6 +161,7 @@ module Plutarch.Prelude (
   ptryFrom,
   PTryFrom,
   PSubtype,
+  PSubtypeRelation (Unrelated, SuperType),
   Generic,
 ) where
 

--- a/Plutarch/TryFrom.hs
+++ b/Plutarch/TryFrom.hs
@@ -5,6 +5,7 @@
 module Plutarch.TryFrom (
   PTryFrom (..),
   ptryFrom,
+  PSubTypeRelation (..),
   PSubtype,
   PSubtype',
   pupcast,
@@ -21,12 +22,16 @@ import Plutarch.Internal.Witness (witness)
 
 import Plutarch.Reducible (Reduce)
 
-type family Helper (a :: PType) (b :: PType) (bi :: PType) :: Bool where
-  Helper _ b b = 'False
+data PSubTypeRelation
+  = SuperType
+  | Unrelated
+
+type family Helper (a :: PType) (b :: PType) (bi :: PType) :: PSubTypeRelation where
+  Helper _ b b = 'Unrelated
   Helper a _ bi = PSubtype' a bi
 
-type family PSubtype' (a :: PType) (b :: PType) :: Bool where
-  PSubtype' a a = 'True
+type family PSubtype' (a :: PType) (b :: PType) :: PSubTypeRelation where
+  PSubtype' a a = 'SuperType
   PSubtype' a b = Helper a b (PInner b)
 
 {- | @PSubtype a b@ constitutes a subtyping relation between @a@ and @b@.
@@ -42,7 +47,7 @@ type family PSubtype' (a :: PType) (b :: PType) :: Bool where
  Subtyping is transitive.
 -}
 type family PSubtype (a :: PType) (b :: PType) :: Constraint where
-  PSubtype a b = PSubtype' a b ~ 'True
+  PSubtype a b = PSubtype' a b ~ 'SuperType
 
 {- |
 @PTryFrom a b@ represents a subtyping relationship between @a@ and @b@,

--- a/Plutarch/TryFrom.hs
+++ b/Plutarch/TryFrom.hs
@@ -5,7 +5,7 @@
 module Plutarch.TryFrom (
   PTryFrom (..),
   ptryFrom,
-  PSubTypeRelation (..),
+  PSubtypeRelation (..),
   PSubtype,
   PSubtype',
   pupcast,
@@ -22,17 +22,20 @@ import Plutarch.Internal.Witness (witness)
 
 import Plutarch.Reducible (Reduce)
 
-data PSubTypeRelation
+data PSubtypeRelation
   = SuperType
   | Unrelated PType PType
 
-type family Helper (a :: PType) (b :: PType) (bi :: PType) :: PSubTypeRelation where
-  Helper a b b = 'Unrelated a b
-  Helper a _ bi = PSubtype' a bi
+type family Helper (a :: PType) (b :: PType) (bi :: PType) (oa :: PType) (ob :: PType) :: PSubtypeRelation where
+  Helper _ b b oa ob = 'Unrelated oa ob
+  Helper a _ bi oa ob = PSubtype'' a bi oa ob
 
-type family PSubtype' (a :: PType) (b :: PType) :: PSubTypeRelation where
-  PSubtype' a a = 'SuperType
-  PSubtype' a b = Helper a b (PInner b)
+type family PSubtype'' (a :: PType) (b :: PType) (oa :: PType) (ob :: PType) :: PSubtypeRelation where
+  PSubtype'' a a _ _ = 'SuperType
+  PSubtype'' a b oa ob = Helper a b (PInner b) oa ob
+
+type family PSubtype' (a :: PType) (b :: PType) :: PSubtypeRelation where
+  PSubtype' a b = PSubtype'' a b a b
 
 {- | @PSubtype a b@ constitutes a subtyping relation between @a@ and @b@.
  This concretely means that `\(x :: Term s b) -> punsafeCoerce x :: Term s a`

--- a/Plutarch/TryFrom.hs
+++ b/Plutarch/TryFrom.hs
@@ -24,10 +24,10 @@ import Plutarch.Reducible (Reduce)
 
 data PSubTypeRelation
   = SuperType
-  | Unrelated
+  | Unrelated PType PType
 
 type family Helper (a :: PType) (b :: PType) (bi :: PType) :: PSubTypeRelation where
-  Helper _ b b = 'Unrelated
+  Helper a b b = 'Unrelated a b
   Helper a _ bi = PSubtype' a bi
 
 type family PSubtype' (a :: PType) (b :: PType) :: PSubTypeRelation where

--- a/Plutarch/TryFrom.hs
+++ b/Plutarch/TryFrom.hs
@@ -25,15 +25,15 @@ import Plutarch.Reducible (Reduce)
 import GHC.TypeLits (ErrorMessage (ShowType, Text, (:<>:)), TypeError)
 
 data PSubtypeRelation
-  = SuperType
-  | Unrelated
+  = PSubtypeRelation
+  | PNoSubtypeRelation
 
 type family Helper (a :: PType) (b :: PType) (bi :: PType) :: PSubtypeRelation where
-  Helper _ b b = 'Unrelated
+  Helper _ b b = 'PNoSubtypeRelation
   Helper a _ bi = PSubtype' a bi
 
 type family PSubtype' (a :: PType) (b :: PType) :: PSubtypeRelation where
-  PSubtype' a a = 'SuperType
+  PSubtype' a a = 'PSubtypeRelation
   PSubtype' a b = Helper a b (PInner b)
 
 {- | @PSubtype a b@ constitutes a subtyping relation between @a@ and @b@.
@@ -49,7 +49,7 @@ type family PSubtype' (a :: PType) (b :: PType) :: PSubtypeRelation where
  Subtyping is transitive.
 -}
 type family PSubtypeHelper (a :: PType) (b :: PType) (r :: PSubtypeRelation) :: Constraint where
-  PSubtypeHelper a b 'Unrelated =
+  PSubtypeHelper a b 'PNoSubtypeRelation =
     TypeError
       ( 'Text "\""
           ':<>: 'ShowType b
@@ -59,10 +59,10 @@ type family PSubtypeHelper (a :: PType) (b :: PType) (r :: PSubtypeRelation) :: 
           ':<>: 'ShowType a
           ':<>: 'Text "\""
       )
-  PSubtypeHelper _ _ 'SuperType = ()
+  PSubtypeHelper _ _ 'PSubtypeRelation = ()
 
 type family PSubtype (a :: PType) (b :: PType) :: Constraint where
-  PSubtype a b = (PSubtype' a b ~ 'SuperType, PSubtypeHelper a b (PSubtype' a b))
+  PSubtype a b = (PSubtype' a b ~ 'PSubtypeRelation, PSubtypeHelper a b (PSubtype' a b))
 
 {- |
 @PTryFrom a b@ represents a subtyping relationship between @a@ and @b@,


### PR DESCRIPTION
Before:
```
<interactive>:1:1: error:
    • Couldn't match type ‘'False’ with ‘'True’
        arising from a use of ‘pdata’
    • In the expression: pdata a
```

After:
```
<interactive>:1:1: error:
    • Couldn't match type ‘'Unrelated PData PInteger’ with ‘'SuperType’
        arising from a use of ‘pdata’
    • In the expression: pdata a
```