### PR TITLE
Fix PRationalData comparison, tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ result*
 /dist-*
 .direnv
 .pre-commit-config.yaml
+.nvimrc

--- a/flake.lock
+++ b/flake.lock
@@ -254,8 +254,8 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1704152458,
-        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "07f6395285469419cf9d078f59b5b49993198c00",

--- a/plutarch-test/goldens/extra.rationaldatautils.regression.bench.golden
+++ b/plutarch-test/goldens/extra.rationaldatautils.regression.bench.golden
@@ -1,0 +1,3 @@
+0/1 #< 758566050/758566050 should be true {"exBudgetCPU":2786341,"exBudgetMemory":8053,"scriptSizeBytes":85}
+758566050/758566050 #<= 1/1 should be true {"exBudgetCPU":2713331,"exBudgetMemory":7753,"scriptSizeBytes":74}
+1/1 #== 2/2 should be true {"exBudgetCPU":2360859,"exBudgetMemory":3693,"scriptSizeBytes":40}

--- a/plutarch-test/goldens/extra.rationaldatautils.regression.uplc.eval.golden
+++ b/plutarch-test/goldens/extra.rationaldatautils.regression.uplc.eval.golden
@@ -1,0 +1,3 @@
+0/1 #< 758566050/758566050 should be true (program 1.0.0 True)
+758566050/758566050 #<= 1/1 should be true (program 1.0.0 True)
+1/1 #== 2/2 should be true (program 1.0.0 True)

--- a/plutarch-test/goldens/extra.rationaldatautils.regression.uplc.golden
+++ b/plutarch-test/goldens/extra.rationaldatautils.regression.uplc.golden
@@ -1,0 +1,50 @@
+0/1 #< 758566050/758566050 should be true (program 1.0.0 ((\i0 ->
+                   (\i0 ->
+                      (\i0 ->
+                         (\i0 ->
+                            (\i0
+                              i0 ->
+                               (\i0 ->
+                                  (\i0 ->
+                                     lessThanInteger
+                                       (multiplyInteger
+                                          (unIData (i5 i2))
+                                          (unIData (i5 (i6 i1))))
+                                       (multiplyInteger
+                                          (unIData (i5 i1))
+                                          (unIData (i5 (i6 i2)))))
+                                    (i6 i2))
+                                 (i5 i2))
+                              #d8799f0001ff
+                              #d8799f0101ff)
+                           (force headList))
+                        (force tailList))
+                     (\i0 -> i2 (unConstrData i1)))
+                  (force (force sndPair))))
+758566050/758566050 #<= 1/1 should be true (program 1.0.0 ((\i0 ->
+                   (\i0 ->
+                      (\i0 ->
+                         (\i0 ->
+                            (\i0 ->
+                               (\i0 ->
+                                  (\i0 ->
+                                     lessThanEqualsInteger
+                                       (multiplyInteger
+                                          (unIData (i3 i2))
+                                          (unIData (i3 (i4 i1))))
+                                       (multiplyInteger
+                                          (unIData (i3 i1))
+                                          (unIData (i3 (i4 i2)))))
+                                    (i4 i6))
+                                 (i3 i5))
+                              (force headList))
+                           (force tailList))
+                        (\i0 -> i2 (unConstrData i1)))
+                     (force (force sndPair)))
+                  #d8799f0101ff))
+1/1 #== 2/2 should be true (program 1.0.0 ((\i0 ->
+                   (\i0 ->
+                      (\i0 -> equalsData (listData (i1 i3)) (listData (i1 i3)))
+                        (\i0 -> i2 (unConstrData i1)))
+                     (force (force sndPair)))
+                  #d8799f0101ff))

--- a/plutarch-test/plutarch-test.cabal
+++ b/plutarch-test/plutarch-test.cabal
@@ -133,6 +133,7 @@ executable plutarch-test
     Plutarch.Extra.IntervalSpec
     Plutarch.Extra.ListSpec
     Plutarch.Extra.MaybeSpec
+    Plutarch.Extra.RationalDataSpec
     Plutarch.FieldSpec
     Plutarch.IntegerSpec
     Plutarch.LiftSpec

