### PR TITLE
Unsure if correct (!): point out that Type is the same as *

### DIFF
--- a/docs/Introduction/Plutarch Types.md
+++ b/docs/Introduction/Plutarch Types.md
@@ -10,6 +10,7 @@ When this guide uses the term "Plutarch Type" we explicitly talk about a type of
 ghci> :k PBool
 PBool :: S -> Type
 ```
+(Note: `Type` is the same thing as `*`)
 
 Thus, any time we see the kind `S -> Type`, we should mentally substitute its kind synonym `PType`. We reiterate: types of kind `PType`, should be considered as _tags_ on computation. They do not represent types of values in the same way as standard Haskell types.
 


### PR DESCRIPTION
Figured it's better to propose a change than create an issue. Is this edit true? Is this behaviour of mine correct?

Follow-up question: Why does it sometimes print Type and sometimes *? Should be added as well, such little unclarities tend to block learning, at least for me.