### PR TITLE
add constructor export for `Script` type, add `deserialiseScript`

### DIFF
--- a/Plutarch.hs
+++ b/Plutarch.hs
@@ -2,7 +2,7 @@ module Plutarch (
   (PI.:-->),
   PI.ClosedTerm,
   PI.compile,
-  PI.Script,
+  PI.Script (PI.Script),
   PI.Dig,
   PI.hashTerm,
   PI.papp,

--- a/Plutarch/Internal.hs
+++ b/Plutarch/Internal.hs
@@ -7,7 +7,7 @@ module Plutarch.Internal (
   -- | $term
   Term (..),
   asClosedRawTerm,
-  Script,
+  Script (Script),
   mapTerm,
   plam',
   plet,

--- a/Plutarch/Script.hs
+++ b/Plutarch/Script.hs
@@ -1,12 +1,16 @@
-module Plutarch.Script (Script (..), serialiseScript) where
+module Plutarch.Script (Script (..), serialiseScript, deserialiseScript) where
 
 import Data.ByteString.Short (ShortByteString)
-import PlutusLedgerApi.Common (serialiseUPLC)
+import GHC.Generics (Generic)
+import PlutusLedgerApi.Common (deserialiseUPLC, serialiseUPLC)
 import UntypedPlutusCore qualified as UPLC
 
 newtype Script = Script {unScript :: UPLC.Program UPLC.DeBruijn UPLC.DefaultUni UPLC.DefaultFun ()}
   deriving newtype (Eq)
-  deriving stock (Show)
+  deriving stock (Show, Generic)
 
 serialiseScript :: Script -> ShortByteString
 serialiseScript = serialiseUPLC . unScript
+
+deserialiseScript :: ShortByteString -> Script
+deserialiseScript = Script . deserialiseUPLC


### PR DESCRIPTION
`Script` previously did export its constructor when it lived in `plutus-ledger-api`, so I think it should do if it lives in Plutarch, too. Additionally, this adds `deserialiseScript`. We had `serialiseScript` already, but not deserialise.