### PR TITLE
`PDataFields` made derivable for PTypes that have `PDataRecord`

### DIFF
--- a/Plutarch/DataRepr/Internal/Field.hs
+++ b/Plutarch/DataRepr/Internal/Field.hs
@@ -39,7 +39,6 @@ import Plutarch (
   plet,
   pto,
   (#),
-  (#$),
   type (:-->),
  )
 
@@ -77,6 +76,7 @@ import Plutarch.TermCont (TermCont (TermCont), runTermCont)
 
 type family Helper (x :: PType) :: [PLabeledType] where
   Helper (PDataSum '[y]) = y
+  Helper (PDataRecord y) = y
 
 {- |
   Class allowing 'letFields' to work for a PType, usually via
@@ -90,8 +90,8 @@ class PDataFields (a :: PType) where
 
   -- | Convert a Term to a 'PDataList'
   ptoFields :: Term s a -> Term s (PDataRecord (PFields a))
-  default ptoFields :: PInner a ~ PDataSum '[PFields a] => Term s a -> Term s (PDataRecord (PFields a))
-  ptoFields x = punDataSum #$ pto x
+  default ptoFields :: (PDataFields (PInner a), PFields (PInner a) ~ PFields a) => Term s a -> Term s (PDataRecord (PFields a))
+  ptoFields x = ptoFields $ pto x
 
 instance PDataFields (PDataRecord as) where
   type PFields (PDataRecord as) = as


### PR DESCRIPTION
Previously, 
```hs
newtype PFoo s
    = PFoo
      ( Term s
          ( PDataRecord
              '[ "abc" ':= PInteger
               ]
          )
      )
  deriving stock (GHC.Generic)
  deriving anyclass (PlutusType, PIsData, PDataFields)
                                          ^ doesn't work

instance DerivePlutusType PFoo where
   DPTStrat _ = PlutusTypeNewtype

-- to get field "abc" of PFoo, you need to use "pto"
a = pconstant $ Foo 10
field @"abc" # a -- Doesn't work
field @"abc" # pto a -- This only works. 
```

This PR make these types derive `PDataFields` with `deriving anyclass`, so that we don't have to `pto` every time we want to access fields.

edit:
I think there's some confusion on why we need this. This is useful because it allows the `PlutusTypeNewtype` with inner of `PDataRecord` to directly derive `PDataFields`. Without this, those types cannot use `pfield` directly and it requires `pto` every time. 

Also, putting instances manually doesn't really make sense because all of them will be 
```hs
intsance PDataFields XYZ where
    type PFields a = PFields (PInner a)
    ptoField x = ptoField $ pto x
```
which is identical to the default instance. All of these can be solved by allowing more types to `PDataFields` defaults other than `PDataSum`.