### PR TITLE
Add tests for PCountable and PEnumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * `pmax` and `pmin` as new methods of `POrd`
 * `#>` and `#>=` as new methods of `PPartialOrd`
-* `pallBS` to `Plutarch.ByteString` (originally from `plutarch-extra')
+* `pallBS` to `Plutarch.ByteString` (originally from `plutarch-extra`)
 * `pisHexDigit` to `Plutarch.String` (originally from `plutarch-extra`)
 * `preverse` and `pcheckSorted` to `Plutarch.List` (originally from
   `plutarch-extra`)
@@ -24,6 +24,9 @@
 * `compileOptimized` in `Plutarch.Internal`, to optimize the generated UPLC
 * `PBitString` and associated functionality for CIP-122 and CIP-123 operations
   on bits, in `Plutarch.BitString`
+* `Positive` type in `Plutarch.Positive` that is Haskell level equivalent of
+  `PPositive`
+* `PUnsafeLiftDecl` and `PConstantDecl` instances for `PPositive`
 
 ## Changed
 
@@ -39,6 +42,10 @@
 * `Plutarch.Bitwise` module, as its functionality has been superseded by more
   type-safe operations in `Plutarch.ByteString`, `Plutarch.BitString` and
   `Plutarch.Convert`
+
+### Fixed
+
+* Bug in `ppredecessorN` for `PPosixTime` where order of subtraction was flipped
 
 # 1.9.0 - 25-09-2024
 

--- a/Plutarch/Enum.hs
+++ b/Plutarch/Enum.hs
@@ -83,7 +83,7 @@ with no maximal or minimal element.
 
 = Laws
 
-1. @ppredecessor . psuccessor x@ @=@ @psuccessor . ppredecessor@ @=@ @id@
+1. @ppredecessor . psuccessor@ @=@ @psuccessor . ppredecessor@ @=@ @id@
 
 If you define 'ppredecessorN', you must also ensure the following hold; the
 default implementation ensures this.

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
@@ -65,7 +65,7 @@ instance PEnumerable PPosixTime where
   {-# INLINEABLE ppredecessorN #-}
   ppredecessorN = phoistAcyclic $ plam $ \p t ->
     let p' = pcon . PPosixTime . pcon . PDataNewtype . pdata . pto $ p
-     in p' - t
+     in t - p'
 
 -- | @since 2.0.0
 instance PIntegral PPosixTime where

--- a/plutarch-ledger-api/test/Laws.hs
+++ b/plutarch-ledger-api/test/Laws.hs
@@ -7,11 +7,7 @@ module Laws (
   ptryFromLaws,
   ptryFromLawsValue,
   ptryFromLawsAssocMap,
-  psuccesssorNotEqSelf,
-  lessThanEqPSuccessorLessThanOrEq,
-  lessThanPSuccessorEqLessThanOrEq,
-  psuccessorNOneEqPSuccessor,
-  psuccessorNAdd,
+  pcountableLaws,
   penumerableLaws,
 ) where
 
@@ -138,7 +134,7 @@ ptryFromLawsAssocMap = [pDataAgreementProp]
         plift (pfromData . ptryFrom @(PAsData (V1.PMap V1.Unsorted PInteger PInteger)) (pconstant . Plutus.toData $ v) $ fst)
           === v
 
-psuccesssorNotEqSelf ::
+pcountableLaws ::
   forall (a :: S -> Type).
   ( PCountable a
   , Arbitrary (PLifted a)
@@ -147,67 +143,25 @@ psuccesssorNotEqSelf ::
   , Show (PLifted a)
   , PUnsafeLiftDecl a
   ) =>
-  TestTree
-psuccesssorNotEqSelf =
-  testProperty "x /= psuccessor x" . forAllShrinkShow arbitrary shrink prettyShow $
-    \(x :: PLifted a) ->
-      plift (psuccessor # pconstant x) =/= x
-
-lessThanEqPSuccessorLessThanOrEq ::
-  forall (a :: S -> Type).
-  ( PCountable a
-  , Arbitrary (PLifted a)
-  , Pretty (PLifted a)
-  , PUnsafeLiftDecl a
-  ) =>
-  TestTree
-lessThanEqPSuccessorLessThanOrEq =
-  testProperty "y < x = psuccessor y <= x" . forAllShrinkShow arbitrary shrink prettyShow $
-    \(x :: PLifted a, y :: PLifted a) ->
-      plift (pconstant y #< pconstant x) === plift ((psuccessor # pconstant y) #<= pconstant x)
-
-lessThanPSuccessorEqLessThanOrEq ::
-  forall (a :: S -> Type).
-  ( PCountable a
-  , Arbitrary (PLifted a)
-  , Pretty (PLifted a)
-  , PUnsafeLiftDecl a
-  ) =>
-  TestTree
-lessThanPSuccessorEqLessThanOrEq =
-  testProperty "x < psuccessor y = x <= y" . forAllShrinkShow arbitrary shrink prettyShow $
-    \(x :: PLifted a, y :: PLifted a) ->
-      plift (pconstant x #< (psuccessor # pconstant y)) === plift (pconstant x #<= pconstant y)
-
-psuccessorNOneEqPSuccessor ::
-  forall (a :: S -> Type).
-  ( PCountable a
-  , Arbitrary (PLifted a)
-  , Pretty (PLifted a)
-  , Eq (PLifted a)
-  , Show (PLifted a)
-  , PUnsafeLiftDecl a
-  ) =>
-  TestTree
-psuccessorNOneEqPSuccessor =
-  testProperty "psuccessorN 1 /= psuccessor" . forAllShrinkShow arbitrary shrink prettyShow $
-    \(x :: PLifted a) ->
-      plift (psuccessorN # 1 # pconstant x) === plift (psuccessor # pconstant x)
-
-psuccessorNAdd ::
-  forall (a :: S -> Type).
-  ( PCountable a
-  , Arbitrary (PLifted a)
-  , Eq (PLifted a)
-  , Show (PLifted a)
-  , PUnsafeLiftDecl a
-  ) =>
-  TestTree
-psuccessorNAdd =
-  testProperty "psuccessorN n . psuccessorN m = psuccessorN (n + m)" . forAllShrinkShow arbitrary shrink show $
-    \(x :: PLifted a, n :: Positive Integer, m :: Positive Integer) ->
-      plift (psuccessorN # pfromInteger (getPositive n) # (psuccessorN # pfromInteger (getPositive m) # pconstant x))
-        === plift (psuccessorN # (pfromInteger (getPositive n) + pfromInteger (getPositive m)) # pconstant x)
+  [TestTree]
+pcountableLaws =
+  [ testProperty "x /= psuccessor x" . forAllShrinkShow arbitrary shrink prettyShow $
+      \(x :: PLifted a) ->
+        plift (psuccessor # pconstant x) =/= x
+  , testProperty "y < x = psuccessor y <= x" . forAllShrinkShow arbitrary shrink prettyShow $
+      \(x :: PLifted a, y :: PLifted a) ->
+        plift (pconstant y #< pconstant x) === plift ((psuccessor # pconstant y) #<= pconstant x)
+  , testProperty "x < psuccessor y = x <= y" . forAllShrinkShow arbitrary shrink prettyShow $
+      \(x :: PLifted a, y :: PLifted a) ->
+        plift (pconstant x #< (psuccessor # pconstant y)) === plift (pconstant x #<= pconstant y)
+  , testProperty "psuccessorN 1 /= psuccessor" . forAllShrinkShow arbitrary shrink prettyShow $
+      \(x :: PLifted a) ->
+        plift (psuccessorN # 1 # pconstant x) === plift (psuccessor # pconstant x)
+  , testProperty "psuccessorN n . psuccessorN m = psuccessorN (n + m)" . forAllShrinkShow arbitrary shrink show $
+      \(x :: PLifted a, n :: Positive Integer, m :: Positive Integer) ->
+        plift (psuccessorN # pfromInteger (getPositive n) # (psuccessorN # pfromInteger (getPositive m) # pconstant x))
+          === plift (psuccessorN # (pfromInteger (getPositive n) + pfromInteger (getPositive m)) # pconstant x)
+  ]
 
 penumerableLaws ::
   forall (a :: S -> Type).

--- a/plutarch-ledger-api/test/Laws.hs
+++ b/plutarch-ledger-api/test/Laws.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Laws (
   punsafeLiftDeclLaws,
@@ -8,6 +9,7 @@ module Laws (
   ptryFromLawsValue,
   ptryFromLawsAssocMap,
   pcountableLaws,
+  pcountableLawsVia,
   penumerableLaws,
 ) where
 
@@ -138,29 +140,41 @@ pcountableLaws ::
   forall (a :: S -> Type).
   ( PCountable a
   , Arbitrary (PLifted a)
-  , Pretty (PLifted a)
   , Eq (PLifted a)
   , Show (PLifted a)
   , PUnsafeLiftDecl a
   ) =>
   [TestTree]
-pcountableLaws =
-  [ testProperty "x /= psuccessor x" . forAllShrinkShow arbitrary shrink prettyShow $
-      \(x :: PLifted a) ->
-        plift (psuccessor # pconstant x) =/= x
-  , testProperty "y < x = psuccessor y <= x" . forAllShrinkShow arbitrary shrink prettyShow $
-      \(x :: PLifted a, y :: PLifted a) ->
-        plift (pconstant y #< pconstant x) === plift ((psuccessor # pconstant y) #<= pconstant x)
-  , testProperty "x < psuccessor y = x <= y" . forAllShrinkShow arbitrary shrink prettyShow $
-      \(x :: PLifted a, y :: PLifted a) ->
-        plift (pconstant x #< (psuccessor # pconstant y)) === plift (pconstant x #<= pconstant y)
-  , testProperty "psuccessorN 1 /= psuccessor" . forAllShrinkShow arbitrary shrink prettyShow $
-      \(x :: PLifted a) ->
-        plift (psuccessorN # 1 # pconstant x) === plift (psuccessor # pconstant x)
+pcountableLaws = pcountableLawsVia @(PLifted a) pconstant plift
+
+pcountableLawsVia ::
+  forall (input :: Type) (output :: Type) (plutarch :: S -> Type).
+  ( PCountable plutarch
+  , Arbitrary input
+  , Eq output
+  , Show input
+  , Show output
+  ) =>
+  (input -> ClosedTerm plutarch) ->
+  (ClosedTerm plutarch -> output) ->
+  [TestTree]
+pcountableLawsVia mkInput mkOutput =
+  [ testProperty "x /= psuccessor x" . forAllShrinkShow arbitrary shrink show $
+      \(x :: input) ->
+        mkOutput (psuccessor # mkInput x) =/= mkOutput (mkInput x)
+  , testProperty "y < x = psuccessor y <= x" . forAllShrinkShow arbitrary shrink show $
+      \(x :: input, y :: input) ->
+        plift (mkInput y #< mkInput x) === plift ((psuccessor # mkInput y) #<= mkInput x)
+  , testProperty "x < psuccessor y = x <= y" . forAllShrinkShow arbitrary shrink show $
+      \(x :: input, y :: input) ->
+        plift (mkInput x #< (psuccessor # mkInput y)) === plift (mkInput x #<= mkInput y)
+  , testProperty "psuccessorN 1 /= psuccessor" . forAllShrinkShow arbitrary shrink show $
+      \(x :: input) ->
+        mkOutput (psuccessorN # 1 # mkInput x) === mkOutput (psuccessor # mkInput x)
   , testProperty "psuccessorN n . psuccessorN m = psuccessorN (n + m)" . forAllShrinkShow arbitrary shrink show $
-      \(x :: PLifted a, n :: Positive Integer, m :: Positive Integer) ->
-        plift (psuccessorN # pfromInteger (getPositive n) # (psuccessorN # pfromInteger (getPositive m) # pconstant x))
-          === plift (psuccessorN # (pfromInteger (getPositive n) + pfromInteger (getPositive m)) # pconstant x)
+      \(x :: input, n :: Positive Integer, m :: Positive Integer) ->
+        mkOutput (psuccessorN # pfromInteger (getPositive n) # (psuccessorN # pfromInteger (getPositive m) # mkInput x))
+          === mkOutput (psuccessorN # (pfromInteger (getPositive n) + pfromInteger (getPositive m)) # mkInput x)
   ]
 
 penumerableLaws ::

--- a/plutarch-ledger-api/test/Laws.hs
+++ b/plutarch-ledger-api/test/Laws.hs
@@ -154,7 +154,7 @@ pcountableLaws =
   , testProperty "x < psuccessor y = x <= y" . forAllShrinkShow arbitrary shrink prettyShow $
       \(x :: PLifted a, y :: PLifted a) ->
         plift (pconstant x #< (psuccessor # pconstant y)) === plift (pconstant x #<= pconstant y)
-  , testProperty "psuccessorN 1 /= psuccessor" . forAllShrinkShow arbitrary shrink prettyShow $
+  , testProperty "psuccessorN 1 = psuccessor" . forAllShrinkShow arbitrary shrink prettyShow $
       \(x :: PLifted a) ->
         plift (psuccessorN # 1 # pconstant x) === plift (psuccessor # pconstant x)
   , testProperty "psuccessorN n . psuccessorN m = psuccessorN (n + m)" . forAllShrinkShow arbitrary shrink show $
@@ -180,7 +180,7 @@ penumerableLaws =
   , testProperty "psuccessor . ppredecessor = id" . forAllShrinkShow arbitrary shrink prettyShow $
       \(x :: PLifted a) ->
         plift (psuccessor #$ ppredecessor # pconstant x) === plift (pconstant x)
-  , testProperty "ppredecessorN 1 /= ppredecessor" . forAllShrinkShow arbitrary shrink prettyShow $
+  , testProperty "ppredecessorN 1 = ppredecessor" . forAllShrinkShow arbitrary shrink prettyShow $
       \(x :: PLifted a) ->
         plift (ppredecessorN # 1 # pconstant x) === plift (ppredecessor # pconstant x)
   , testProperty "ppredecessorN n . ppredecessorN m = ppredecessorN (n + m)" . forAllShrinkShow arbitrary shrink show $

--- a/plutarch-ledger-api/test/Laws.hs
+++ b/plutarch-ledger-api/test/Laws.hs
@@ -15,7 +15,7 @@ import Plutarch.Builtin (pforgetData)
 import Plutarch.Enum (PCountable (psuccessor, psuccessorN), PEnumerable (ppredecessor, ppredecessorN))
 import Plutarch.LedgerApi.V1 qualified as V1
 import Plutarch.Lift (PUnsafeLiftDecl (PLifted))
-import Plutarch.Num (PNum (pfromInteger))
+import Plutarch.Positive (Positive)
 import Plutarch.Prelude
 import Plutarch.Unsafe (punsafeCoerce)
 import PlutusLedgerApi.Common qualified as Plutus
@@ -26,7 +26,6 @@ import Prettyprinter (Pretty (pretty), defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.String (renderString)
 import Test.QuickCheck (
   Arbitrary (arbitrary, shrink),
-  Positive (getPositive),
   forAllShrinkShow,
   (=/=),
   (===),
@@ -158,9 +157,9 @@ pcountableLaws =
       \(x :: PLifted a) ->
         plift (psuccessorN # 1 # pconstant x) === plift (psuccessor # pconstant x)
   , testProperty "psuccessorN n . psuccessorN m = psuccessorN (n + m)" . forAllShrinkShow arbitrary shrink show $
-      \(x :: PLifted a, n :: Positive Integer, m :: Positive Integer) ->
-        plift (psuccessorN # pfromInteger (getPositive n) # (psuccessorN # pfromInteger (getPositive m) # pconstant x))
-          === plift (psuccessorN # (pfromInteger (getPositive n) + pfromInteger (getPositive m)) # pconstant x)
+      \(x :: PLifted a, n :: Positive, m :: Positive) ->
+        plift (psuccessorN # pconstant n # (psuccessorN # pconstant m # pconstant x))
+          === plift (psuccessorN # (pconstant n + pconstant m) # pconstant x)
   ]
 
 penumerableLaws ::
@@ -184,9 +183,9 @@ penumerableLaws =
       \(x :: PLifted a) ->
         plift (ppredecessorN # 1 # pconstant x) === plift (ppredecessor # pconstant x)
   , testProperty "ppredecessorN n . ppredecessorN m = ppredecessorN (n + m)" . forAllShrinkShow arbitrary shrink show $
-      \(x :: PLifted a, n :: Positive Integer, m :: Positive Integer) ->
-        plift (ppredecessorN # pfromInteger (getPositive n) # (ppredecessorN # pfromInteger (getPositive m) # pconstant x))
-          === plift (ppredecessorN # (pfromInteger (getPositive n) + pfromInteger (getPositive m)) # pconstant x)
+      \(x :: PLifted a, n :: Positive, m :: Positive) ->
+        plift (ppredecessorN # pconstant n # (ppredecessorN # pconstant m # pconstant x))
+          === plift (ppredecessorN # (pconstant n + pconstant m) # pconstant x)
   ]
 
 -- Helpers

--- a/plutarch-ledger-api/test/Utils.hs
+++ b/plutarch-ledger-api/test/Utils.hs
@@ -11,13 +11,9 @@ module Utils (
 ) where
 
 import Laws (
-  lessThanEqPSuccessorLessThanOrEq,
-  lessThanPSuccessorEqLessThanOrEq,
+  pcountableLaws,
   penumerableLaws,
   pisDataLaws,
-  psuccessorNAdd,
-  psuccessorNOneEqPSuccessor,
-  psuccesssorNotEqSelf,
   ptryFromLaws,
   ptryFromLawsAssocMap,
   ptryFromLawsValue,
@@ -92,15 +88,7 @@ checkLedgerPropertiesPCountable ::
   , PUnsafeLiftDecl a
   ) =>
   TestTree
-checkLedgerPropertiesPCountable =
-  testGroup
-    (typeName @(S -> Type) @a)
-    [ psuccesssorNotEqSelf @a
-    , lessThanEqPSuccessorLessThanOrEq @a
-    , lessThanPSuccessorEqLessThanOrEq @a
-    , psuccessorNOneEqPSuccessor @a
-    , psuccessorNAdd @a
-    ]
+checkLedgerPropertiesPCountable = testGroup (typeName @(S -> Type) @a) (pcountableLaws @a)
 
 checkLedgerPropertiesPEnumerable ::
   forall (a :: S -> Type).

--- a/plutarch-ledger-api/test/Utils.hs
+++ b/plutarch-ledger-api/test/Utils.hs
@@ -1,22 +1,17 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE RankNTypes #-}
 
 module Utils (
   checkLedgerProperties,
   checkLedgerPropertiesValue,
   checkLedgerPropertiesAssocMap,
   checkLedgerPropertiesPCountable,
-  checkLedgerPropertiesPCountableVia,
   checkLedgerPropertiesPEnumerable,
-  fromPPositive,
-  toPPositive,
   fewerTests,
 ) where
 
 import Laws (
   pcountableLaws,
-  pcountableLawsVia,
   penumerableLaws,
   pisDataLaws,
   ptryFromLaws,
@@ -27,13 +22,11 @@ import Laws (
 import Plutarch.Enum (PCountable, PEnumerable)
 import Plutarch.LedgerApi.V1 qualified as PLA
 import Plutarch.Lift (PUnsafeLiftDecl (PLifted))
-import Plutarch.Num (PNum (pfromInteger))
-import Plutarch.Positive (PPositive)
 import Plutarch.Prelude
 import PlutusLedgerApi.Common qualified as Plutus
 import PlutusLedgerApi.V1.Orphans ()
 import Prettyprinter (Pretty)
-import Test.QuickCheck (Arbitrary, Positive (getPositive))
+import Test.QuickCheck (Arbitrary)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (QuickCheckTests)
 import Type.Reflection (Typeable, tyConName, typeRep, typeRepTyCon)
@@ -89,33 +82,13 @@ checkLedgerPropertiesPCountable ::
   ( Typeable a
   , PCountable a
   , Arbitrary (PLifted a)
+  , Pretty (PLifted a)
   , Eq (PLifted a)
   , Show (PLifted a)
   , PUnsafeLiftDecl a
   ) =>
   TestTree
 checkLedgerPropertiesPCountable = testGroup (typeName @(S -> Type) @a) (pcountableLaws @a)
-
-checkLedgerPropertiesPCountableVia ::
-  forall (input :: Type) (output :: Type) (plutarch :: S -> Type).
-  ( Typeable plutarch
-  , PCountable plutarch
-  , Arbitrary input
-  , Show input
-  , Eq output
-  , Show output
-  ) =>
-  (input -> ClosedTerm plutarch) ->
-  (ClosedTerm plutarch -> output) ->
-  TestTree
-checkLedgerPropertiesPCountableVia mkInput mkOutput =
-  testGroup (typeName @(S -> Type) @plutarch) (pcountableLawsVia mkInput mkOutput)
-
-toPPositive :: Positive Integer -> ClosedTerm PPositive
-toPPositive = pfromInteger . getPositive
-
-fromPPositive :: ClosedTerm PPositive -> Integer
-fromPPositive t = plift $ pto t
 
 checkLedgerPropertiesPEnumerable ::
   forall (a :: S -> Type).

--- a/plutarch-ledger-api/test/Utils.hs
+++ b/plutarch-ledger-api/test/Utils.hs
@@ -6,12 +6,14 @@ module Utils (
   checkLedgerPropertiesValue,
   checkLedgerPropertiesAssocMap,
   checkLedgerPropertiesPCountable,
+  checkLedgerPropertiesPEnumerable,
   fewerTests,
 ) where
 
 import Laws (
   lessThanEqPSuccessorLessThanOrEq,
   lessThanPSuccessorEqLessThanOrEq,
+  penumerableLaws,
   pisDataLaws,
   psuccessorNAdd,
   psuccessorNOneEqPSuccessor,
@@ -21,7 +23,7 @@ import Laws (
   ptryFromLawsValue,
   punsafeLiftDeclLaws,
  )
-import Plutarch.Enum (PCountable)
+import Plutarch.Enum (PCountable, PEnumerable)
 import Plutarch.LedgerApi.V1 qualified as PLA
 import Plutarch.Lift (PUnsafeLiftDecl (PLifted))
 import Plutarch.Prelude
@@ -99,6 +101,19 @@ checkLedgerPropertiesPCountable =
     , psuccessorNOneEqPSuccessor @a
     , psuccessorNAdd @a
     ]
+
+checkLedgerPropertiesPEnumerable ::
+  forall (a :: S -> Type).
+  ( Typeable a
+  , PEnumerable a
+  , Arbitrary (PLifted a)
+  , Pretty (PLifted a)
+  , Eq (PLifted a)
+  , Show (PLifted a)
+  , PUnsafeLiftDecl a
+  ) =>
+  TestTree
+checkLedgerPropertiesPEnumerable = testGroup (typeName @(S -> Type) @a) (penumerableLaws @a)
 
 fewerTests :: QuickCheckTests -> QuickCheckTests -> QuickCheckTests
 fewerTests divisor = (`quot` divisor)

--- a/plutarch-ledger-api/test/Utils.hs
+++ b/plutarch-ledger-api/test/Utils.hs
@@ -5,16 +5,23 @@ module Utils (
   checkLedgerProperties,
   checkLedgerPropertiesValue,
   checkLedgerPropertiesAssocMap,
+  checkLedgerPropertiesPCountable,
   fewerTests,
 ) where
 
 import Laws (
+  lessThanEqPSuccessorLessThanOrEq,
+  lessThanPSuccessorEqLessThanOrEq,
   pisDataLaws,
+  psuccessorNAdd,
+  psuccessorNOneEqPSuccessor,
+  psuccesssorNotEqSelf,
   ptryFromLaws,
   ptryFromLawsAssocMap,
   ptryFromLawsValue,
   punsafeLiftDeclLaws,
  )
+import Plutarch.Enum (PCountable)
 import Plutarch.LedgerApi.V1 qualified as PLA
 import Plutarch.Lift (PUnsafeLiftDecl (PLifted))
 import Plutarch.Prelude
@@ -70,6 +77,27 @@ checkLedgerPropertiesAssocMap =
     [ punsafeLiftDeclLaws @(PLA.PMap PLA.Unsorted PInteger PInteger) "PMap <-> AssocMap.Map"
     , pisDataLaws @(PLA.PMap PLA.Unsorted PInteger PInteger) "PMap"
     , ptryFromLawsAssocMap
+    ]
+
+checkLedgerPropertiesPCountable ::
+  forall (a :: S -> Type).
+  ( Typeable a
+  , PCountable a
+  , Arbitrary (PLifted a)
+  , Pretty (PLifted a)
+  , Eq (PLifted a)
+  , Show (PLifted a)
+  , PUnsafeLiftDecl a
+  ) =>
+  TestTree
+checkLedgerPropertiesPCountable =
+  testGroup
+    (typeName @(S -> Type) @a)
+    [ psuccesssorNotEqSelf @a
+    , lessThanEqPSuccessorLessThanOrEq @a
+    , lessThanPSuccessorEqLessThanOrEq @a
+    , psuccessorNOneEqPSuccessor @a
+    , psuccessorNAdd @a
     ]
 
 fewerTests :: QuickCheckTests -> QuickCheckTests -> QuickCheckTests

--- a/plutarch-ledger-api/test/Utils.hs
+++ b/plutarch-ledger-api/test/Utils.hs
@@ -1,17 +1,22 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
 
 module Utils (
   checkLedgerProperties,
   checkLedgerPropertiesValue,
   checkLedgerPropertiesAssocMap,
   checkLedgerPropertiesPCountable,
+  checkLedgerPropertiesPCountableVia,
   checkLedgerPropertiesPEnumerable,
+  fromPPositive,
+  toPPositive,
   fewerTests,
 ) where
 
 import Laws (
   pcountableLaws,
+  pcountableLawsVia,
   penumerableLaws,
   pisDataLaws,
   ptryFromLaws,
@@ -22,11 +27,13 @@ import Laws (
 import Plutarch.Enum (PCountable, PEnumerable)
 import Plutarch.LedgerApi.V1 qualified as PLA
 import Plutarch.Lift (PUnsafeLiftDecl (PLifted))
+import Plutarch.Num (PNum (pfromInteger))
+import Plutarch.Positive (PPositive)
 import Plutarch.Prelude
 import PlutusLedgerApi.Common qualified as Plutus
 import PlutusLedgerApi.V1.Orphans ()
 import Prettyprinter (Pretty)
-import Test.QuickCheck (Arbitrary)
+import Test.QuickCheck (Arbitrary, Positive (getPositive))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (QuickCheckTests)
 import Type.Reflection (Typeable, tyConName, typeRep, typeRepTyCon)
@@ -82,13 +89,33 @@ checkLedgerPropertiesPCountable ::
   ( Typeable a
   , PCountable a
   , Arbitrary (PLifted a)
-  , Pretty (PLifted a)
   , Eq (PLifted a)
   , Show (PLifted a)
   , PUnsafeLiftDecl a
   ) =>
   TestTree
 checkLedgerPropertiesPCountable = testGroup (typeName @(S -> Type) @a) (pcountableLaws @a)
+
+checkLedgerPropertiesPCountableVia ::
+  forall (input :: Type) (output :: Type) (plutarch :: S -> Type).
+  ( Typeable plutarch
+  , PCountable plutarch
+  , Arbitrary input
+  , Show input
+  , Eq output
+  , Show output
+  ) =>
+  (input -> ClosedTerm plutarch) ->
+  (ClosedTerm plutarch -> output) ->
+  TestTree
+checkLedgerPropertiesPCountableVia mkInput mkOutput =
+  testGroup (typeName @(S -> Type) @plutarch) (pcountableLawsVia mkInput mkOutput)
+
+toPPositive :: Positive Integer -> ClosedTerm PPositive
+toPPositive = pfromInteger . getPositive
+
+fromPPositive :: ClosedTerm PPositive -> Integer
+fromPPositive t = plift $ pto t
 
 checkLedgerPropertiesPEnumerable ::
   forall (a :: S -> Type).

--- a/plutarch-ledger-api/test/V1.hs
+++ b/plutarch-ledger-api/test/V1.hs
@@ -8,9 +8,12 @@ import Utils (
   checkLedgerProperties,
   checkLedgerPropertiesAssocMap,
   checkLedgerPropertiesPCountable,
+  checkLedgerPropertiesPCountableVia,
   checkLedgerPropertiesPEnumerable,
   checkLedgerPropertiesValue,
   fewerTests,
+  fromPPositive,
+  toPPositive,
  )
 
 tests :: TestTree
@@ -49,7 +52,7 @@ tests =
         "PCountable"
         [ checkLedgerPropertiesPCountable @PInteger
         , checkLedgerPropertiesPCountable @PLA.PPosixTime
-        -- , checkLedgerPropertiesPCountable @PPositive -- TODO: Figure out PLifted PPositive
+        , checkLedgerPropertiesPCountableVia toPPositive fromPPositive
         ]
     , testGroup
         "PEnumerable"

--- a/plutarch-ledger-api/test/V1.hs
+++ b/plutarch-ledger-api/test/V1.hs
@@ -1,11 +1,13 @@
 module V1 (tests) where
 
+import Plutarch.Integer (PInteger)
 import Plutarch.LedgerApi.V1 qualified as PLA
 import PlutusLedgerApi.V1.Orphans ()
 import Test.Tasty (TestTree, adjustOption, testGroup)
 import Utils (
   checkLedgerProperties,
   checkLedgerPropertiesAssocMap,
+  checkLedgerPropertiesPCountable,
   checkLedgerPropertiesValue,
   fewerTests,
  )
@@ -42,4 +44,10 @@ tests =
     , adjustOption (fewerTests 16) $ checkLedgerProperties @PLA.PTxInfo
     , checkLedgerPropertiesValue
     , checkLedgerPropertiesAssocMap
+    , testGroup
+        "PCountable"
+        [ checkLedgerPropertiesPCountable @PInteger
+        , checkLedgerPropertiesPCountable @PLA.PPosixTime
+        -- , checkLedgerPropertiesPCountable @PPositive -- TODO: Figure out PLifted PPositive
+        ]
     ]

--- a/plutarch-ledger-api/test/V1.hs
+++ b/plutarch-ledger-api/test/V1.hs
@@ -8,6 +8,7 @@ import Utils (
   checkLedgerProperties,
   checkLedgerPropertiesAssocMap,
   checkLedgerPropertiesPCountable,
+  checkLedgerPropertiesPEnumerable,
   checkLedgerPropertiesValue,
   fewerTests,
  )
@@ -49,5 +50,10 @@ tests =
         [ checkLedgerPropertiesPCountable @PInteger
         , checkLedgerPropertiesPCountable @PLA.PPosixTime
         -- , checkLedgerPropertiesPCountable @PPositive -- TODO: Figure out PLifted PPositive
+        ]
+    , testGroup
+        "PEnumerable"
+        [ checkLedgerPropertiesPEnumerable @PInteger
+        , checkLedgerPropertiesPEnumerable @PLA.PPosixTime
         ]
     ]

--- a/plutarch-ledger-api/test/V1.hs
+++ b/plutarch-ledger-api/test/V1.hs
@@ -8,12 +8,9 @@ import Utils (
   checkLedgerProperties,
   checkLedgerPropertiesAssocMap,
   checkLedgerPropertiesPCountable,
-  checkLedgerPropertiesPCountableVia,
   checkLedgerPropertiesPEnumerable,
   checkLedgerPropertiesValue,
   fewerTests,
-  fromPPositive,
-  toPPositive,
  )
 
 tests :: TestTree
@@ -52,7 +49,7 @@ tests =
         "PCountable"
         [ checkLedgerPropertiesPCountable @PInteger
         , checkLedgerPropertiesPCountable @PLA.PPosixTime
-        , checkLedgerPropertiesPCountableVia toPPositive fromPPositive
+        -- , checkLedgerPropertiesPCountable @PPositive -- TODO: Figure out PLifted PPositive
         ]
     , testGroup
         "PEnumerable"

--- a/plutarch-ledger-api/test/V1.hs
+++ b/plutarch-ledger-api/test/V1.hs
@@ -2,6 +2,7 @@ module V1 (tests) where
 
 import Plutarch.Integer (PInteger)
 import Plutarch.LedgerApi.V1 qualified as PLA
+import Plutarch.Positive (PPositive)
 import PlutusLedgerApi.V1.Orphans ()
 import Test.Tasty (TestTree, adjustOption, testGroup)
 import Utils (
@@ -49,7 +50,7 @@ tests =
         "PCountable"
         [ checkLedgerPropertiesPCountable @PInteger
         , checkLedgerPropertiesPCountable @PLA.PPosixTime
-        -- , checkLedgerPropertiesPCountable @PPositive -- TODO: Figure out PLifted PPositive
+        , checkLedgerPropertiesPCountable @PPositive
         ]
     , testGroup
         "PEnumerable"

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -145,6 +145,7 @@ library
     , plutus-ledger-api
     , plutus-tx
     , prettyprinter
+    , QuickCheck
     , random
     , sop-core
 


### PR DESCRIPTION
- Closes #723
- Fixes `ppredecessorN` for `PPosixTime`
- Adds `Positive`

I'm not 100% sure where `instance Arbitrary Positive` should be, I've added it to `Plutarch.Positive` module but that required adding a dependency on `QuickCheck`. 