--- a/plutarch-test/tests/Plutarch/Extra/RationalDataSpec.hs
+++ b/plutarch-test/tests/Plutarch/Extra/RationalDataSpec.hs
@@ -1,0 +1,121 @@
+module Plutarch.Extra.RationalDataSpec (spec) where
+
+import Hedgehog (Gen, PropertyT, forAll)
+import Hedgehog.Gen qualified as Gen
+import Hedgehog.Range qualified as Range
+import Plutarch.Extra.RationalData ()
+import Plutarch.Prelude
+import Plutarch.Test (passert, pgoldenSpec, (@->), (@|))
+import Plutarch.Test.Property.HaskEquiv (testPEq)
+import PlutusTx.Ratio qualified as PlutusTx
+import Test.Hspec (Spec, describe, it)
+import Test.Hspec.Hedgehog (hedgehog, modifyMaxSuccess)
+
+spec :: Spec
+spec = modifyMaxSuccess (const 10_000) $ do
+  describe "extra.rationaldatautils" $ do
+    describe "properties" $ do
+      it "normalizes" . hedgehog $ propNorm
+      it "x / y == a / b iff xb == ya" . hedgehog $ propEq
+      it "x / y < a / b iff xb < ya" . hedgehog $ propLt
+      it "x / y <= a / b iff xb <= ya" . hedgehog $ propLe
+    describe "regression" . pgoldenSpec $ do
+      "0/1 #< 758566050/758566050 should be true" @| regression1 @-> passert
+      "758566050/758566050 #<= 1/1 should be true" @| regression2 @-> passert
+      "1/1 #== 2/2 should be true" @| regression3 @-> passert
+
+-- Helpers
+
+-- Properties
+
+propNorm :: PropertyT IO ()
+propNorm = do
+  n <- forAll genNumeratorSmall
+  d <- forAll . Gen.choice $ [genDenominatorN, genDenominatorP]
+  let frac = PlutusTx.unsafeRatio n d
+  -- If signa match, answer must be positive
+  if
+    | signum n == signum d -> do
+        let absFrac = PlutusTx.unsafeRatio (abs n) (abs d)
+        testPEq (pconstant frac) (pconstant absFrac)
+    -- If numerator is zero, we get zero no matter what
+    | signum n == 0 -> do
+        let zeroFrac = PlutusTx.unsafeRatio 0 1
+        testPEq (pconstant frac) (pconstant zeroFrac)
+    -- Otherwise, answer must be negative
+    | otherwise -> do
+        let negFrac = PlutusTx.unsafeRatio (negate . abs $ n) (abs d)
+        testPEq (pconstant frac) (pconstant negFrac)
+
+propEq :: PropertyT IO ()
+propEq = do
+  x <- forAll genNumerator
+  y <- forAll genDenominator
+  a <- forAll genNumerator
+  b <- forAll genDenominator
+  let lhsFrac = PlutusTx.unsafeRatio x y
+  let rhsFrac = PlutusTx.unsafeRatio a b
+  testPEq
+    (pconstant lhsFrac #== pconstant rhsFrac)
+    (pconstant (x * b) #== pconstant (y * a))
+
+propLt :: PropertyT IO ()
+propLt = do
+  x <- forAll genNumerator
+  y <- forAll genDenominator
+  a <- forAll genNumerator
+  b <- forAll genDenominator
+  let lhsFrac = PlutusTx.unsafeRatio x y
+  let rhsFrac = PlutusTx.unsafeRatio a b
+  testPEq
+    (pconstant lhsFrac #< pconstant rhsFrac)
+    (pconstant (x * b) #< pconstant (y * a))
+
+propLe :: PropertyT IO ()
+propLe = do
+  x <- forAll genNumerator
+  y <- forAll genDenominator
+  a <- forAll genNumerator
+  b <- forAll genDenominator
+  let lhsFrac = PlutusTx.unsafeRatio x y
+  let rhsFrac = PlutusTx.unsafeRatio a b
+  testPEq
+    (pconstant lhsFrac #<= pconstant rhsFrac)
+    (pconstant (x * b) #<= pconstant (y * a))
+
+-- Generators
+
+genNumerator :: Gen Integer
+genNumerator = Gen.integral $ Range.linearFrom 0 (-1_000_000_000) 1_000_000_000
+
+genNumeratorSmall :: Gen Integer
+genNumeratorSmall = Gen.integral $ Range.linearFrom 0 (-100) 100
+
+genDenominator :: Gen Integer
+genDenominator = Gen.integral $ Range.linear 1 1_000_000_000
+
+genDenominatorN :: Gen Integer
+genDenominatorN = Gen.integral $ Range.linear (-1) (-100)
+
+genDenominatorP :: Gen Integer
+genDenominatorP = Gen.integral $ Range.linear 1 100
+
+-- Regression cases
+
+regression1 :: forall (s :: S). Term s PBool
+regression1 = unTermCont $ do
+  let lhs = pconstant $ PlutusTx.unsafeRatio 0 1
+  let rhs = pconstant $ PlutusTx.unsafeRatio 758566050 758566050
+  pure $ lhs #< rhs
+
+regression2 :: forall (s :: S). Term s PBool
+regression2 = unTermCont $ do
+  let lhs = pconstant $ PlutusTx.unsafeRatio 758566050 758566050
+  let rhs = pconstant $ PlutusTx.unsafeRatio 1 1
+  pure $ lhs #<= rhs
+
+regression3 :: forall (s :: S). Term s PBool
+regression3 = unTermCont $ do
+  let lhs = pconstant $ PlutusTx.unsafeRatio 1 1
+  let rhs = pconstant $ PlutusTx.unsafeRatio 2 2
+  pure $ lhs #== rhs


### PR DESCRIPTION
Fixes #618. In addition to fixing the issue, tests have been added to make sure comparison operators behave as expected, both on the reported failure cases and also more broadly.

I'm not sure why the failure in `PEq` happened: currently, this shouldn't be the case. It's possible we were working against a pre-normalization version of `Rational` in PlutusTx? Either way, I can't repro that issue, and the tests show no issues as far as I can tell.

@peter-mlabs - this should fix your issue, though I can't add you as a reviewer for some reason.