### PR TITLE
Remove `extra-substituters` and `extra-trusted-public-keys` from nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,6 @@
   description = "plutarch";
 
   nixConfig = {
-    extra-substituters = [ "https://cache.iog.io" ];
-    extra-trusted-public-keys = [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
     allow-import-from-derivation = "true";
     bash-prompt = "\\[\\e[0m\\][\\[\\e[0;2m\\]nix \\[\\e[0;1m\\]plutarch \\[\\e[0;93m\\]\\w\\[\\e[0m\\]]\\[\\e[0m\\]$ \\[\\e[0m\\]";
     cores = "1";

--- a/plutarch-docs/README.md
+++ b/plutarch-docs/README.md
@@ -27,6 +27,12 @@ The Plutarch guide is your one-stop shop for getting up to speed on Plutarch!
 
 - [Common Extensions and GHC options](./Run.md#common-extensions-and-ghc-options)
 - [Evaluation](./Run.md#evaluation)
+- Nix binary cache is recommended. Otherwise nix will build from GHC itself.
+
+Use Plutonomicon binary cache via cachix: https://plutonomicon.cachix.org
+
+When setting up cachix, it recommends adding users to `trusted-users` at nix configuration. This
+is [insecure](https://github.com/cachix/cachix/issues/612) and is not recommended.
 
 ## Introduction and Basic Syntax
 

--- a/plutarch-docs/README.md
+++ b/plutarch-docs/README.md
@@ -31,8 +31,8 @@ The Plutarch guide is your one-stop shop for getting up to speed on Plutarch!
 
 Use Plutonomicon binary cache via cachix: https://plutonomicon.cachix.org
 
-When setting up cachix, it recommends adding users to `trusted-users` at nix configuration. This
-is [insecure](https://github.com/cachix/cachix/issues/612) and is not recommended.
+DO NOT add your user to `trusted-users` as `cachix use` suggests because this is
+[insecure](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-trusted-users).
 
 ## Introduction and Basic Syntax
 


### PR DESCRIPTION
`extra-substituters` and `extra-trusted-public-keys` in flake's nixConfig is unsafe. Removing this and adding documentation for users to add binary cache by themselves.