### PR TITLE
Create plutarch-api

### DIFF
--- a/plutarch-api/CHANGELOG.md
+++ b/plutarch-api/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog for `plutarch-api-v2`
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## 2.0.0 -- 17-01-2024
+
+Initial version

--- a/plutarch-api/plutarch-api.cabal
+++ b/plutarch-api/plutarch-api.cabal
@@ -1,0 +1,63 @@
+cabal-version: 3.0
+name:          plutarch-api
+version:       2.0.0
+
+common common-lang
+  default-language:   Haskell2010
+  ghc-options:
+    -Wall -Wcompat -Wincomplete-record-updates
+    -Wincomplete-uni-patterns -Wredundant-constraints -Werror
+    -Wmissing-deriving-strategies -Wmissing-export-lists
+
+  build-depends:      base
+  default-extensions:
+    BangPatterns
+    BinaryLiterals
+    DataKinds
+    DeriveAnyClass
+    DeriveGeneric
+    DeriveTraversable
+    DerivingVia
+    DuplicateRecordFields
+    EmptyCase
+    FlexibleContexts
+    FlexibleInstances
+    GeneralizedNewtypeDeriving
+    HexFloatLiterals
+    ImportQualifiedPost
+    InstanceSigs
+    KindSignatures
+    LambdaCase
+    MultiParamTypeClasses
+    NoStarIsType
+    NumericUnderscores
+    OverloadedLabels
+    OverloadedStrings
+    PackageImports
+    ScopedTypeVariables
+    StandaloneDeriving
+    TupleSections
+    TypeApplications
+    TypeFamilies
+    TypeOperators
+    UndecidableInstances
+
+library
+  import:          common-lang
+  exposed-modules:
+    Plutarch.Api
+    Plutarch.Api.AssocMap
+    Plutarch.Api.Utils
+    Plutarch.Api.Value
+
+  build-depends:
+    , bytestring
+    , cryptonite
+    , memory
+    , plutarch
+    , plutus-core
+    , plutus-ledger-api
+    , plutus-tx
+    , serialise
+
+  hs-source-dirs:  src

