### PR TITLE
Add fixity for `PNum` operators

### DIFF
--- a/Plutarch/Num.hs
+++ b/Plutarch/Num.hs
@@ -42,6 +42,12 @@ class PNum (a :: PType) where
   default pfromInteger :: PNum (PInner a) => Integer -> Term s a
   pfromInteger x = punsafeDowncast $ pfromInteger x
 
+-- prohibit mixing arithmetic operators such as
+-- (2 #+ 3 #* 4) without explicit precedence.
+infix (#+) 6
+infix (#-) 6
+infix (#*) 6
+
 -- orphan instance, but only visibly orphan when importing internal modules
 instance PNum a => Num (Term s a) where
   (+) = (#+)


### PR DESCRIPTION
`PNum` operators have no fixity, and hence expressions such as
```hs
2 #+ 3 #* 4
```
are legal, while counter-intuitive as their Haskell-level equivalent `Num` operator _do have_ fixity. The current PR proposes to fix that issue by adding explicit `infix _ 6` to each of the operators. That way GHC can catch some precedence bugs, as above.