### PR TITLE
Improve error message when accesing invalid field of `HRec`

### DIFF
--- a/Plutarch/DataRepr/Internal/HList/Utils.hs
+++ b/Plutarch/DataRepr/Internal/HList/Utils.hs
@@ -11,7 +11,7 @@ module Plutarch.DataRepr.Internal.HList.Utils (
 
 import Data.Kind (Type)
 import GHC.TypeLits (
-  ErrorMessage (Text),
+  ErrorMessage (Text, (:$$:), (:<>:)),
   Nat,
   Symbol,
   TypeError,
@@ -36,6 +36,11 @@ type family IndexList (n :: Nat) (l :: [k]) :: k where
 -- | Indexing list of labeled pairs by label
 type IndexLabel :: Symbol -> [(Symbol, Type)] -> Type
 type family IndexLabel name as where
+  IndexLabel name '[] =
+    TypeError
+      ( 'Text "Invalid field name `" ':<>: 'Text name ':<>: 'Text "`"
+          ':$$: 'Text "Consider adding it to `pletFields` list"
+      )
   IndexLabel name ('(name, a) ': _) = a
   IndexLabel name (_ ': as) = IndexLabel name as
 


### PR DESCRIPTION


After:
```
test/Plutarch/Test/Suite/Plutarch/Field.hs:82:54: error: [GHC-64725]
    • Invalid field name `foo`
      Consider adding it to `pletFields` list
    • In the second argument of ‘(#)’, namely ‘getField @"foo" y’
      In the first argument of ‘(#)’, namely
        ‘ppairDataBuiltin # getField @"foo" y’
      In the expression:
        ppairDataBuiltin # getField @"foo" y
          # getField @"stakingCredential" y
   |
82 | ppairDataBuiltin # getField @"foo" y # getField @"stakingCredential" y
   |                    ^^^^^^^^
```


Before:
```
test/Plutarch/Test/Suite/Plutarch/Field.hs:82:54: error: [GHC-18872]
    • Couldn't match type: Plutarch.DataRepr.Internal.HList.Utils.IndexLabel
                             "foo" ('[] @(ghc-prim-0.10.0:GHC.Types.Symbol, Type))
                     with: Term s (PAsData a0)
        arising from a use of ‘getField’
    • In the second argument of ‘(#)’, namely ‘getField @"foo" y’
      In the first argument of ‘(#)’, namely
        ‘ppairDataBuiltin # getField @"foo" y’
      In the expression:
        ppairDataBuiltin # getField @"foo" y
          # getField @"stakingCredential" y
    • Relevant bindings include
        y :: Plutarch.DataRepr.Internal.Field.HRecOf
               (PDataRecord
                  ((:)
                     @PLabeledType
                     ("credential"
                      := plutarch-ledger-api-3.2.1:Plutarch.LedgerApi.V1.Credential.PCredential)
                     ((:)
                        @PLabeledType
                        ("stakingCredential"
                         := Plutarch.LedgerApi.Utils.PMaybeData
                              plutarch-ledger-api-3.2.1:Plutarch.LedgerApi.V1.Credential.PStakingCredential)
                        ('[] @PLabeledType))))
               ((:)
                  @ghc-prim-0.10.0:GHC.Types.Symbol
                  "credential"
                  ((:)
                     @ghc-prim-0.10.0:GHC.Types.Symbol
                     "stakingCredential"
                     ('[] @ghc-prim-0.10.0:GHC.Types.Symbol)))
               s
          (bound at test/Plutarch/Test/Suite/Plutarch/Field.hs:81:96)
        addrFields :: Term
                        s
                        (PDataRecord
                           ((:)
                              @PLabeledType
                              ("credential"
                               := plutarch-ledger-api-3.2.1:Plutarch.LedgerApi.V1.Credential.PCredential)
                              ((:)
                                 @PLabeledType
                                 ("stakingCredential"
                                  := Plutarch.LedgerApi.Utils.PMaybeData
                                       plutarch-ledger-api-3.2.1:Plutarch.LedgerApi.V1.Credential.PStakingCredential)
                                 ('[] @PLabeledType))))
          (bound at test/Plutarch/Test/Suite/Plutarch/Field.hs:80:56)
   |
82 | ppairDataBuiltin # getField @"foo" y # getField @"stakingCredential" y
   |                    ^^^^^^^^
```