--- a/plutarch-api/src/Plutarch/Api.hs
+++ b/plutarch-api/src/Plutarch/Api.hs
@@ -1,0 +1,1275 @@
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | = Note
+
+The 'Value.PValue' and 'AssocMap.PMap'-related functionality can be found in
+other modules, as these clash with the Plutarch prelude. These should be
+imported qualified.
+-}
+module Plutarch.Api (
+  -- * Contexts
+  PScriptContext (..),
+  PTxInfo (..),
+  PScriptPurpose (..),
+
+  -- * Tx
+  PTxOutRef (..),
+  PTxOut (..),
+  PTxId (..),
+  PTxInInfo (..),
+  POutputDatum (..),
+
+  -- * Script
+
+  -- ** Types
+  PDatum (..),
+  PDatumHash (..),
+  PRedeemer (..),
+  PRedeemerHash (..),
+  PScriptHash (..),
+
+  -- ** Functions
+  scriptHash,
+  datumHash,
+  redeemerHash,
+  dataHash,
+
+  -- * Value
+  Value.PValue (..),
+  Value.AmountGuarantees (..),
+  Value.PCurrencySymbol (..),
+  Value.PTokenName (..),
+
+  -- * DCert
+  PDCert (..),
+
+  -- * Assoc map
+
+  -- ** Types
+  AssocMap.PMap (..),
+  AssocMap.KeyGuarantees (..),
+  AssocMap.Commutativity (..),
+
+  -- * Address
+  PCredential (..),
+  PStakingCredential (..),
+  PAddress (..),
+
+  -- * Time
+  PPosixTime (..),
+
+  -- * Interval
+  PInterval (..),
+  PLowerBound (..),
+  PUpperBound (..),
+  PExtended (..),
+
+  -- * Crypto
+
+  -- ** Types
+  PubKey (..),
+  PPubKeyHash (..),
+  pubKeyHash,
+
+  -- * Utilities
+
+  -- ** Types
+  PMaybeData (..),
+
+  -- ** Functions
+  ptuple,
+) where
+
+import Codec.Serialise (serialise)
+import Crypto.Hash (
+  Blake2b_224 (Blake2b_224),
+  Blake2b_256 (Blake2b_256),
+  hashWith,
+ )
+import Data.Bifunctor (first)
+import Data.ByteArray (convert)
+import Data.ByteString (ByteString, toStrict)
+import Data.ByteString.Short (fromShort)
+import Data.Coerce (coerce)
+import Plutarch.Api.AssocMap qualified as AssocMap
+import Plutarch.Api.Utils (Mret)
+import Plutarch.Api.Value qualified as Value
+import Plutarch.Builtin (pasConstr, pconstrBuiltin, pforgetData)
+import Plutarch.DataRepr (
+  DerivePConstantViaData (DerivePConstantViaData),
+  PDataFields,
+ )
+import Plutarch.Lift (
+  DerivePConstantViaBuiltin (DerivePConstantViaBuiltin),
+  DerivePConstantViaNewtype (DerivePConstantViaNewtype),
+  PConstantDecl (PConstanted),
+  PUnsafeLiftDecl (PLifted),
+ )
+import Plutarch.Num (PNum)
+import Plutarch.Prelude
+import Plutarch.Reducible (Reduce)
+import Plutarch.Script (Script (unScript))
+import Plutarch.TryFrom (PTryFrom (PTryFromExcess, ptryFrom'))
+import Plutarch.Unsafe (punsafeCoerce)
+import PlutusLedgerApi.Common (serialiseUPLC)
+import PlutusLedgerApi.V2 qualified as Plutus
+import PlutusTx.Prelude qualified as PlutusTx
+
+-- | @since 2.0.0
+newtype PScriptContext (s :: S)
+  = PScriptContext
+      ( Term
+          s
+          ( PDataRecord
+              '[ "txInfo" ':= PTxInfo
+               , "purpose" ':= PScriptPurpose
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PScriptContext where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PScriptContext where
+  type PLifted _ = Plutus.ScriptContext
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.ScriptContext PScriptContext)
+  instance
+    PConstantDecl Plutus.ScriptContext
+
+-- A pending transaction. This is the view as seen by a validator script.
+--
+-- @since 2.0.0
+newtype PTxInfo (s :: S)
+  = PTxInfo
+      ( Term
+          s
+          ( PDataRecord
+              '[ "inputs" ':= PBuiltinList PTxInInfo
+               , "referenceInputs" ':= PBuiltinList PTxInInfo
+               , "outputs" ':= PBuiltinList PTxOut
+               , "fee" ':= Value.PValue 'AssocMap.Sorted 'Value.Positive
+               , "mint" ':= Value.PValue 'AssocMap.Sorted 'Value.NoGuarantees -- value minted by transaction
+               , "dcert" ':= PBuiltinList PDCert -- Digests of certificates included in this transaction
+               , "wdrl" ':= AssocMap.PMap 'AssocMap.Unsorted PStakingCredential PInteger -- Staking withdrawals
+               , "validRange" ':= PInterval PPosixTime
+               , "signatories" ':= PBuiltinList (PAsData PPubKeyHash)
+               , "redeemers" ':= AssocMap.PMap 'AssocMap.Unsorted PScriptPurpose PRedeemer
+               , "datums" ':= AssocMap.PMap 'AssocMap.Unsorted PDatumHash PDatum
+               , "id" ':= PTxId -- hash of the pending transaction
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PTxInfo where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PTxInfo where
+  type PLifted _ = Plutus.TxInfo
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.TxInfo PTxInfo)
+  instance
+    PConstantDecl Plutus.TxInfo
+
+-- | @since 2.0.0
+data PScriptPurpose (s :: S)
+  = PMinting (Term s (PDataRecord '["_0" ':= Value.PCurrencySymbol]))
+  | PSpending (Term s (PDataRecord '["_0" ':= PTxOutRef]))
+  | PRewarding (Term s (PDataRecord '["_0" ':= PStakingCredential]))
+  | PCertifying (Term s (PDataRecord '["_0" ':= PDCert]))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PScriptPurpose where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PScriptPurpose where
+  type PLifted PScriptPurpose = Plutus.ScriptPurpose
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.ScriptPurpose PScriptPurpose)
+  instance
+    PConstantDecl Plutus.ScriptPurpose
+
+-- | @since 2.0.0
+newtype PTxOut (s :: S)
+  = PTxOut
+      ( Term
+          s
+          ( PDataRecord
+              '[ "address" ':= PAddress
+               , "value" ':= Value.PValue 'AssocMap.Sorted 'Value.Positive
+               , "datum" ':= POutputDatum
+               , "referenceScript" ':= PMaybeData PScriptHash
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PTxOut where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PTxOut where
+  type PLifted PTxOut = Plutus.TxOut
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.TxOut PTxOut)
+  instance
+    PConstantDecl Plutus.TxOut
+
+{- | An input of the pending transaction.
+
+@since 2.0.0
+-}
+newtype PTxInInfo (s :: S)
+  = PTxInInfo
+      ( Term
+          s
+          ( PDataRecord
+              '[ "outRef" ':= PTxOutRef
+               , "resolved" ':= PTxOut
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PTxInInfo where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PTxInInfo where
+  type PLifted PTxInInfo = Plutus.TxInInfo
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.TxInInfo PTxInInfo)
+  instance
+    PConstantDecl Plutus.TxInInfo
+
+-- | @since 2.0.0
+data POutputDatum (s :: S)
+  = PNoOutputDatum (Term s (PDataRecord '[]))
+  | POutputDatumHash (Term s (PDataRecord '["datumHash" ':= PDatumHash]))
+  | -- | Inline datum as per
+    -- [CIP-0032](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0032/README.md)
+    POutputDatum (Term s (PDataRecord '["outputDatum" ':= PDatum]))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType POutputDatum where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl POutputDatum where
+  type PLifted POutputDatum = Plutus.OutputDatum
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.OutputDatum POutputDatum)
+  instance
+    PConstantDecl Plutus.OutputDatum
+
+-- | @since 2.0.0
+newtype PDatum (s :: S) = PDatum (Term s PData)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PDatum where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PDatum where
+  type PLifted PDatum = Plutus.Datum
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaBuiltin Plutus.Datum PDatum PData)
+  instance
+    PConstantDecl Plutus.Datum
+
+-- | @since 2.0.0
+newtype PRedeemer (s :: S) = PRedeemer (Term s PData)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PRedeemer where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PRedeemer where
+  type PLifted PRedeemer = Plutus.Redeemer
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaBuiltin Plutus.Redeemer PRedeemer PData)
+  instance
+    PConstantDecl Plutus.Redeemer
+
+-- | @since 2.0.0
+newtype PDatumHash (s :: S) = PDatumHash (Term s PByteString)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PDatumHash where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PDatumHash where
+  type PLifted PDatumHash = Plutus.DatumHash
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaBuiltin Plutus.DatumHash PDatumHash PByteString)
+  instance
+    PConstantDecl Plutus.DatumHash
+
+-- | @since 2.0.0
+newtype PRedeemerHash (s :: S) = PRedeemerHash (Term s PByteString)
+
+{- | Hash a script, appending the Plutus V2 prefix.
+
+@since 2.0.0
+-}
+scriptHash :: Script -> Plutus.ScriptHash
+scriptHash = hashScriptWithPrefix "\x02"
+
+-- | @since 2.0.0
+data PDCert (s :: S)
+  = PDCertDelegRegKey (Term s (PDataRecord '["_0" ':= PStakingCredential]))
+  | PDCertDelegDeRegKey (Term s (PDataRecord '["_0" ':= PStakingCredential]))
+  | PDCertDelegDelegate
+      ( Term
+          s
+          ( PDataRecord
+              '[ "_0" ':= PStakingCredential
+               , "_1" ':= PPubKeyHash
+               ]
+          )
+      )
+  | PDCertPoolRegister (Term s (PDataRecord '["_0" ':= PPubKeyHash, "_1" ':= PPubKeyHash]))
+  | PDCertPoolRetire (Term s (PDataRecord '["_0" ':= PPubKeyHash, "_1" ':= PInteger]))
+  | PDCertGenesis (Term s (PDataRecord '[]))
+  | PDCertMir (Term s (PDataRecord '[]))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PDCert where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PDCert where
+  type PLifted PDCert = Plutus.DCert
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.DCert PDCert)
+  instance
+    PConstantDecl Plutus.DCert
+
+-- | @since 2.0.0
+data PCredential (s :: S)
+  = PPubKeyCredential (Term s (PDataRecord '["_0" ':= PPubKeyHash]))
+  | PScriptCredential (Term s (PDataRecord '["_0" ':= PScriptHash]))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    , -- | @since 2.0.0
+      PTryFrom PData
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PCredential where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PCredential where
+  type PLifted PCredential = Plutus.Credential
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.Credential PCredential)
+  instance
+    PConstantDecl Plutus.Credential
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PCredential)
+
+-- | @since 2.0.0
+data PStakingCredential (s :: S)
+  = PStakingHash (Term s (PDataRecord '["_0" ':= PCredential]))
+  | PStakingPtr
+      ( Term
+          s
+          ( PDataRecord
+              '[ "_0" ':= PInteger
+               , "_1" ':= PInteger
+               , "_2" ':= PInteger
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    , -- | @since 2.0.0
+      PTryFrom PData
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PStakingCredential where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PStakingCredential where
+  type PLifted PStakingCredential = Plutus.StakingCredential
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.StakingCredential PStakingCredential)
+  instance
+    PConstantDecl Plutus.StakingCredential
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PStakingCredential)
+
+-- | @since 2.0.0
+newtype PPosixTime (s :: S) = PPosixTime (Term s PInteger)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PIntegral
+    , -- | @since 2.0.0
+      PNum
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PPosixTime where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PPosixTime where
+  type PLifted PPosixTime = Plutus.POSIXTime
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaNewtype Plutus.POSIXTime PPosixTime PInteger)
+  instance
+    PConstantDecl Plutus.POSIXTime
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PPosixTime) where
+  type PTryFromExcess PData (PAsData PPosixTime) = Mret PPosixTime
+  ptryFrom' ::
+    forall (s :: S) (r :: S -> Type).
+    Term s PData ->
+    ((Term s (PAsData PPosixTime), Reduce (PTryFromExcess PData (PAsData PPosixTime) s)) -> Term s r) ->
+    Term s r
+  ptryFrom' opq = runTermCont $ do
+    (wrapped :: Term s (PAsData PInteger), unwrapped :: Term s PInteger) <-
+      tcont $ ptryFrom @(PAsData PInteger) opq
+    tcont $ \f -> pif (0 #<= unwrapped) (f ()) (ptraceError "ptryFrom(POSIXTime): must be positive")
+    pure (punsafeCoerce wrapped, pcon $ PPosixTime unwrapped)
+
+-- | @since 2.0.0
+newtype PInterval (a :: S -> Type) (s :: S)
+  = PInterval
+      ( Term
+          s
+          ( PDataRecord
+              '[ "from" ':= PLowerBound a
+               , "to" ':= PUpperBound a
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType (PInterval a) where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance
+  PLiftData a =>
+  PUnsafeLiftDecl (PInterval a)
+  where
+  type PLifted (PInterval a) = (Plutus.Interval (PLifted a))
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData (Plutus.Interval a) (PInterval (PConstanted a)))
+  instance
+    PConstantData a =>
+    PConstantDecl (Plutus.Interval a)
+
+-- | @since 2.0.0
+newtype PPubKeyHash (s :: S) = PPubKeyHash (Term s PByteString)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PPubKeyHash where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PPubKeyHash where
+  type PLifted PPubKeyHash = Plutus.PubKeyHash
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaBuiltin Plutus.PubKeyHash PPubKeyHash PByteString)
+  instance
+    PConstantDecl Plutus.PubKeyHash
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PPubKeyHash) where
+  type PTryFromExcess PData (PAsData PPubKeyHash) = Mret PPubKeyHash
+  ptryFrom' opq = runTermCont $ do
+    unwrapped <- tcont . plet $ ptryFrom @(PAsData PByteString) opq snd
+    tcont $ \f ->
+      pif
+        (plengthBS # unwrapped #== 28)
+        (f ())
+        (ptraceError "ptryFrom(PPubKeyHash): must be 28 bytes long")
+    pure (punsafeCoerce opq, pcon . PPubKeyHash $ unwrapped)
+
+-- | @since 2.0.0
+newtype PubKey = PubKey
+  { getPubKey :: Plutus.LedgerBytes
+  -- ^ @since 2.0.0
+  }
+  deriving stock
+    ( -- | @since 2.0.0
+      Eq
+    , -- | @since 2.0.0
+      Ord
+    )
+  deriving stock
+    ( -- | @since 2.0.0
+      Show
+    )
+
+-- | @since 2.0.0
+pubKeyHash :: PubKey -> Plutus.PubKeyHash
+pubKeyHash = coerce hashLedgerBytes
+
+-- | @since 2.0.0
+newtype PTxId (s :: S) = PTxId (Term s (PDataRecord '["_0" ':= PByteString]))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PTxId where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PTxId where
+  type PLifted PTxId = Plutus.TxId
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.TxId PTxId)
+  instance
+    PConstantDecl Plutus.TxId
+
+-- | @since 2.0.0
+instance PTryFrom PData PTxId where
+  type PTryFromExcess PData PTxId = Mret PByteString
+  ptryFrom' opq cont = ptryFrom @(PAsData PTxId) opq (cont . first punsafeCoerce)
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PTxId) where
+  type PTryFromExcess PData (PAsData PTxId) = Mret PByteString
+  ptryFrom' opq = runTermCont $ do
+    opq' <- tcont . plet $ pasConstr # opq
+    tcont $ \f ->
+      pif (pfstBuiltin # opq' #== 0) (f ()) $ ptraceError "ptryFrom(TxId): invalid constructor id"
+    flds <- tcont . plet $ psndBuiltin # opq'
+    let dataBs = phead # flds
+    tcont $ \f ->
+      pif (pnil #== ptail # flds) (f ()) $ ptraceError "ptryFrom(TxId): constructor fields len > 1"
+    unwrapped <- tcont . plet $ ptryFrom @(PAsData PByteString) dataBs snd
+    tcont $ \f ->
+      pif (plengthBS # unwrapped #== 32) (f ()) $ ptraceError "ptryFrom(TxId): must be 32 bytes long"
+    pure (punsafeCoerce opq, unwrapped)
+
+{- | Reference to a transaction output, with an index referencing which exact
+output we mean.
+
+@since 2.0.0
+-}
+newtype PTxOutRef (s :: S)
+  = PTxOutRef
+      ( Term
+          s
+          ( PDataRecord
+              '[ "id" ':= PTxId
+               , "idx" ':= PInteger
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PTryFrom PData
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PTxOutRef where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PTxOutRef where
+  type PLifted PTxOutRef = Plutus.TxOutRef
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.TxOutRef PTxOutRef)
+  instance
+    PConstantDecl Plutus.TxOutRef
+
+-- | @since 2.0.0
+newtype PAddress (s :: S)
+  = PAddress
+      ( Term
+          s
+          ( PDataRecord
+              '[ "credential" ':= PCredential
+               , "stakingCredential" ':= PMaybeData PStakingCredential
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    , -- | @since 2.0.0
+      PTryFrom PData
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PAddress where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PAddress where
+  type PLifted PAddress = Plutus.Address
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData Plutus.Address PAddress)
+  instance
+    PConstantDecl Plutus.Address
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PAddress)
+
+-- | @since 2.0.0
+data PMaybeData (a :: S -> Type) (s :: S)
+  = PDJust (Term s (PDataRecord '["_0" ':= a]))
+  | PDNothing (Term s (PDataRecord '[]))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType (PMaybeData a) where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance PTryFrom PData a => PTryFrom PData (PMaybeData a)
+
+-- | @since 2.0.0
+instance PTryFrom PData a => PTryFrom PData (PAsData (PMaybeData a))
+
+-- | @since 2.0.0
+instance PLiftData a => PUnsafeLiftDecl (PMaybeData a) where
+  type PLifted (PMaybeData a) = Maybe (PLifted a)
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData (Maybe a) (PMaybeData (PConstanted a)))
+  instance
+    PConstantData a => PConstantDecl (Maybe a)
+
+-- Have to manually write this instance because the constructor id ordering is screwed for 'Maybe'....
+
+-- | @since 2.0.0
+instance (PIsData a, POrd a) => PPartialOrd (PMaybeData a) where
+  x #< y = pmaybeLT False (#<) # x # y
+  x #<= y = pmaybeLT True (#<=) # x # y
+
+-- | @since 2.0.0
+instance (PIsData a, POrd a) => POrd (PMaybeData a)
+
+-- | @since 2.0.0
+newtype PScriptHash (s :: S) = PScriptHash (Term s PByteString)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PScriptHash where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PScriptHash where
+  type PLifted PScriptHash = Plutus.ScriptHash
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaBuiltin Plutus.ScriptHash PScriptHash PByteString)
+  instance
+    PConstantDecl Plutus.ScriptHash
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PScriptHash) where
+  type PTryFromExcess PData (PAsData PScriptHash) = Mret PScriptHash
+  ptryFrom' opq = runTermCont $ do
+    unwrapped <- tcont . plet $ ptryFrom @(PAsData PByteString) opq snd
+    tcont $ \f ->
+      pif
+        (plengthBS # unwrapped #== 28)
+        (f ())
+        (ptraceError "ptryFrom(PScriptHash): must be 28 bytes long")
+    pure (punsafeCoerce opq, pcon . PScriptHash $ unwrapped)
+
+-- | @since 2.0.0
+newtype PUpperBound (a :: S -> Type) (s :: S)
+  = PUpperBound
+      ( Term
+          s
+          ( PDataRecord
+              '[ "_0" ':= PExtended a
+               , "_1" ':= PBool
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType (PUpperBound a) where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance
+  PLiftData a =>
+  PUnsafeLiftDecl (PUpperBound a)
+  where
+  type PLifted (PUpperBound a) = (Plutus.UpperBound (PLifted a))
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData (Plutus.UpperBound a) (PUpperBound (PConstanted a)))
+  instance
+    PConstantData a =>
+    PConstantDecl (Plutus.UpperBound a)
+
+-- | @since 2.0.0
+data PExtended (a :: S -> Type) (s :: S)
+  = PNegInf (Term s (PDataRecord '[]))
+  | PFinite (Term s (PDataRecord '["_0" ':= a]))
+  | PPosInf (Term s (PDataRecord '[]))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType (PExtended a) where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+newtype PLowerBound (a :: S -> Type) (s :: S)
+  = PLowerBound
+      ( Term
+          s
+          ( PDataRecord
+              '[ "_0" ':= PExtended a
+               , "_1" ':= PBool
+               ]
+          )
+      )
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PDataFields
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType (PLowerBound a) where
+  type DPTStrat _ = PlutusTypeData
+
+-- | @since 2.0.0
+instance
+  PLiftData a =>
+  PUnsafeLiftDecl (PLowerBound a)
+  where
+  type PLifted (PLowerBound a) = (Plutus.LowerBound (PLifted a))
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaData (Plutus.LowerBound a) (PLowerBound (PConstanted a)))
+  instance
+    PConstantData a =>
+    PConstantDecl (Plutus.LowerBound a)
+
+-- | @since 2.0.0
+datumHash :: Plutus.Datum -> Plutus.DatumHash
+datumHash = coerce . dataHash
+
+-- | @since 2.0.0
+dataHash ::
+  forall (a :: Type).
+  Plutus.ToData a =>
+  a ->
+  PlutusTx.BuiltinByteString
+dataHash = hashData . Plutus.toData
+
+-- | @since 2.0.0
+redeemerHash :: Plutus.Redeemer -> Plutus.RedeemerHash
+redeemerHash = coerce . dataHash
+
+-- TODO: Make this sludge a newtype.
+
+-- | @since 2.0.0
+ptuple ::
+  forall (a :: S -> Type) (b :: S -> Type) (s :: S).
+  Term
+    s
+    ( PAsData a
+        :--> PAsData b
+        :--> PDataSum
+              '[ '[ "_0" ':= a
+                  , "_1" ':= b
+                  ]
+               ]
+    )
+ptuple = phoistAcyclic $ plam $ \x y ->
+  punsafeCoerce $
+    pconstrBuiltin
+      # 0
+      #$ pcons
+      # pforgetData x
+      #$ pcons
+      # pforgetData y
+      # pnil
+
+-- Helpers
+
+hashScriptWithPrefix :: ByteString -> Script -> Plutus.ScriptHash
+hashScriptWithPrefix prefix scr =
+  Plutus.ScriptHash . hashBlake2b_224 $
+    prefix <> (fromShort . serialiseUPLC . unScript $ scr)
+
+hashLedgerBytes :: Plutus.LedgerBytes -> PlutusTx.BuiltinByteString
+hashLedgerBytes = hashBlake2b_224 . PlutusTx.fromBuiltin . Plutus.getLedgerBytes
+
+hashBlake2b_224 :: ByteString -> PlutusTx.BuiltinByteString
+hashBlake2b_224 = PlutusTx.toBuiltin . convert @_ @ByteString . hashWith Blake2b_224
+
+hashBlake2b_256 :: ByteString -> PlutusTx.BuiltinByteString
+hashBlake2b_256 = PlutusTx.toBuiltin . convert @_ @ByteString . hashWith Blake2b_256
+
+hashData :: Plutus.Data -> PlutusTx.BuiltinByteString
+hashData = hashBlake2b_256 . toStrict . serialise
+
+pmaybeLT ::
+  forall (a :: S -> Type) (s :: S).
+  Bool ->
+  ( forall (s' :: S) (rec_ :: [PLabeledType]).
+    rec_ ~ '["_0" ':= a] =>
+    Term s' (PDataRecord rec_) ->
+    Term s' (PDataRecord rec_) ->
+    Term s' PBool
+  ) ->
+  Term s (PMaybeData a :--> PMaybeData a :--> PBool)
+pmaybeLT whenBothNothing ltF = phoistAcyclic $
+  plam $ \x y -> unTermCont $ do
+    a <- tcont . plet $ pasConstr #$ pforgetData $ pdata x
+    b <- tcont . plet $ pasConstr #$ pforgetData $ pdata y
+    cid1 <- tcont . plet $ pfstBuiltin # a
+    cid2 <- tcont . plet $ pfstBuiltin # b
+    pure
+      $ pif
+        (cid1 #< cid2)
+        (pconstant False)
+      $ pif
+        (cid1 #== cid2)
+        {- Some hand optimization here: usually, the fields would be 'plet'ed here if using 'POrd' derivation
+          machinery. However, in this case - there's no need for the fields for the 'Nothing' case.
+
+          Would be nice if this could be done on the auto derivation case....
+        -}
+        ( pif
+            (cid1 #== 0)
+            (ltF (punsafeCoerce $ psndBuiltin # a) (punsafeCoerce $ psndBuiltin # b))
+            -- Both are 'Nothing'. Let caller choose answer.
+            $ pconstant whenBothNothing
+        )
+      $ pconstant True

--- a/plutarch-api/src/Plutarch/Api/AssocMap.hs
+++ b/plutarch-api/src/Plutarch/Api/AssocMap.hs
@@ -1,0 +1,818 @@
+{-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | This module is designed to be imported qualified, as many of its
+identifiers clash with the Plutarch prelude.
+-}
+module Plutarch.Api.AssocMap (
+  -- * Types
+  PMap (..),
+  KeyGuarantees (..),
+  Commutativity (..),
+
+  -- * Functions
+
+  -- ** Creation
+  pempty,
+
+  -- ** Transformation
+  passertSorted,
+  pmap,
+  pmapData,
+  pmapMaybe,
+  pmapMaybeData,
+
+  -- ** Relational lift
+  pcheckBinRel,
+
+  -- ** Folds
+  pall,
+
+  -- ** Combination
+  punionResolvingCollisionsWith,
+
+  -- ** Queries
+  pnull,
+) where
+
+import Data.Bifunctor (bimap)
+import Data.Proxy (Proxy (Proxy))
+import Data.Traversable (for)
+import Plutarch.Api.Utils (Mret)
+import Plutarch.Bool (PSBool (PSFalse, PSTrue), psfalse, pstrue)
+import Plutarch.Builtin (
+  pasMap,
+  pdataImpl,
+  pforgetData,
+  pfromDataImpl,
+  ppairDataBuiltin,
+ )
+import Plutarch.Internal (punsafeBuiltin)
+import Plutarch.Internal.Witness (witness)
+import Plutarch.Lift (
+  PConstantDecl,
+  PConstantRepr,
+  PConstanted,
+  PLifted,
+  PUnsafeLiftDecl,
+  pconstantFromRepr,
+  pconstantToRepr,
+ )
+import Plutarch.List qualified as List
+import Plutarch.Prelude hiding (pall, pmap, pnull, pzipWith)
+import Plutarch.Prelude qualified as PPrelude
+import Plutarch.TryFrom (PTryFrom (PTryFromExcess, ptryFrom'))
+import Plutarch.Unsafe (punsafeCoerce, punsafeDowncast)
+import PlutusCore qualified as PLC
+import PlutusLedgerApi.V2 qualified as Plutus
+import PlutusTx.AssocMap qualified as PlutusMap
+import Prelude hiding (pred)
+
+-- TODO: Rename this, because this is actually a _sorting_ guarantee!
+
+-- | @since 2.0.0
+data KeyGuarantees = Sorted | Unsorted
+
+-- | @since 2.0.0
+newtype PMap (keysort :: KeyGuarantees) (k :: PType) (v :: PType) (s :: S)
+  = PMap (Term s (PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType (PMap keysort k v) where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PIsData (PMap keysort k v) where
+  pfromDataImpl x = punsafeCoerce $ pasMap # pforgetData x
+  pdataImpl x = punsafeBuiltin PLC.MapData # x
+
+-- | @since 2.0.0
+instance PEq (PMap 'Sorted k v) where
+  x #== y = peqViaData # x # y
+    where
+      peqViaData ::
+        forall (s :: S).
+        Term s (PMap 'Sorted k v :--> PMap 'Sorted k v :--> PBool)
+      peqViaData = phoistAcyclic $ plam $ \m0 m1 -> pdata m0 #== pdata m1
+
+-- | @since 2.0.0
+instance
+  ( PLiftData k
+  , PLiftData v
+  , Ord (PLifted k)
+  ) =>
+  PUnsafeLiftDecl (PMap 'Unsorted k v)
+  where
+  type PLifted (PMap 'Unsorted k v) = PlutusMap.Map (PLifted k) (PLifted v)
+
+-- | @since 2.0.0
+instance
+  ( PConstantData k
+  , PConstantData v
+  , Ord k
+  ) =>
+  PConstantDecl (PlutusMap.Map k v)
+  where
+  type PConstantRepr (PlutusMap.Map k v) = [(Plutus.Data, Plutus.Data)]
+  type PConstanted (PlutusMap.Map k v) = PMap 'Unsorted (PConstanted k) (PConstanted v)
+  pconstantToRepr m = bimap Plutus.toData Plutus.toData <$> PlutusMap.toList m
+  pconstantFromRepr m = fmap PlutusMap.fromList $
+    for m $ \(x, y) -> do
+      x' <- Plutus.fromData x
+      y' <- Plutus.fromData y
+      Just (x', y')
+
+-- | @since 2.0.0
+instance
+  ( PTryFrom PData (PAsData k)
+  , PTryFrom PData (PAsData v)
+  ) =>
+  PTryFrom PData (PAsData (PMap 'Unsorted k v))
+  where
+  type PTryFromExcess PData (PAsData (PMap 'Unsorted k v)) = Mret (PMap 'Unsorted k v)
+  ptryFrom' opq = runTermCont $ do
+    opq' <- tcont . plet $ pasMap # opq
+    unwrapped <- tcont . plet $ List.pmap # ptryFromPair # opq'
+    pure (punsafeCoerce opq, pcon . PMap $ unwrapped)
+    where
+      ptryFromPair ::
+        forall (s :: S).
+        Term s (PBuiltinPair PData PData :--> PBuiltinPair (PAsData k) (PAsData v))
+      ptryFromPair = plam $ \p ->
+        ppairDataBuiltin
+          # ptryFrom (pfstBuiltin # p) fst
+          # ptryFrom (psndBuiltin # p) fst
+
+-- | @since 2.0.0
+instance
+  ( POrd k
+  , PIsData k
+  , PIsData v
+  , PTryFrom PData (PAsData k)
+  , PTryFrom PData (PAsData v)
+  ) =>
+  PTryFrom PData (PAsData (PMap 'Sorted k v))
+  where
+  type PTryFromExcess PData (PAsData (PMap 'Sorted k v)) = Mret (PMap 'Sorted k v)
+  ptryFrom' opq = runTermCont $ do
+    (opq', _) <- tcont $ ptryFrom @(PAsData (PMap 'Unsorted k v)) opq
+    unwrapped <- tcont $ plet . papp passertSorted . pfromData $ opq'
+    pure (punsafeCoerce opq, unwrapped)
+
+-- | @since 2.0.0
+data Commutativity = Commutative | NonCommutative
+  deriving stock
+    ( -- | @since 2.0.0
+      Eq
+    , -- | @since 2.0.0
+      Ord
+    , -- | @since 2.0.0
+      Show
+    )
+
+-- TODO: Rename this, because the name is confusing.
+
+{- | Given a 'PMap' of uncertain order, yield a 'PMap' that is known to be
+sorted.
+
+@since 2.0.0
+-}
+passertSorted ::
+  forall (k :: S -> Type) (v :: S -> Type) (any :: KeyGuarantees) (s :: S).
+  (POrd k, PIsData k, PIsData v) =>
+  Term s (PMap any k v :--> PMap 'Sorted k v)
+passertSorted =
+  let _ = witness (Proxy :: Proxy (PIsData v))
+   in phoistAcyclic $
+        plam $ \m ->
+          precList
+            ( \self x xs ->
+                plet (pfromData $ pfstBuiltin # x) $ \k ->
+                  plam $ \badKey ->
+                    pif
+                      (badKey # k)
+                      (ptraceError "unsorted map")
+                      (self # xs # plam (#< k))
+            )
+            -- this is actually the empty map so we can
+            -- safely assume that it is sorted
+            (const . plam . const $ punsafeCoerce m)
+            # pto m
+            # plam (const $ pcon PFalse)
+
+{- | Construct an empty 'PMap'.
+
+@since 2.0.0
+-}
+pempty :: Term s (PMap 'Sorted k v)
+pempty = punsafeDowncast pnil
+
+{- | Given a comparison function and a "zero" value, check whether a binary relation holds over
+2 sorted 'PMap's.
+
+= Important note
+
+This is primarily intended to be used with 'PValue'. We assume that the comparison behaves like
+a comparison would (thus, being at least a partial order, or possibly a total order or
+equivalence), and that the starting value does not break it. Use with extreme care.
+
+@since 2.0.0
+-}
+pcheckBinRel ::
+  forall (k :: S -> Type) (v :: S -> Type) (s :: S).
+  (POrd k, PIsData k, PIsData v) =>
+  Term
+    s
+    ( (v :--> v :--> PBool)
+        :--> v
+        :--> PMap 'Sorted k v
+        :--> PMap 'Sorted k v
+        :--> PBool
+    )
+pcheckBinRel = phoistAcyclic $
+  plam $ \f z m1 m2 ->
+    let inner = pfix #$ plam $ \self l1 l2 ->
+          pelimList
+            ( \x xs ->
+                plet (pfromData $ psndBuiltin # x) $ \v1 ->
+                  pelimList
+                    ( \y ys -> unTermCont $ do
+                        v2 <- tcont . plet . pfromData $ psndBuiltin # y
+                        k1 <- tcont . plet . pfromData $ pfstBuiltin # x
+                        k2 <- tcont . plet . pfromData $ pfstBuiltin # y
+                        pure
+                          $ pif
+                            (k1 #== k2)
+                            ( f
+                                # v1
+                                # v2
+                                #&& self
+                                # xs
+                                # ys
+                            )
+                          $ pif
+                            (k1 #< k2)
+                            (f # v1 # z #&& self # xs # l2)
+                          $ f
+                            # z
+                            # v2
+                            #&& self
+                            # l1
+                            # ys
+                    )
+                    ( f
+                        # v1
+                        # z
+                        #&& PPrelude.pall
+                        # plam (\p -> f # pfromData (psndBuiltin # p) # z)
+                        # xs
+                    )
+                    l2
+            )
+            (PPrelude.pall # plam (\p -> f # z #$ pfromData $ psndBuiltin # p) # l2)
+            l1
+     in inner # pto m1 # pto m2
+
+{- | Verifies all values in the map satisfy the given predicate.
+
+@since 2.0.0
+-}
+pall ::
+  forall (any :: KeyGuarantees) (k :: S -> Type) (v :: S -> Type) (s :: S).
+  PIsData v =>
+  Term s ((v :--> PBool) :--> PMap any k v :--> PBool)
+pall = phoistAcyclic $
+  plam $ \pred m ->
+    List.pall # plam (\pair -> pred #$ pfromData $ psndBuiltin # pair) # pto m
+
+{- | Build the union of two 'PMap's, merging values that share the same key using the
+given function.
+
+@since 2.0.0
+-}
+punionResolvingCollisionsWith ::
+  forall (k :: S -> Type) (v :: S -> Type) (s :: S).
+  (POrd k, PIsData k, PIsData v) =>
+  Commutativity ->
+  Term s ((v :--> v :--> v) :--> PMap 'Sorted k v :--> PMap 'Sorted k v :--> PMap 'Sorted k v)
+punionResolvingCollisionsWith commutativity =
+  phoistAcyclic $
+    plam $
+      pzipWith . unionMergeHandler commutativity
+
+{- | Maps and filters the map, much like 'Data.List.mapMaybe'.
+
+@since 2.0.0
+-}
+pmapMaybe ::
+  forall (g :: KeyGuarantees) (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
+  (PIsData a, PIsData b) =>
+  Term s ((a :--> PMaybe b) :--> PMap g k a :--> PMap g k b)
+pmapMaybe = phoistAcyclic $
+  plam $ \f -> pmapMaybeData #$ plam $ \v -> pmatch (f # pfromData v) $ \case
+    PNothing -> pcon PNothing
+    PJust v' -> pcon $ PJust (pdata v')
+
+{- | As 'pmapMaybe', but over Data representation.
+
+@since 2.0.0
+-}
+pmapMaybeData ::
+  forall (g :: KeyGuarantees) (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
+  Term s ((PAsData a :--> PMaybe (PAsData b)) :--> PMap g k a :--> PMap g k b)
+pmapMaybeData = phoistAcyclic $
+  plam $ \f m ->
+    pcon . PMap $
+      precList
+        ( \self x xs ->
+            plet (self # xs) $ \xs' ->
+              pmatch (f #$ psndBuiltin # x) $ \case
+                PNothing -> xs'
+                PJust v -> pcons # (ppairDataBuiltin # (pfstBuiltin # x) # v) # xs'
+        )
+        (const pnil)
+        # pto m
+
+{- | Tests whether the map is empty.
+
+@since 2.0.0
+-}
+pnull ::
+  forall (any :: KeyGuarantees) (k :: S -> Type) (v :: S -> Type) (s :: S).
+  Term s (PMap any k v :--> PBool)
+pnull = plam (\m -> List.pnull # pto m)
+
+{- | Applies a function to every value in the map, much like 'Data.List.map'.
+
+@since 2.0.0
+-}
+pmap ::
+  forall (g :: KeyGuarantees) (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
+  (PIsData a, PIsData b) =>
+  Term s ((a :--> b) :--> PMap g k a :--> PMap g k b)
+pmap = phoistAcyclic $
+  plam $
+    \f -> pmapData #$ plam $ \v -> pdata (f # pfromData v)
+
+{- | As 'pmap', but over Data representations.
+
+@since 2.0.0
+-}
+pmapData ::
+  forall (g :: KeyGuarantees) (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
+  Term s ((PAsData a :--> PAsData b) :--> PMap g k a :--> PMap g k b)
+pmapData = phoistAcyclic $
+  plam $ \f m ->
+    pcon . PMap $
+      precList
+        ( \self x xs ->
+            pcons
+              # (ppairDataBuiltin # (pfstBuiltin # x) # (f #$ psndBuiltin # x))
+              # (self # xs)
+        )
+        (const pnil)
+        # pto m
+
+-- Helpers
+
+-- TODO: Get rid of this whole mess.
+type SomeMergeHandler (k :: S -> Type) (v :: S -> Type) (s :: S) =
+  SomeMergeHandler_ (->) (Term s k) (Term s v)
+
+-- Signals how to handle value merging for matching keys in 'pzipWith'.
+data SomeMergeHandler_ (f :: Type -> Type -> Type) (k :: Type) (v :: Type)
+  = SomeMergeHandlerCommutative (MergeHandlerCommutative_ f k v)
+  | SomeMergeHandler (MergeHandler_ f k v)
+
+deriving stock instance
+  (forall a b. Show (f a b)) =>
+  Show (SomeMergeHandler_ f k v)
+
+type MergeHandler (k :: S -> Type) (v :: S -> Type) (s :: S) =
+  MergeHandler_ (->) (Term s k) (Term s v)
+
+{- Signals how to handle value merging for matching keys in 'pzipWith'.
+
+ No restrictions on commutativity: Safe to use for both commutative and
+ non-commutative merging operations.
+-}
+data MergeHandler_ (f :: Type -> Type -> Type) (k :: Type) (v :: Type) = MergeHandler
+  { mhBoth :: BothPresentHandler_ f k v
+  , mhLeft :: OnePresentHandler_ f k v
+  , mhRight :: OnePresentHandler_ f k v
+  }
+
+deriving stock instance
+  (forall a b. Show (f a b)) =>
+  Show (MergeHandler_ f k v)
+
+type MergeHandlerCommutative (k :: S -> Type) (v :: S -> Type) (s :: S) =
+  MergeHandlerCommutative_ (->) (Term s k) (Term s v)
+
+{- Signals how to handle value merging for matching keys in 'pzipWith'.
+
+ Safe to use for commutative merging operations only.
+-}
+data MergeHandlerCommutative_ (f :: Type -> Type -> Type) (k :: Type) (v :: Type) = MergeHandlerCommutative
+  { mhcBoth :: BothPresentHandlerCommutative_ f k v
+  , mhcOne :: OnePresentHandler_ f k v
+  }
+
+deriving stock instance
+  (forall a b. Show (f a b)) =>
+  Show (MergeHandlerCommutative_ f k v)
+
+type BothPresentHandler (k :: S -> Type) (v :: S -> Type) (s :: S) =
+  BothPresentHandler_ (->) (Term s k) (Term s v)
+
+data BothPresentHandler_ (f :: Type -> Type -> Type) (k :: Type) (v :: Type)
+  = DropBoth
+  | -- True ~ left, False ~ right
+    PassArg Bool
+  | HandleBoth (k `f` (v `f` (v `f` v)))
+
+deriving stock instance
+  (forall a b. Show (f a b)) =>
+  Show (BothPresentHandler_ f k v)
+
+type BothPresentHandlerCommutative (k :: S -> Type) (v :: S -> Type) (s :: S) =
+  BothPresentHandlerCommutative_ (->) (Term s k) (Term s v)
+
+data BothPresentHandlerCommutative_ (f :: Type -> Type -> Type) (k :: Type) (v :: Type)
+  = DropBothCommutative
+  | HandleBothCommutative (k `f` (v `f` (v `f` v)))
+
+deriving stock instance
+  (forall a b. Show (f a b)) =>
+  Show (BothPresentHandlerCommutative_ f k v)
+
+type OnePresentHandler (k :: S -> Type) (v :: S -> Type) (s :: S) =
+  OnePresentHandler_ (->) (Term s k) (Term s v)
+
+data OnePresentHandler_ (f :: Type -> Type -> Type) (k :: Type) (v :: Type)
+  = DropOne
+  | PassOne
+  | HandleOne (k `f` (v `f` v))
+
+deriving stock instance
+  (forall a b. Show (f a b)) =>
+  Show (OnePresentHandler_ f k v)
+
+unionMergeHandler ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  Commutativity ->
+  Term s (v :--> (v :--> v)) ->
+  SomeMergeHandler k v s
+unionMergeHandler NonCommutative merge =
+  SomeMergeHandler $ MergeHandler (HandleBoth \_ vl vr -> merge # vl # vr) PassOne PassOne
+unionMergeHandler Commutative merge =
+  SomeMergeHandlerCommutative $
+    MergeHandlerCommutative (HandleBothCommutative \_ vl vr -> merge # vl # vr) PassOne
+
+{- Zip two 'PMap's, using a 'SomeMergeHandler' to decide how to merge based on key
+ presence on the left and right.
+
+ Note that using a 'MergeHandlerCommutative' is less costly than a 'MergeHandler'.
+-}
+pzipWith ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (POrd k, PIsData k, PIsData v) =>
+  SomeMergeHandler k v s ->
+  Term
+    s
+    ( PMap 'Sorted k v
+        :--> PMap 'Sorted k v
+        :--> PMap 'Sorted k v
+    )
+pzipWith (SomeMergeHandler mh) =
+  pzipWithData (SomeMergeHandler $ mergeHandlerOnData mh)
+pzipWith (SomeMergeHandlerCommutative mhc) =
+  pzipWithData (SomeMergeHandlerCommutative $ mergeHandlerCommutativeOnData mhc)
+
+{- Zip two 'PMap's, using a 'SomeMergeHandler' to decide how to merge based on key
+ presence on the left and right.
+
+ Note that using a 'MergeHandlerCommutative' is less costly than a 'MergeHandler'.
+-}
+pzipWithData ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (POrd k, PIsData k) =>
+  SomeMergeHandler (PAsData k) (PAsData v) s ->
+  Term
+    s
+    ( PMap 'Sorted k v
+        :--> PMap 'Sorted k v
+        :--> PMap 'Sorted k v
+    )
+pzipWithData (SomeMergeHandler mh@(MergeHandler _ _ rightPresent)) =
+  plam $ \x y ->
+    pcon $ PMap $ zipMerge rightPresent (zipMergeInsert mh) # pto x # pto y
+pzipWithData (SomeMergeHandlerCommutative mh@(MergeHandlerCommutative _ onePresent)) =
+  plam $ \x y ->
+    pcon $ PMap $ zipMergeCommutative onePresent (zipMergeInsertCommutative mh) # pto x # pto y
+
+mergeHandlerOnData ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (PIsData k, PIsData v) =>
+  MergeHandler k v s ->
+  MergeHandler (PAsData k) (PAsData v) s
+mergeHandlerOnData (MergeHandler bothPresent leftPresent rightPresent) =
+  MergeHandler (bothPresentOnData bothPresent) (onePresentOnData leftPresent) (onePresentOnData rightPresent)
+
+mergeHandlerCommutativeOnData ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (PIsData k, PIsData v) =>
+  MergeHandlerCommutative k v s ->
+  MergeHandlerCommutative (PAsData k) (PAsData v) s
+mergeHandlerCommutativeOnData (MergeHandlerCommutative bothPresent onePresent) =
+  MergeHandlerCommutative (bothPresentCommutativeOnData bothPresent) (onePresentOnData onePresent)
+
+zipMerge ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  OnePresentHandler (PAsData k) (PAsData v) s ->
+  Term
+    s
+    ( PSBool
+        :--> PBuiltinPair (PAsData k) (PAsData v)
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+    ) ->
+  Term
+    s
+    ( PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+    )
+zipMerge rightPresent mergeInsertRec = plam $ \ls rs -> pmatch ls $ \case
+  PNil ->
+    case rightPresent of
+      DropOne -> pcon PNil
+      PassOne -> rs
+      HandleOne handler ->
+        List.pmap
+          # plam
+            ( \pair ->
+                plet (pfstBuiltin # pair) \k ->
+                  ppairDataBuiltin # k # handler k (psndBuiltin # pair)
+            )
+          # rs
+  PCons l ls' -> mergeInsertRec # pstrue # l # ls' # rs
+
+zipMergeInsert ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (POrd k, PIsData k) =>
+  MergeHandler (PAsData k) (PAsData v) s ->
+  -- | 'PSTrue' means first arg is left, second arg is right.
+  -- The first list gets passed in deconstructed form as head and tail
+  -- separately.
+  Term
+    s
+    ( PSBool
+        :--> PBuiltinPair (PAsData k) (PAsData v)
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+    )
+zipMergeInsert (MergeHandler bothPresent leftPresent rightPresent) = unTermCont $ do
+  -- deduplicates all the zipMerge calls through plet, almost as good as hoisting
+  zipMerge' <- tcont $ plet $ plam $ zipMerge rightPresent
+  pure $ pfix #$ plam $ \self argOrder' x xs' ys -> unTermCont $ do
+    let zipMergeRec = zipMerge' # self
+        xs = pcons # x # xs'
+        zipMergeOrdered xSide ySide =
+          pmatch argOrder' $ \argOrder -> applyOrder argOrder zipMergeRec xSide ySide
+    pure $ pmatch ys $ \case
+      PNil -> pmatch argOrder' $ \argOrder ->
+        -- picking handler for presence of x-side only
+        case branchOrder argOrder leftPresent rightPresent of
+          DropOne -> pcon PNil
+          PassOne -> pcons # x # xs'
+          HandleOne handler ->
+            List.pmap
+              # plam
+                ( \pair ->
+                    plet (pfstBuiltin # pair) \k ->
+                      ppairDataBuiltin # k # handler k (psndBuiltin # pair)
+                )
+              # xs
+      PCons y1 ys' -> unTermCont $ do
+        y <- tcont $ plet y1
+        xk <- tcont $ plet (pfstBuiltin # x)
+        yk <- tcont $ plet (pfstBuiltin # y)
+        pure $
+          pif
+            (xk #== yk)
+            ( case bothPresent of
+                DropBoth -> zipMergeOrdered xs' ys'
+                PassArg passLeft -> pmatch argOrder' $ \argOrder ->
+                  pcons
+                    # (if passLeft == (argOrder == PSTrue) then x else y)
+                    # applyOrder argOrder zipMergeRec xs' ys'
+                HandleBoth merge -> pmatch argOrder' $ \argOrder ->
+                  pcons
+                    # ( ppairDataBuiltin
+                          # xk
+                          #$ applyOrder' argOrder (merge xk) (psndBuiltin # x) (psndBuiltin # y)
+                      )
+                    #$ applyOrder argOrder zipMergeRec xs' ys'
+            )
+            ( pif
+                (pfromData xk #< pfromData yk)
+                ( pmatch argOrder' $ \argOrder ->
+                    -- picking handler for presence of only x-side
+                    case branchOrder argOrder leftPresent rightPresent of
+                      DropOne -> self # branchOrder argOrder psfalse pstrue # y # ys' # xs'
+                      PassOne -> pcons # x # applyOrder argOrder zipMergeRec xs' ys
+                      HandleOne handler ->
+                        pcons
+                          # (ppairDataBuiltin # xk # handler xk (psndBuiltin # x))
+                          # (self # branchOrder argOrder psfalse pstrue # y # ys' # xs')
+                )
+                ( pmatch argOrder' $ \argOrder ->
+                    -- picking handler for presence of only y-side
+                    case branchOrder argOrder rightPresent leftPresent of
+                      DropOne -> self # argOrder' # x # xs' # ys'
+                      PassOne -> pcons # y # applyOrder argOrder zipMergeRec xs ys'
+                      HandleOne handler ->
+                        pcons
+                          # (ppairDataBuiltin # yk # handler yk (psndBuiltin # y))
+                          # (self # argOrder' # x # xs' # ys')
+                )
+            )
+
+zipMergeCommutative ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  OnePresentHandler (PAsData k) (PAsData v) s ->
+  Term
+    s
+    ( PBuiltinPair (PAsData k) (PAsData v)
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+    ) ->
+  Term
+    s
+    ( PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+    )
+zipMergeCommutative onePresent mergeInsertRec = plam $ \ls rs -> pmatch ls $ \case
+  PNil ->
+    case onePresent of
+      DropOne -> pcon PNil
+      PassOne -> rs
+      HandleOne handler ->
+        List.pmap
+          # plam
+            ( \pair ->
+                plet (pfstBuiltin # pair) \k ->
+                  ppairDataBuiltin # k # handler k (psndBuiltin # pair)
+            )
+          # rs
+  PCons l ls' -> mergeInsertRec # l # ls' # rs
+
+zipMergeInsertCommutative ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (POrd k, PIsData k) =>
+  MergeHandlerCommutative (PAsData k) (PAsData v) s ->
+  -- | 'PSTrue' means first arg is left, second arg is right.
+  -- The first list gets passed in deconstructed form as head and tail
+  -- separately.
+  Term
+    s
+    ( PBuiltinPair (PAsData k) (PAsData v)
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+        :--> PBuiltinList (PBuiltinPair (PAsData k) (PAsData v))
+    )
+zipMergeInsertCommutative (MergeHandlerCommutative bothPresent onePresent) = unTermCont $ do
+  -- deduplicates all the zipMerge calls through plet, almost as good as hoisting
+  zipMerge' <- tcont $ plet $ plam $ zipMergeCommutative onePresent
+  pure $ pfix #$ plam $ \self x xs' ys -> unTermCont $ do
+    let zipMergeRec = zipMerge' # self
+        xs = pcons # x # xs'
+    pure $ pmatch ys $ \case
+      PNil ->
+        -- picking handler for presence of x-side only
+        case onePresent of
+          DropOne -> pcon PNil
+          PassOne -> pcons # x # xs'
+          HandleOne handler ->
+            List.pmap
+              # plam
+                ( \pair ->
+                    plet (pfstBuiltin # pair) \k ->
+                      ppairDataBuiltin # k # handler k (psndBuiltin # pair)
+                )
+              # xs
+      PCons y1 ys' -> unTermCont $ do
+        y <- tcont $ plet y1
+        xk <- tcont $ plet (pfstBuiltin # x)
+        yk <- tcont $ plet (pfstBuiltin # y)
+        pure $
+          pif
+            (xk #== yk)
+            ( case bothPresent of
+                DropBothCommutative -> zipMergeRec # xs' # ys'
+                HandleBothCommutative merge ->
+                  pcons
+                    # ( ppairDataBuiltin
+                          # xk
+                          #$ merge xk (psndBuiltin # x) (psndBuiltin # y)
+                      )
+                    #$ zipMergeRec
+                    # xs'
+                    # ys'
+            )
+            ( pif
+                (pfromData xk #< pfromData yk)
+                ( case onePresent of
+                    DropOne -> self # y # ys' # xs'
+                    PassOne -> pcons # x # (zipMergeRec # xs' # ys)
+                    HandleOne handler ->
+                      pcons
+                        # (ppairDataBuiltin # xk # handler xk (psndBuiltin # x))
+                        # (self # y # ys' # xs')
+                )
+                ( case onePresent of
+                    DropOne -> self # x # xs' # ys'
+                    PassOne -> pcons # y # (zipMergeRec # ys' # xs)
+                    HandleOne handler ->
+                      pcons
+                        # (ppairDataBuiltin # yk # handler yk (psndBuiltin # y))
+                        # (self # x # xs' # ys')
+                )
+            )
+
+bothPresentOnData ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (PIsData k, PIsData v) =>
+  BothPresentHandler k v s ->
+  BothPresentHandler (PAsData k) (PAsData v) s
+bothPresentOnData = \case
+  DropBoth -> DropBoth
+  PassArg arg -> PassArg arg
+  HandleBoth f -> HandleBoth \k x y -> pdata $ f (pfromData k) (pfromData x) (pfromData y)
+
+onePresentOnData ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (PIsData k, PIsData v) =>
+  OnePresentHandler k v s ->
+  OnePresentHandler (PAsData k) (PAsData v) s
+onePresentOnData = \case
+  DropOne -> DropOne
+  PassOne -> PassOne
+  HandleOne f -> HandleOne \x y -> pdata $ f (pfromData x) (pfromData y)
+
+bothPresentCommutativeOnData ::
+  forall (s :: S) (k :: PType) (v :: PType).
+  (PIsData k, PIsData v) =>
+  BothPresentHandlerCommutative k v s ->
+  BothPresentHandlerCommutative (PAsData k) (PAsData v) s
+bothPresentCommutativeOnData = \case
+  DropBothCommutative -> DropBothCommutative
+  HandleBothCommutative f ->
+    HandleBothCommutative \k x y -> pdata $ f (pfromData k) (pfromData x) (pfromData y)
+
+-- | Apply given Plutarch fun with given reified (on Haskell-level) arg order.
+applyOrder ::
+  forall (s :: S) (a :: PType) (b :: PType).
+  -- | 'PSTrue' means first arg is left, second arg is right.
+  PSBool s ->
+  -- | A function that expects argument order 'left right'.
+  Term s (a :--> a :--> b) ->
+  -- | First arg.
+  Term s a ->
+  -- | Second arg.
+  Term s a ->
+  Term s b
+applyOrder argOrder pfun a b = branchOrder argOrder (pfun # a # b) (pfun # b # a)
+
+branchOrder :: forall (s :: S) (a :: Type). PSBool s -> a -> a -> a
+branchOrder PSTrue t _ = t
+branchOrder PSFalse _ f = f
+
+applyOrder' ::
+  forall (s :: S) (a :: Type) (b :: Type).
+  -- | 'PSTrue' means first arg is left, second arg is right.
+  PSBool s ->
+  -- | A function that expects argument order 'left right'.
+  (a -> a -> b) ->
+  -- | First arg.
+  a ->
+  -- | Second arg.
+  a ->
+  b
+applyOrder' argOrder fun a b = branchOrder argOrder (fun a b) (fun b a)

--- a/plutarch-api/src/Plutarch/Api/Utils.hs
+++ b/plutarch-api/src/Plutarch/Api/Utils.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE PolyKinds #-}
+
+{- | Useful tools that aren't part of the Plutarch API per se, but get used in
+multiple places.
+-}
+module Plutarch.Api.Utils (
+  Mret (..),
+) where
+
+import Plutarch.Prelude
+
+{- | 'Term', but with its type arguments flipped. This is a useful helper for
+defining 'PTryFrom' instances.
+
+For example, consider the 'PTryFrom' instance for 'PTokenName':
+
+@
+instance PTryFrom PData (PAsData PTokenName) where
+   type PTryFromExcess PData (PAsData PTokenName) = Mret PTokenName
+@
+
+We need to do this because 'PTryFromExcess' expects something of kind @S ->
+Type@, but 'Term' has kind @S -> (S -> Type) -> Type@, which doesn't quite
+fit. By using 'Mret', we end up with something of kind @(S -> Type)
+-> S -> Type@, which fits.
+
+The name is just 'Term' written backwards.
+
+@since 2.0.0
+-}
+newtype Mret (a :: S -> Type) (s :: S) = Mret (Term s a)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )

--- a/plutarch-api/src/Plutarch/Api/Value.hs
+++ b/plutarch-api/src/Plutarch/Api/Value.hs
@@ -1,0 +1,477 @@
+{-# LANGUAGE RoleAnnotations #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{- | Value-related functionality. In order to keep the interface efficient and
+ safe at the same time, there is a type-level distinction between 'PValue's
+ that are guaranteed to be properly normalized and those that provide no
+ such guarantee.
+
+ Also for efficiency reasons, the Ada-specific functions assume that there
+ can be only one token name for the Ada currency symbol, and they don't check
+ whether it matches 'Plutus.adaToken'.
+-}
+module Plutarch.Api.Value (
+  -- * Types
+  PValue (PValue),
+  PCurrencySymbol (PCurrencySymbol),
+  PTokenName (PTokenName),
+  AmountGuarantees (NoGuarantees, NonZero, Positive),
+
+  -- * Functions
+
+  -- ** Transformation
+  passertPositive,
+  pforgetPositive,
+  pnormalize,
+
+  -- ** Partial ordering
+  pcheckBinRel,
+
+  -- ** Combination
+  punionResolvingCollisionsWith,
+) where
+
+import Plutarch.Api.AssocMap qualified as AssocMap
+import Plutarch.Api.Utils (Mret)
+import Plutarch.Lift (
+  DerivePConstantViaBuiltin (DerivePConstantViaBuiltin),
+  DerivePConstantViaNewtype (DerivePConstantViaNewtype),
+  PConstantDecl,
+  PLifted,
+  PUnsafeLiftDecl,
+ )
+import Plutarch.Prelude
+import Plutarch.TryFrom (PTryFrom (PTryFromExcess, ptryFrom'))
+import Plutarch.Unsafe (punsafeCoerce, punsafeDowncast)
+import PlutusLedgerApi.V2 qualified as Plutus
+import PlutusTx.Prelude qualified as PlutusTx
+
+-- | @since 2.0.0
+newtype PTokenName (s :: S) = PTokenName (Term s PByteString)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @wsince 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PTokenName where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PTokenName where
+  type PLifted PTokenName = Plutus.TokenName
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaBuiltin Plutus.TokenName PTokenName PByteString)
+  instance
+    PConstantDecl Plutus.TokenName
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PTokenName) where
+  type PTryFromExcess PData (PAsData PTokenName) = Mret PTokenName
+  ptryFrom' opq = runTermCont $ do
+    unwrapped <- tcont . plet $ ptryFrom @(PAsData PByteString) opq snd
+    tcont $ \f ->
+      pif (plengthBS # unwrapped #<= 32) (f ()) (ptraceError "ptryFrom(TokenName): must be at most 32 Bytes long")
+    pure (punsafeCoerce opq, pcon . PTokenName $ unwrapped)
+
+-- | @since 2.0.0
+newtype PCurrencySymbol (s :: S) = PCurrencySymbol (Term s PByteString)
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PEq
+    , -- | @since 2.0.0
+      PPartialOrd
+    , -- | @since 2.0.0
+      POrd
+    , -- | @since 2.0.0
+      PShow
+    )
+
+-- | @since 2.0.0
+instance DerivePlutusType PCurrencySymbol where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData PCurrencySymbol) where
+  type PTryFromExcess PData (PAsData PCurrencySymbol) = Mret PCurrencySymbol
+  ptryFrom' opq = runTermCont $ do
+    unwrapped <- tcont . plet $ ptryFrom @(PAsData PByteString) opq snd
+    len <- tcont . plet $ plengthBS # unwrapped
+    tcont $ \f ->
+      pif (len #== 0 #|| len #== 28) (f ()) (ptraceError "ptryFrom(CurrencySymbol): must be 28 bytes long or empty")
+    pure (punsafeCoerce opq, pcon . PCurrencySymbol $ unwrapped)
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl PCurrencySymbol where
+  type PLifted PCurrencySymbol = Plutus.CurrencySymbol
+
+-- | @since 2.0.0
+deriving via
+  (DerivePConstantViaBuiltin Plutus.CurrencySymbol PCurrencySymbol PByteString)
+  instance
+    PConstantDecl Plutus.CurrencySymbol
+
+-- | @since 2.0.0
+data AmountGuarantees = NoGuarantees | NonZero | Positive
+
+-- | @since 2.0.0
+newtype PValue (keys :: AssocMap.KeyGuarantees) (amounts :: AmountGuarantees) (s :: S)
+  = PValue (Term s (AssocMap.PMap keys PCurrencySymbol (AssocMap.PMap keys PTokenName PInteger)))
+  deriving stock
+    ( -- | @since 2.0.0
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since 2.0.0
+      PlutusType
+    , -- | @since 2.0.0
+      PIsData
+    , -- | @since 2.0.0
+      PShow
+    )
+
+type role PValue nominal nominal nominal
+
+-- | @since 2.0.0
+instance DerivePlutusType (PValue keys amounts) where
+  type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since 2.0.0
+instance PUnsafeLiftDecl (PValue 'AssocMap.Unsorted 'NonZero) where
+  type PLifted (PValue 'AssocMap.Unsorted 'NonZero) = Plutus.Value
+
+-- | @since 2.0.0
+deriving via
+  ( DerivePConstantViaNewtype
+      Plutus.Value
+      (PValue 'AssocMap.Unsorted 'NonZero)
+      (AssocMap.PMap 'AssocMap.Unsorted PCurrencySymbol (AssocMap.PMap 'AssocMap.Unsorted PTokenName PInteger))
+  )
+  instance
+    PConstantDecl Plutus.Value
+
+-- | @since 2.0.0
+instance PEq (PValue 'AssocMap.Sorted 'Positive) where
+  a #== b = pto a #== pto b
+
+-- | @since 2.0.0
+instance PEq (PValue 'AssocMap.Sorted 'NonZero) where
+  a #== b = pto a #== pto b
+
+{- | Partial ordering implementation for sorted 'PValue' with 'Positive' amounts.
+
+Use 'pcheckBinRel' if 'AmountGuarantees' is 'NoGuarantees'.
+
+@since 2.0.0
+-}
+instance PPartialOrd (PValue 'AssocMap.Sorted 'Positive) where
+  (#<) ::
+    forall (s :: S).
+    Term s (PValue 'AssocMap.Sorted 'Positive) ->
+    Term s (PValue 'AssocMap.Sorted 'Positive) ->
+    Term s PBool
+  a #< b = a' #< pforgetPositive b
+    where
+      a' :: Term s (PValue 'AssocMap.Sorted 'NonZero)
+      a' = pforgetPositive a
+  (#<=) ::
+    forall (s :: S).
+    Term s (PValue 'AssocMap.Sorted 'Positive) ->
+    Term s (PValue 'AssocMap.Sorted 'Positive) ->
+    Term s PBool
+  a #<= b = a' #<= pforgetPositive b
+    where
+      a' :: Term s (PValue 'AssocMap.Sorted 'NonZero)
+      a' = pforgetPositive a
+
+{- | Partial ordering implementation for sorted 'PValue' with 'NonZero' amounts.
+
+Use 'pcheckBinRel' if 'AmountGuarantees' is 'NoGuarantees'.
+
+@since 2.0.0
+-}
+instance PPartialOrd (PValue 'AssocMap.Sorted 'NonZero) where
+  a #< b = f # a # b
+    where
+      f ::
+        forall (s :: S).
+        Term
+          s
+          ( PValue 'AssocMap.Sorted 'NonZero
+              :--> PValue 'AssocMap.Sorted 'NonZero
+              :--> PBool
+          )
+      f = phoistAcyclic $ pcheckBinRel #$ phoistAcyclic $ plam (#<)
+  a #<= b = f # a # b
+    where
+      f ::
+        forall (s :: S).
+        Term
+          s
+          ( PValue 'AssocMap.Sorted 'NonZero
+              :--> PValue 'AssocMap.Sorted 'NonZero
+              :--> PBool
+          )
+      f = phoistAcyclic $ pcheckBinRel #$ phoistAcyclic $ plam (#<=)
+
+-- | @since 2.0.0
+instance PEq (PValue 'AssocMap.Sorted 'NoGuarantees) where
+  a #== b =
+    AssocMap.pall
+      # (AssocMap.pall # plam (#== 0))
+      -- While '(-)' is not commutative, we don't need that property here.
+      -- TODO benchmark with '(==)'
+      # pto (punionResolvingCollisionsWith AssocMap.Commutative # plam (-) # a # b)
+
+-- | @since 2.0.0
+instance Semigroup (Term s (PValue 'AssocMap.Sorted 'Positive)) where
+  a <> b =
+    punsafeDowncast (pto $ punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b)
+
+-- | @since 2.0.0
+instance PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted 'Positive)) where
+  a <> b =
+    punsafeDowncast (pto $ punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b)
+
+-- | @since 2.0.0
+instance Semigroup (Term s (PValue 'AssocMap.Sorted 'NonZero)) where
+  a <> b =
+    pnormalize #$ punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b
+
+-- | @since 2.0.0
+instance PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted 'NonZero)) where
+  a <> b =
+    pnormalize #$ punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b
+
+-- | @since 2.0.0
+instance Semigroup (Term s (PValue 'AssocMap.Sorted 'NoGuarantees)) where
+  a <> b =
+    punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b
+
+-- | @since 2.0.0
+instance PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted 'NoGuarantees)) where
+  a <> b =
+    punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b
+
+-- | @since 2.0.0
+instance
+  Semigroup (Term s (PValue 'AssocMap.Sorted normalization)) =>
+  Monoid (Term s (PValue 'AssocMap.Sorted normalization))
+  where
+  mempty = pcon (PValue AssocMap.pempty)
+
+-- | @since 2.0.0
+instance
+  PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted normalization)) =>
+  PlutusTx.Monoid (Term s (PValue 'AssocMap.Sorted normalization))
+  where
+  mempty = pcon (PValue AssocMap.pempty)
+
+-- | @since 2.0.0
+instance
+  PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted 'NoGuarantees)) =>
+  PlutusTx.Group (Term s (PValue 'AssocMap.Sorted 'NoGuarantees))
+  where
+  inv a = pmapAmounts # plam negate # a
+
+-- | @since 2.0.0
+instance
+  PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted 'NonZero)) =>
+  PlutusTx.Group (Term s (PValue 'AssocMap.Sorted 'NonZero))
+  where
+  inv a =
+    punsafeCoerce $ PlutusTx.inv (punsafeCoerce a :: Term s (PValue 'AssocMap.Sorted 'NoGuarantees))
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData (PValue 'AssocMap.Unsorted 'NoGuarantees))
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData (PValue 'AssocMap.Sorted 'NoGuarantees))
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData (PValue 'AssocMap.Sorted 'Positive)) where
+  type PTryFromExcess PData (PAsData (PValue 'AssocMap.Sorted 'Positive)) = Mret (PValue 'AssocMap.Sorted 'Positive)
+  ptryFrom' opq = runTermCont $ do
+    (opq', _) <- tcont $ ptryFrom @(PAsData (PValue 'AssocMap.Sorted 'NoGuarantees)) opq
+    unwrapped <- tcont . plet . papp passertPositive . pfromData $ opq'
+    pure (punsafeCoerce opq, unwrapped)
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData (PValue 'AssocMap.Unsorted 'Positive)) where
+  type PTryFromExcess PData (PAsData (PValue 'AssocMap.Unsorted 'Positive)) = Mret (PValue 'AssocMap.Unsorted 'Positive)
+  ptryFrom' opq = runTermCont $ do
+    (opq', _) <- tcont $ ptryFrom @(PAsData (PValue 'AssocMap.Unsorted 'NoGuarantees)) opq
+    unwrapped <- tcont . plet . papp passertPositive . pfromData $ opq'
+    pure (punsafeCoerce opq, unwrapped)
+
+-- | @since 2.0.0
+instance PTryFrom PData (PAsData (PValue 'AssocMap.Sorted 'NonZero)) where
+  type PTryFromExcess PData (PAsData (PValue 'AssocMap.Sorted 'NonZero)) = Mret (PValue 'AssocMap.Sorted 'NonZero)
+  ptryFrom' opq = runTermCont $ do
+    (opq', _) <- tcont $ ptryFrom @(PAsData (PValue 'AssocMap.Sorted 'NoGuarantees)) opq
+    unwrapped <- tcont . plet . papp passertNonZero . pfromData $ opq'
+    pure (punsafeCoerce opq, unwrapped)
+
+{- | \'Forget\' that a 'Value' has an only-positive guarantee.
+
+@since 2.0.0
+-}
+pforgetPositive ::
+  forall (a :: AmountGuarantees) (k :: AssocMap.KeyGuarantees) (s :: S).
+  Term s (PValue k 'Positive) ->
+  Term s (PValue k a)
+pforgetPositive = punsafeCoerce
+
+{- | Given a description of a relation on amounts, check whether that relation
+holds over sorted 'PValue's.
+
+= Important note
+
+This is intended for use with boolean comparison functions, which must define
+at least a partial order (total orders and equivalences are acceptable as
+well). Use of this with anything else is not guaranteed to give anything
+resembling a sensible answer. Use with extreme care.
+
+@since 2.0.0
+-}
+pcheckBinRel ::
+  forall (any0 :: AmountGuarantees) (any1 :: AmountGuarantees) (s :: S).
+  Term
+    s
+    ( (PInteger :--> PInteger :--> PBool)
+        :--> PValue 'AssocMap.Sorted any0
+        :--> PValue 'AssocMap.Sorted any1
+        :--> PBool
+    )
+pcheckBinRel = phoistAcyclic $
+  plam $ \f ->
+    punsafeCoerce @_ @_ @(PValue AssocMap.Sorted any0 :--> PValue AssocMap.Sorted any1 :--> PBool) $
+      AssocMap.pcheckBinRel @PCurrencySymbol # (AssocMap.pcheckBinRel @PTokenName # f # 0) # AssocMap.pempty
+
+{- | Combine two 'PValue's applying the given function to any pair of
+ quantities with the same asset class. Note that the result is _not_
+ 'normalize'd and may contain zero quantities.
+
+ @since 2.0.0
+-}
+punionResolvingCollisionsWith ::
+  forall (any0 :: AmountGuarantees) (any1 :: AmountGuarantees) (s :: S).
+  AssocMap.Commutativity ->
+  Term
+    s
+    ( (PInteger :--> PInteger :--> PInteger)
+        :--> PValue 'AssocMap.Sorted any0
+        :--> PValue 'AssocMap.Sorted any1
+        :--> PValue 'AssocMap.Sorted 'NoGuarantees
+    )
+punionResolvingCollisionsWith commutativity = phoistAcyclic $
+  plam $ \combine x y ->
+    pcon . PValue $
+      AssocMap.punionResolvingCollisionsWith commutativity
+        # plam (\x' y' -> AssocMap.punionResolvingCollisionsWith commutativity # combine # x' # y')
+        # pto x
+        # pto y
+
+{- | Normalize the argument to contain no zero quantity nor empty token map.
+
+@since 2.0.0
+-}
+pnormalize ::
+  forall (any :: AmountGuarantees) (s :: S).
+  Term s (PValue 'AssocMap.Sorted any :--> PValue 'AssocMap.Sorted 'NonZero)
+pnormalize = phoistAcyclic $
+  plam $ \value ->
+    pcon . PValue $
+      AssocMap.pmapMaybe # plam normalizeTokenMap # pto value
+  where
+    normalizeTokenMap ::
+      forall (s' :: S) (k :: S -> Type) (any1 :: AssocMap.KeyGuarantees).
+      Term s' (AssocMap.PMap any1 k PInteger) ->
+      Term s' (PMaybe (AssocMap.PMap any1 k PInteger))
+    normalizeTokenMap tokenMap =
+      plet (AssocMap.pmapMaybeData # plam nonZero # tokenMap) $ \normalMap ->
+        pif
+          (AssocMap.pnull # normalMap)
+          (pcon PNothing)
+          (pcon $ PJust normalMap)
+    nonZero ::
+      forall (s' :: S).
+      Term s' (PAsData PInteger) ->
+      Term s' (PMaybe (PAsData PInteger))
+    nonZero intData =
+      pif (intData #== zeroData) (pcon PNothing) (pcon $ PJust intData)
+
+{- | Given a 'PValue', either construct another 'PValue' with the same contents
+and a proof that all amounts in it are positive, or error.
+
+@since 2.0.0
+-}
+passertPositive ::
+  forall (kg :: AssocMap.KeyGuarantees) (ag :: AmountGuarantees) (s :: S).
+  Term s (PValue kg ag :--> PValue kg 'Positive)
+passertPositive = phoistAcyclic $
+  plam $ \value ->
+    pif
+      ( AssocMap.pall
+          # plam (\submap -> AssocMap.pall # plam (0 #<) # submap)
+          # pto value
+      )
+      (punsafeDowncast $ pto value)
+      (ptraceError "Negative amount in Value")
+
+-- Helpers
+
+zeroData :: forall (s :: S). Term s (PAsData PInteger)
+zeroData = pdata 0
+
+-- Applies a function to every amount in the map.
+pmapAmounts ::
+  forall (k :: AssocMap.KeyGuarantees) (a :: AmountGuarantees) (s :: S).
+  Term s ((PInteger :--> PInteger) :--> PValue k a :--> PValue k 'NoGuarantees)
+pmapAmounts = phoistAcyclic $
+  plam $
+    \f v -> pcon $ PValue $ AssocMap.pmap # plam (AssocMap.pmap # f #) # pto v
+
+passertNonZero ::
+  forall (kg :: AssocMap.KeyGuarantees) (ag :: AmountGuarantees).
+  ( forall (s :: S). Term s (PValue kg ag :--> PValue kg 'NonZero)
+  )
+passertNonZero = plam $ \val ->
+  pif (outer #$ pto . pto $ val) (punsafeCoerce val) (ptraceError "Zero amount in Value")
+  where
+    outer ::
+      forall (s' :: S) (k :: AssocMap.KeyGuarantees).
+      Term s' (PBuiltinList (PBuiltinPair (PAsData PCurrencySymbol) (PAsData (AssocMap.PMap k PTokenName PInteger))) :--> PBool)
+    outer = pfix #$ plam $ \self m ->
+      pmatch m $ \case
+        PCons x xs -> inner # (pto . pfromData $ psndBuiltin # x) #&& self # xs
+        PNil -> pcon PTrue
+    inner :: ClosedTerm (PBuiltinList (PBuiltinPair (PAsData PTokenName) (PAsData PInteger)) :--> PBool)
+    inner = pfix #$ plam $ \self m ->
+      pmatch m $ \case
+        PCons x xs -> pnot # (psndBuiltin # x #== pconstantData 0) #&& self # xs
+        PNil -> pcon PTrue


### PR DESCRIPTION
Initial repair for #640. Currently, this is minimal: nothing's been rewired yet, and only the exports from `Plutarch.Api.V2` are retained. This is designed to keep review surface minimal before we tackle additional porting and rewiring.