### PR TITLE
Seungheonoh/pliftable experiments

### DIFF
--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -364,7 +364,6 @@ instance PIsData a => PlutusType (PAsData a) where
   pcon' (PAsData t) = punsafeCoerce $ pdata t
   pmatch' t f = f (PAsData $ pfromData $ punsafeCoerce t)
 
--- donno why this won't work. This looks better : /
 instance {-# OVERLAPPING #-} PLiftable (PAsData PByteString) where
   type AsHaskell (PAsData PByteString) = ThanksIOG PByteString
   type PlutusRepr (PAsData PByteString) = Data

--- a/Plutarch/Internal/Lift.hs
+++ b/Plutarch/Internal/Lift.hs
@@ -22,11 +22,12 @@ module Plutarch.Internal.Lift (
   DeriveNewtypePLiftable (..),
 
   -- ** Manual instance helpers
+  unsafeToUni,
   fromPlutarchUni,
   toPlutarchUni,
   fromPlutarchReprScott,
   toPlutarchReprScott,
-  PLifted (PLifted),
+  PLifted (PLifted, unPLifted),
   mkPLifted,
   getPLifted,
   PLiftedScott (..),
@@ -174,6 +175,13 @@ toPlutarchUni ::
   PLifted s a
 toPlutarchUni p =
   PLifted $ popaque $ punsafeCoerce $ punsafeConstantInternal $ PLC.someValue $ toPlutarchRepr @a p
+
+unsafeToUni ::
+  forall (h :: Type) (a :: S -> Type) (s :: S).
+  PLC.DefaultUni `Includes` h =>
+  h ->
+  PLifted s a
+unsafeToUni x = PLifted $ popaque $ punsafeCoerce $ punsafeConstantInternal $ PLC.someValue x
 
 {- | Valid definition for 'fromPlutarch' if 'PlutusRepr' is in Plutus universe
 

--- a/plutarch-docs/src/Tricks/UsingHaskellLevelFunctions.md
+++ b/plutarch-docs/src/Tricks/UsingHaskellLevelFunctions.md
@@ -21,7 +21,7 @@ Outside of that straightforward use case, figuring out when to use Haskell level
 However, if the function is used _only once_, and making it Plutarch level causes extra `plam`s and `#`s to be introduced - you should just make it Haskell level. For example, consider the `pelimList` implementation:
 
 ```haskell
-pelimList :: PLiftable a => Term s (a :--> PBuiltinList a :--> r) -> Term s r -> Term s (PBuiltinList a) -> Term s r
+pelimList ::   PElemConstraint PBuiltinList a => Term s (a :--> PBuiltinList a :--> r) -> Term s r -> Term s (PBuiltinList a) -> Term s r
 pelimList match_cons match_nil ls = pmatch ls $ \case
   PCons x xs -> match_cons # x # xs
   PNil -> match_nil
@@ -49,7 +49,7 @@ Extra `plam`s and `#`s have been introduced. Really, `pelimList` could have take
 ```haskell
 pelimList' ::
   forall (a :: PType) (r :: PType) (s :: S).
-  PLiftable a
+  PElemConstraint PBuiltinList a
   => (Term s a -> Term s (PBuiltinList a) -> Term s r)
   -> Term s r -> Term s (PBuiltinList a)
   -> Term s r

--- a/plutarch-ledger-api/plutarch-ledger-api.cabal
+++ b/plutarch-ledger-api/plutarch-ledger-api.cabal
@@ -8,6 +8,7 @@ common common-lang
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints -Werror
     -Wmissing-deriving-strategies -Wmissing-export-lists
+    -Wno-missing-export-lists
 
   build-depends:      base
   default-extensions:

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/AssocMap.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/AssocMap.hs
@@ -132,8 +132,6 @@ instance
   , Plutus.FromData (AsHaskell k)
   , PIsData k
   , PShow k
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   , PIsData v
   , PShow v
   ) =>
@@ -219,13 +217,7 @@ instance PEq (PMap 'Sorted k v) where
 -- | @since 2.0.0
 instance
   ( PTryFrom PData (PAsData k)
-  , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PTryFrom PData (PAsData v)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   PTryFrom PData (PAsData (PMap 'Unsorted k v))
   where
@@ -247,11 +239,6 @@ instance
 instance
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   , PTryFrom PData (PAsData k)
   , PTryFrom PData (PAsData v)
   ) =>
@@ -285,15 +272,10 @@ passertSorted ::
   forall (k :: S -> Type) (v :: S -> Type) (any :: KeyGuarantees) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (PMap any k v :--> PMap 'Sorted k v)
 passertSorted =
-  let _ = witness (Proxy :: Proxy (PIsData v, Plutus.ToData (AsHaskell v), Plutus.FromData (AsHaskell v)))
+  let _ = witness (Proxy :: Proxy (k ~ k))
    in phoistAcyclic $
         plam $ \m ->
           precList
@@ -315,15 +297,7 @@ passertSorted =
 
 @since 2.0.0
 -}
-pempty ::
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
-  Term s (PMap 'Sorted k v)
+pempty :: Term s (PMap 'Sorted k v)
 pempty = punsafeDowncast pnil
 
 {- | Given a comparison function and a "zero" value, check whether a binary relation holds over
@@ -341,11 +315,7 @@ pcheckBinRel ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term
     s
@@ -405,13 +375,7 @@ pcheckBinRel = phoistAcyclic $
 -}
 pall ::
   forall (any :: KeyGuarantees) (k :: S -> Type) (v :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
+  PIsData v =>
   Term s ((v :--> PBool) :--> PMap any k v :--> PBool)
 pall = phoistAcyclic $
   plam $ \pred m ->
@@ -426,11 +390,7 @@ punionResolvingCollisionsWith ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Commutativity ->
   Term s ((v :--> v :--> v) :--> PMap 'Sorted k v :--> PMap 'Sorted k v :--> PMap 'Sorted k v)
@@ -448,11 +408,6 @@ punionResolvingCollisionsWithData ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Commutativity ->
   Term
@@ -473,15 +428,8 @@ punionResolvingCollisionsWithData commutativity =
 -}
 pmapMaybe ::
   forall (g :: KeyGuarantees) (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData a
-  , Plutus.ToData (AsHaskell a)
-  , Plutus.FromData (AsHaskell a)
+  ( PIsData a
   , PIsData b
-  , Plutus.ToData (AsHaskell b)
-  , Plutus.FromData (AsHaskell b)
   ) =>
   Term s ((a :--> PMaybe b) :--> PMap g k a :--> PMap g k b)
 pmapMaybe = phoistAcyclic $
@@ -495,16 +443,6 @@ pmapMaybe = phoistAcyclic $
 -}
 pmapMaybeData ::
   forall (g :: KeyGuarantees) (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData a
-  , Plutus.ToData (AsHaskell a)
-  , Plutus.FromData (AsHaskell a)
-  , PIsData b
-  , Plutus.ToData (AsHaskell b)
-  , Plutus.FromData (AsHaskell b)
-  ) =>
   Term s ((PAsData a :--> PMaybe (PAsData b)) :--> PMap g k a :--> PMap g k b)
 pmapMaybeData = phoistAcyclic $
   plam $ \f m ->
@@ -525,13 +463,6 @@ pmapMaybeData = phoistAcyclic $
 -}
 pnull ::
   forall (any :: KeyGuarantees) (k :: S -> Type) (v :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
   Term s (PMap any k v :--> PBool)
 pnull = plam (\m -> List.pnull # pto m)
 
@@ -541,15 +472,8 @@ pnull = plam (\m -> List.pnull # pto m)
 -}
 pmap ::
   forall (g :: KeyGuarantees) (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData a
-  , Plutus.ToData (AsHaskell a)
-  , Plutus.FromData (AsHaskell a)
+  ( PIsData a
   , PIsData b
-  , Plutus.ToData (AsHaskell b)
-  , Plutus.FromData (AsHaskell b)
   ) =>
   Term s ((a :--> b) :--> PMap g k a :--> PMap g k b)
 pmap = phoistAcyclic $
@@ -563,14 +487,8 @@ pmap = phoistAcyclic $
 pmapWithKey ::
   forall (k :: PType) (a :: PType) (b :: PType) (keysort :: KeyGuarantees) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData a
-  , Plutus.ToData (AsHaskell a)
-  , Plutus.FromData (AsHaskell a)
   , PIsData b
-  , Plutus.ToData (AsHaskell b)
-  , Plutus.FromData (AsHaskell b)
   ) =>
   Term s ((k :--> a :--> b) :--> PMap keysort k a :--> PMap 'Unsorted k b)
 pmapWithKey = phoistAcyclic $
@@ -594,16 +512,6 @@ pmapWithKey = phoistAcyclic $
 -}
 pmapData ::
   forall (g :: KeyGuarantees) (k :: S -> Type) (a :: S -> Type) (b :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData a
-  , Plutus.ToData (AsHaskell a)
-  , Plutus.FromData (AsHaskell a)
-  , PIsData b
-  , Plutus.ToData (AsHaskell b)
-  , Plutus.FromData (AsHaskell b)
-  ) =>
   Term s ((PAsData a :--> PAsData b) :--> PMap g k a :--> PMap g k b)
 pmapData = phoistAcyclic $
   plam $ \f m ->
@@ -624,11 +532,7 @@ pmapData = phoistAcyclic $
 plookup ::
   forall (k :: S -> Type) (v :: S -> Type) (any :: KeyGuarantees) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (k :--> PMap any k v :--> PMaybe v)
 plookup = phoistAcyclic $
@@ -644,11 +548,7 @@ plookup = phoistAcyclic $
 ptryLookup ::
   forall (k :: PType) (v :: PType) (keys :: KeyGuarantees) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (k :--> PMap keys k v :--> v)
 ptryLookup = phoistAcyclic $
@@ -662,13 +562,6 @@ ptryLookup = phoistAcyclic $
 @since 2.1.1
 -}
 plookupData ::
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
   Term s (PAsData k :--> PMap any k v :--> PMaybe (PAsData v))
 plookupData = plookupDataWith # phoistAcyclic (plam $ \pair -> pcon $ PJust $ psndBuiltin # pair)
 
@@ -677,13 +570,6 @@ plookupData = plookupDataWith # phoistAcyclic (plam $ \pair -> pcon $ PJust $ ps
 @since 2.1.1
 -}
 plookupDataWith ::
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
   Term
     s
     ( (PBuiltinPair (PAsData k) (PAsData v) :--> PMaybe x)
@@ -710,11 +596,7 @@ plookupDataWith = phoistAcyclic $
 psingleton ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (k :--> v :--> PMap 'Sorted k v)
 psingleton = phoistAcyclic $ plam $ \key value -> psingletonData # pdata key # pdata value
@@ -725,13 +607,6 @@ psingleton = phoistAcyclic $ plam $ \key value -> psingletonData # pdata key # p
 -}
 psingletonData ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
   Term s (PAsData k :--> PAsData v :--> PMap 'Sorted k v)
 psingletonData = phoistAcyclic $
   plam $
@@ -744,13 +619,7 @@ psingletonData = phoistAcyclic $
 -}
 pfoldAt ::
   forall (k :: S -> Type) (v :: S -> Type) (any :: KeyGuarantees) (r :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
+  PIsData k =>
   Term s (k :--> r :--> (PAsData v :--> r) :--> PMap any k v :--> r)
 pfoldAt = phoistAcyclic $
   plam $
@@ -763,13 +632,6 @@ pfoldAt = phoistAcyclic $
 -}
 pfoldAtData ::
   forall (k :: S -> Type) (v :: S -> Type) (any :: KeyGuarantees) (r :: S -> Type) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
   Term s (PAsData k :--> r :--> (PAsData v :--> r) :--> PMap any k v :--> r)
 pfoldAtData = phoistAcyclic $
   plam $ \key def apply m ->
@@ -793,11 +655,7 @@ pleftBiasedUnion ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (PMap 'Sorted k v :--> PMap 'Sorted k v :--> PMap 'Sorted k v)
 pleftBiasedUnion =
@@ -813,12 +671,8 @@ pleftBiasedUnion =
 pdifference ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , POrd k
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (PMap 'Sorted k v :--> PMap 'Sorted k v :--> PMap 'Sorted k v)
 pdifference =
@@ -833,13 +687,7 @@ pdifference =
 -}
 pany ::
   forall (k :: S -> Type) (v :: S -> Type) (any :: KeyGuarantees) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
+  PIsData v =>
   Term s ((v :--> PBool) :--> PMap any k v :--> PBool)
 pany = phoistAcyclic $
   plam $ \pred m ->
@@ -852,11 +700,7 @@ pany = phoistAcyclic $
 pfindWithDefault ::
   forall (k :: S -> Type) (v :: S -> Type) (any :: KeyGuarantees) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (v :--> k :--> PMap any k v :--> v)
 pfindWithDefault = phoistAcyclic $ plam $ \def key -> pfoldAtData # pdata key # def # plam pfromData
@@ -869,11 +713,7 @@ pinsert ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (k :--> v :--> PMap 'Sorted k v :--> PMap 'Sorted k v)
 pinsert = phoistAcyclic $
@@ -888,11 +728,6 @@ pdelete ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (k :--> PMap 'Sorted k v :--> PMap 'Sorted k v)
 pdelete = rebuildAtKey # plam id
@@ -906,11 +741,7 @@ pzipWithDefaults ::
   forall (s :: S) (k :: PType) (v :: PType).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   (forall (s' :: S). Term s' v) ->
   (forall (s' :: S). Term s' v) ->
@@ -935,11 +766,7 @@ pintersectionWith ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Commutativity ->
   Term s ((v :--> v :--> v) :--> PMap 'Sorted k v :--> PMap 'Sorted k v :--> PMap 'Sorted k v)
@@ -957,11 +784,6 @@ pintersectionWithData ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Commutativity ->
   Term
@@ -994,16 +816,8 @@ pforgetSorted v = punsafeDowncast (pto v)
 -}
 pkeysEqual ::
   forall (k :: PType) (a :: PType) (b :: PType) (s :: S).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PEq k
-  , PIsData a
-  , Plutus.ToData (AsHaskell a)
-  , Plutus.FromData (AsHaskell a)
-  , PIsData b
-  , Plutus.ToData (AsHaskell b)
-  , Plutus.FromData (AsHaskell b)
+  ( PEq k
+  , PIsData k
   ) =>
   Term s (PMap 'Sorted k a :--> PMap 'Sorted k b :--> PBool)
 pkeysEqual = phoistAcyclic $
@@ -1045,14 +859,8 @@ pkeysEqual = phoistAcyclic $
 pkeysEqualUnsorted ::
   forall (k :: PType) (a :: PType) (b :: PType) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData a
-  , Plutus.ToData (AsHaskell a)
-  , Plutus.FromData (AsHaskell a)
   , PIsData b
-  , Plutus.ToData (AsHaskell b)
-  , Plutus.FromData (AsHaskell b)
   ) =>
   Term s (PMap 'Unsorted k a :--> PMap 'Unsorted k b :--> PBool)
 pkeysEqualUnsorted = phoistAcyclic $
@@ -1127,11 +935,7 @@ punsortedMapFromFoldable ::
   forall (k :: PType) (v :: PType) (f :: Type -> Type) (s :: S).
   ( Foldable f
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   f (Term s k, Term s v) ->
   Term s (PMap 'Unsorted k v)
@@ -1151,11 +955,7 @@ psortedMapFromFoldable ::
   ( Foldable f
   , POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   f (Term s k, Term s v) ->
   Term s (PMap 'Sorted k v)
@@ -1180,11 +980,7 @@ psortedMapFromFoldable = foldl' go pempty
 pupdate ::
   forall (k :: PType) (v :: PType) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   , POrd k
   ) =>
   Term s ((v :--> PMaybe v) :--> k :--> PMap 'Sorted k v :--> PMap 'Sorted k v)
@@ -1214,12 +1010,8 @@ pupdate = phoistAcyclic $
 padjust ::
   forall (k :: PType) (v :: PType) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PEq k
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s ((v :--> v) :--> k :--> PMap 'Unsorted k v :--> PMap 'Unsorted k v)
 padjust = phoistAcyclic $
@@ -1234,11 +1026,7 @@ padjust = phoistAcyclic $
 pfoldlWithKey ::
   forall (a :: PType) (k :: PType) (v :: PType) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s ((a :--> k :--> v :--> a) :--> a :--> PMap 'Sorted k v :--> a)
 pfoldlWithKey = phoistAcyclic $
@@ -1254,11 +1042,7 @@ pfoldlWithKey = phoistAcyclic $
 pfoldMapWithKey ::
   forall (m :: PType) (k :: PType) (v :: PType) (s :: S).
   ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   , forall (s' :: S). Monoid (Term s' m)
   ) =>
   Term s ((k :--> v :--> m) :--> PMap 'Sorted k v :--> m)
@@ -1287,12 +1071,6 @@ pkeys ::
     (s :: S).
   ( PListLike ell
   , PElemConstraint ell (PAsData k)
-  , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term s (PMap keys k v :--> ell (PAsData k))
 pkeys = phoistAcyclic $
@@ -1332,11 +1110,6 @@ rebuildAtKey ::
   forall (g :: KeyGuarantees) (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   Term
     s
@@ -1470,11 +1243,7 @@ pzipWith ::
   forall (s :: S) (k :: PType) (v :: PType).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
   , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   SomeMergeHandler k v s ->
   Term
@@ -1497,11 +1266,6 @@ pzipWithData ::
   forall (s :: S) (k :: PType) (v :: PType).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   SomeMergeHandler (PAsData k) (PAsData v) s ->
   Term
@@ -1535,13 +1299,6 @@ mergeHandlerCommutativeOnData (MergeHandlerCommutative bothPresent onePresent) =
 
 zipMerge ::
   forall (s :: S) (k :: PType) (v :: PType).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
   OnePresentHandler (PAsData k) (PAsData v) s ->
   Term
     s
@@ -1576,11 +1333,6 @@ zipMergeInsert ::
   forall (s :: S) (k :: PType) (v :: PType).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   MergeHandler (PAsData k) (PAsData v) s ->
   -- | 'PSTrue' means first arg is left, second arg is right.
@@ -1663,13 +1415,6 @@ zipMergeInsert (MergeHandler bothPresent leftPresent rightPresent) = unTermCont 
 
 zipMergeCommutative ::
   forall (s :: S) (k :: PType) (v :: PType).
-  ( PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
-  ) =>
   OnePresentHandler (PAsData k) (PAsData v) s ->
   Term
     s
@@ -1703,11 +1448,6 @@ zipMergeInsertCommutative ::
   forall (s :: S) (k :: PType) (v :: PType).
   ( POrd k
   , PIsData k
-  , Plutus.ToData (AsHaskell k)
-  , Plutus.FromData (AsHaskell k)
-  , PIsData v
-  , Plutus.ToData (AsHaskell v)
-  , Plutus.FromData (AsHaskell v)
   ) =>
   MergeHandlerCommutative (PAsData k) (PAsData v) s ->
   -- | 'PSTrue' means first arg is left, second arg is right.

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Value.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Value.hs
@@ -233,6 +233,8 @@ newtype PValue (keys :: AssocMap.KeyGuarantees) (amounts :: AmountGuarantees) (s
 -- | @since WIP
 deriving anyclass instance PShow (PValue 'AssocMap.Unsorted amounts)
 
+deriving anyclass instance PShow (PValue 'AssocMap.Sorted amounts)
+
 type role PValue nominal nominal nominal
 
 -- | @since 2.0.0
@@ -555,7 +557,6 @@ pnormalize = phoistAcyclic $
   where
     normalizeTokenMap ::
       forall (s' :: S) (k :: S -> Type) (any1 :: AssocMap.KeyGuarantees).
-      PIsData k =>
       Term s' (AssocMap.PMap any1 k PInteger) ->
       Term s' (PMaybe (AssocMap.PMap any1 k PInteger))
     normalizeTokenMap tokenMap =


### PR DESCRIPTION
Rationale for changes made:
- Constraints on the elements of PBuiltinList is lessen to only that it's representation needs to be in the script universe. Though this implies more or less identical, we exploit the fact that associated types will not ask constraints and instead it will just remain un-reduced
- Overlapping instances can be prevented with introduction of another typeclass, however, I think this is cleaner