### PR TITLE
Ensure that zero values get rejected from Value singleton functions

### DIFF
--- a/Plutarch/Api/V1/Value.hs
+++ b/Plutarch/Api/V1/Value.hs
@@ -247,7 +247,7 @@ pconstantSingleton ::
   ClosedTerm PInteger ->
   ClosedTerm (PValue 'Sorted 'NonZero)
 pconstantSingleton symbol token amount
-  | plift amount == 0 = mempty
+  | plift amount == 0 = ptraceError "pconstantSingleton: Given a zero argument, expecting nonzero."
   | otherwise = punsafeDowncast (AssocMap.psingleton # symbol #$ AssocMap.psingleton # token # amount)
 
 -- | Construct a constant singleton 'PValue' containing only the given positive quantity of the given currency.
@@ -257,7 +257,7 @@ pconstantPositiveSingleton ::
   ClosedTerm PInteger ->
   ClosedTerm (PValue 'Sorted 'Positive)
 pconstantPositiveSingleton symbol token amount
-  | plift amount == 0 = mempty
+  | plift amount == 0 = ptraceError "pconstantPositiveSingleton: Given a zero argument, expecting nonzero."
   | plift amount < 0 = error "Negative amount"
   | otherwise = punsafeDowncast (AssocMap.psingleton # symbol #$ AssocMap.psingleton # token # amount)
 
@@ -270,7 +270,7 @@ psingleton = phoistAcyclic $
   plam $ \symbol token amount ->
     pif
       (amount #== 0)
-      mempty
+      (ptraceError "psingleton: Given a zero argument, expecting nonzero.")
       (punsafeDowncast $ AssocMap.psingleton # symbol #$ AssocMap.psingleton # token # amount)
 
 {- | Construct a singleton 'PValue' containing only the given quantity of the
@@ -286,7 +286,7 @@ psingletonData = phoistAcyclic $
   plam $ \symbol token amount ->
     pif
       (amount #== zeroData)
-      mempty
+      (ptraceError "psingletonData: Given a zero argument, expecting nonzero.")
       ( punsafeDowncast
           ( AssocMap.psingletonData # symbol
               #$ pdata


### PR DESCRIPTION
Currently, the functions `pconstantSingleton`, `pconstantPositiveSingleton`, `psingleton` and `psingletonData` do not properly reject zero arguments. While technically what they do is not wrong (they don't end up containing zero amounts), it's still not correct behaviour: an empty `PValue` is not a 'singleton' by any definition.

This PR fixes this problem to instead error if given a zero argument in those cases.