### PR TITLE
Re-export Utils from V1 and V2

### DIFF
--- a/plutarch-ledger-api/CHANGELOG.md
+++ b/plutarch-ledger-api/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## 3.2.1 -- 11-07-2024
+
+### Changed
+
+* `Plutarch.LedgerApi.Utils` identifiers are now re-exported from V1 and V2 as
+  well
+
 ## 3.2.0 -- 05-07-2024
 
 ### Changed

--- a/plutarch-ledger-api/plutarch-ledger-api.cabal
+++ b/plutarch-ledger-api/plutarch-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          plutarch-ledger-api
-version:       3.1.1
+version:       3.2.1
 
 common common-lang
   default-language:   Haskell2010

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
@@ -48,6 +48,22 @@ module Plutarch.LedgerApi.V1 (
   AssocMap.PMap (..),
   AssocMap.KeyGuarantees (..),
   AssocMap.Commutativity (..),
+
+  -- * Utilities
+
+  -- ** Types
+  Utils.PMaybeData (..),
+  Utils.PRationalData (..),
+
+  -- ** Utilities
+  Utils.pfromDJust,
+  Utils.pisDJust,
+  Utils.pmaybeData,
+  Utils.pdjust,
+  Utils.pdnothing,
+  Utils.pmaybeToMaybeData,
+  Utils.passertPDJust,
+  Utils.prationalFromData,
 ) where
 
 import Plutarch.DataRepr (
@@ -56,6 +72,7 @@ import Plutarch.DataRepr (
  )
 import Plutarch.LedgerApi.AssocMap qualified as AssocMap
 import Plutarch.LedgerApi.Interval qualified as Interval
+import Plutarch.LedgerApi.Utils qualified as Utils
 import Plutarch.LedgerApi.V1.Address qualified as Address
 import Plutarch.LedgerApi.V1.Contexts qualified as Contexts
 import Plutarch.LedgerApi.V1.Credential qualified as Credential

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V2.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V2.hs
@@ -49,6 +49,22 @@ module Plutarch.LedgerApi.V2 (
   AssocMap.PMap (..),
   AssocMap.KeyGuarantees (..),
   AssocMap.Commutativity (..),
+
+  -- * Utilities
+
+  -- ** Types
+  Utils.PMaybeData (..),
+  Utils.PRationalData (..),
+
+  -- ** Utilities
+  Utils.pfromDJust,
+  Utils.pisDJust,
+  Utils.pmaybeData,
+  Utils.pdjust,
+  Utils.pdnothing,
+  Utils.pmaybeToMaybeData,
+  Utils.passertPDJust,
+  Utils.prationalFromData,
 ) where
 
 import Plutarch.DataRepr (
@@ -57,6 +73,7 @@ import Plutarch.DataRepr (
  )
 import Plutarch.LedgerApi.AssocMap qualified as AssocMap
 import Plutarch.LedgerApi.Interval qualified as Interval
+import Plutarch.LedgerApi.Utils qualified as Utils
 import Plutarch.LedgerApi.V1.Address qualified as Address
 import Plutarch.LedgerApi.V1.Contexts qualified as Contexts
 import Plutarch.LedgerApi.V1.Credential qualified as Credential


### PR DESCRIPTION
This ensures that both the types and functions from `Plutarch.LedgerApi.Utils` are available from `V1` and `V2` modules. This was already the case for `V3`, so this just keeps things symmetrical.