### PR TITLE
Fix zero-ada behaviour of mint value generators

### DIFF
--- a/plutarch-ledger-api/CHANGELOG.md
+++ b/plutarch-ledger-api/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * `PPosixTime` now permits negative values as a result of its operations
 * `PEq`, `PPartialOrd` and `POrd` for `PLowerBound` and `PUpperBound` match the
   semantics of `plutus-ledger-api`'s equivalents for these types
+* `V3.PTxInfo.mint` now has `NonZero` guarantee
+* `V1.PTxInfo.mint` now has `NoGuarantees` guarantee
 
 ### Fixed
 

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
@@ -182,7 +182,7 @@ deriving via
 -- | @since 3.1.1
 instance PTryFrom PData (PAsData PTxInInfo)
 
--- | @since 3.1.1
+-- | @since WIP
 newtype PTxInfo (s :: S)
   = PTxInfo
       ( Term

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
@@ -191,7 +191,7 @@ newtype PTxInfo (s :: S)
               '[ "inputs" ':= PBuiltinList (PAsData PTxInInfo)
                , "outputs" ':= PBuiltinList (PAsData PTxOut)
                , "fee" ':= Value.PValue 'AssocMap.Sorted 'Value.Positive
-               , "mint" ':= Value.PValue 'AssocMap.Sorted 'Value.NonZero -- value minted by transaction
+               , "mint" ':= Value.PValue 'AssocMap.Sorted 'Value.NoGuarantees -- value minted by transaction
                , "dCert" ':= PBuiltinList (PAsData DCert.PDCert)
                , "wdrl" ':= PBuiltinList (PAsData (PBuiltinPair (PAsData Credential.PStakingCredential) (PAsData PInteger))) -- Staking withdrawals
                , "validRange" ':= Interval.PInterval Time.PPosixTime

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Contexts.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Contexts.hs
@@ -818,7 +818,7 @@ instance PTryFrom PData (PAsData PTxInInfo)
 
 -- A pending transaction. This is the view as seen by a validator script.
 --
--- @since 3.1.0
+-- @since WIP
 newtype PTxInfo (s :: S)
   = PTxInfo
       ( Term

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Contexts.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Contexts.hs
@@ -828,7 +828,7 @@ newtype PTxInfo (s :: S)
                , "referenceInputs" ':= PBuiltinList (PAsData PTxInInfo)
                , "outputs" ':= PBuiltinList (PAsData PTxOut)
                , "fee" ':= Value.PLovelace
-               , "mint" ':= Value.PValue 'AssocMap.Sorted 'Value.NoGuarantees -- value minted by transaction
+               , "mint" ':= Value.PValue 'AssocMap.Sorted 'Value.NonZero -- value minted by transaction
                , "txCerts" ':= PBuiltinList (PAsData PTxCert)
                , "wdrl" ':= AssocMap.PMap 'AssocMap.Unsorted PCredential Value.PLovelace -- Staking withdrawals
                , "validRange" ':= Interval.PInterval PPosixTime

--- a/plutarch-orphanage/CHANGELOG.md
+++ b/plutarch-orphanage/CHANGELOG.md
@@ -6,11 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## WIP
 
+### Added
+
+* `V3` version of `MintValue` that does not include zero Ada
+
 ### Changed
 
 * `Arbitrary` instance for `POSIXTime` can now generate negative values as well.
   This does not affect `Interval POSIXTime`'s instance, as the formation rules
   assume non-negative interval endpoints.
+* `V1.MintValue` and `V1.NonAdaValue` generators now include zero Ada entry
 
 ## 1.0.3 -- 04-07-2024
 

--- a/plutarch-orphanage/plutarch-orphanage.cabal
+++ b/plutarch-orphanage/plutarch-orphanage.cabal
@@ -69,6 +69,7 @@ library
     PlutusLedgerApi.V1.Orphans.Value
     PlutusLedgerApi.V2.Orphans.Contexts
     PlutusLedgerApi.V2.Orphans.Tx
+    PlutusLedgerApi.V3.Orphans.Value
 
   build-depends:
     , bytestring

--- a/plutarch-orphanage/src/PlutusLedgerApi/V2/Orphans/Contexts.hs
+++ b/plutarch-orphanage/src/PlutusLedgerApi/V2/Orphans/Contexts.hs
@@ -50,7 +50,7 @@ instance Arbitrary PLA.TxInfo where
       <*> arbitrary -- reference inputs
       <*> (getNonEmpty <$> arbitrary) -- outputs
       <*> (Value.getFeeValue <$> arbitrary) -- fee
-      <*> (Value.getNonAdaValue <$> arbitrary) -- mint
+      <*> (Value.getMintValue <$> arbitrary) -- mint
       <*> arbitrary -- dcert
       <*> arbitrary -- withdrawals
       <*> arbitrary -- valid range

--- a/plutarch-orphanage/src/PlutusLedgerApi/V3/Orphans.hs
+++ b/plutarch-orphanage/src/PlutusLedgerApi/V3/Orphans.hs
@@ -12,9 +12,9 @@ import PlutusLedgerApi.V1.Orphans.Credential ()
 import PlutusLedgerApi.V1.Orphans.Interval ()
 import PlutusLedgerApi.V1.Orphans.Time ()
 import PlutusLedgerApi.V1.Orphans.Value ()
-import PlutusLedgerApi.V1.Orphans.Value qualified as Value
 import PlutusLedgerApi.V2.Orphans.Tx ()
 import PlutusLedgerApi.V3 qualified as PLA
+import PlutusLedgerApi.V3.Orphans.Value qualified as Value
 import PlutusTx.AssocMap qualified as AssocMap
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Prelude qualified as PlutusTx
@@ -863,7 +863,7 @@ instance Arbitrary PLA.TxInfo where
     routs <- arbitrary
     outs <- getNonEmpty <$> arbitrary
     fee <- arbitrary
-    mint <- Value.getNonAdaValue <$> arbitrary
+    mint <- Value.getMintValue <$> arbitrary
     cert <- arbitrary
     wdrl <- arbitrary
     valid <- arbitrary
@@ -882,7 +882,7 @@ instance Arbitrary PLA.TxInfo where
     routs' <- shrink routs
     NonEmpty outs' <- shrink (NonEmpty outs)
     fee' <- shrink fee
-    (Value.NonAdaValue mint') <- shrink (Value.NonAdaValue mint)
+    (Value.MintValue mint') <- shrink (Value.MintValue mint)
     cert' <- shrink cert
     wdrl' <- shrink wdrl
     valid' <- shrink valid

--- a/plutarch-orphanage/src/PlutusLedgerApi/V3/Orphans/Value.hs
+++ b/plutarch-orphanage/src/PlutusLedgerApi/V3/Orphans/Value.hs
@@ -1,0 +1,107 @@
+module PlutusLedgerApi.V3.Orphans.Value (
+  -- * Specialized Value wrappers
+  MintValue (..),
+  getMintValue,
+) where
+
+import Data.ByteString (ByteString)
+import Data.ByteString qualified as BS
+import Data.Coerce (coerce)
+import Data.Set qualified as Set
+import PlutusLedgerApi.Orphans.Common (getBlake2b244Hash)
+import PlutusLedgerApi.V1 qualified as PLA
+import PlutusLedgerApi.V1.Orphans.Value ()
+import PlutusLedgerApi.V1.Value qualified as Value
+import PlutusTx.AssocMap qualified as AssocMap
+import PlutusTx.Prelude qualified as PlutusTx
+import Test.QuickCheck (
+  Arbitrary (arbitrary, shrink),
+  Arbitrary1 (liftArbitrary, liftShrink),
+  CoArbitrary,
+  Function (function),
+  Gen,
+  NonZero (NonZero),
+  chooseBoundedIntegral,
+  chooseInt,
+  functionMap,
+  getNonEmpty,
+  getNonZero,
+  resize,
+  scale,
+  sized,
+  vectorOf,
+ )
+
+{- | A 'PLA.Value' that contains only non-zero amounts but does not have zero Ada entry
+
+= Note
+
+This is designed to act as a modifier, and thus, we expose the constructor
+even though it preserves invariants. If you use the constructor directly,
+be /very/ certain that the Value being wrapped satisfies the invariants
+described above: failing to do so means all guarantees of this type are off
+the table.
+
+@since WIP
+-}
+newtype MintValue = MintValue PLA.Value
+  deriving
+    ( -- | @since WIP
+      Eq
+    )
+    via PLA.Value
+  deriving stock
+    ( -- | @since WIP
+      Show
+    )
+
+-- | @since WIP
+instance Arbitrary MintValue where
+  {-# INLINEABLE arbitrary #-}
+  arbitrary =
+    MintValue <$> do
+      -- Generate a set of currency symbols that aren't Ada
+      keySet <- Set.fromList <$> liftArbitrary (PLA.CurrencySymbol . getBlake2b244Hash <$> arbitrary)
+      let keyList = Set.toList keySet
+      -- For each key, generate a set of token name keys that aren't Ada
+      keyVals <- traverse (scale (`quot` 8) . mkInner) keyList
+      pure . foldMap (\(cs, vals) -> foldMap (uncurry (Value.singleton cs)) vals) $ keyVals
+    where
+      mkInner :: PLA.CurrencySymbol -> Gen (PLA.CurrencySymbol, [(PLA.TokenName, Integer)])
+      mkInner cs =
+        (cs,)
+          . Set.toList
+          . Set.fromList
+          . getNonEmpty
+          <$> liftArbitrary ((,) <$> genNonAdaTokenName <*> (getNonZero <$> arbitrary))
+
+      genNonAdaTokenName :: Gen PLA.TokenName
+      genNonAdaTokenName = fmap (PLA.TokenName . PlutusTx.toBuiltin @ByteString . BS.pack) . sized $ \size -> do
+        len <- resize size . chooseInt $ (1, 32)
+        vectorOf len . chooseBoundedIntegral $ (33, 126)
+  {-# INLINEABLE shrink #-}
+  shrink (MintValue (Value.Value v)) =
+    MintValue . Value.Value <$> do
+      -- To ensure we don't break anything, we shrink in only two ways:
+      --
+      -- 1. Dropping keys (outer or inner)
+      -- 2. Shrinking amounts
+      --
+      -- To make this a bit easier on ourselves, we first 'unpack' the Value
+      -- completely, shrink the resulting (nested) list, then 'repack'. As neither
+      -- of these changes affect order or uniqueness, we're safe.
+      let asList = fmap AssocMap.toList <$> AssocMap.toList v
+      shrunk <- liftShrink (\(cs, inner) -> (cs,) <$> liftShrink (\(tn, amount) -> (tn,) . getNonZero <$> shrink (NonZero amount)) inner) asList
+      pure . AssocMap.unsafeFromList . fmap (fmap AssocMap.unsafeFromList) $ shrunk
+
+-- | @since WIP
+deriving via PLA.Value instance CoArbitrary MintValue
+
+-- | @since WIP
+instance Function MintValue where
+  {-# INLINEABLE function #-}
+  function = functionMap coerce MintValue
+
+-- | @since WIP
+getMintValue :: MintValue -> Value.Value
+getMintValue = coerce


### PR DESCRIPTION
- Fix previous specialized value generators to include zero Ada entry in V1 and V2
- Add new mint value generator for V3 that does not include zero Ada entry as this invariant [changed in V3](https://github.com/IntersectMBO/plutus/blob/384997b4f395c984685a10a8317c7f729c37ff26/plutus-ledger-api/src/PlutusLedgerApi/V3/Contexts.hs#L483-L487)
- Fix mint value guarantee in V1 to `NoGuarantees` from `NonZero` (apparently it was always wrong)
- Fix mint value guarantee in V3 to `NonZero` from `NoGuarantees`