### PR TITLE
Remove PPartialOrd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## Added
 
-* `pmax` and `pmin` as new methods of `POrd`
-* `#>` and `#>=` as new methods of `PPartialOrd`
+* `#>=`, `pmax` and `pmin` as new methods of `POrd`
+* `#>` as an argument-flipping version of `#<`
 * `pallBS` to `Plutarch.ByteString` (originally from `plutarch-extra`)
 * `pisHexDigit` to `Plutarch.String` (originally from `plutarch-extra`)
 * `preverse` and `pcheckSorted` to `Plutarch.List` (originally from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## Added
 
-* `#>=`, `pmax` and `pmin` as new methods of `POrd`
-* `#>` as an argument-flipping version of `#<`
+* `pmax` and `pmin` as new methods of `POrd`
+* `#>` and `#>=` as argument-flipping versions of `#<` and `#<=`
 * `pallBS` to `Plutarch.ByteString` (originally from `plutarch-extra`)
 * `pisHexDigit` to `Plutarch.String` (originally from `plutarch-extra`)
 * `preverse` and `pcheckSorted` to `Plutarch.List` (originally from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 * `Plutarch.Num` is now `Plutarch.Internal.Numeric`
 * `PIntegral` type class is now in `Plutarch.Internal.Numeric`
 * `Plutarch.Integer` is now `Plutarch.Builtin.Integer`
+* `#<`, `#<=`, `#>=`, `#>` are now part of `POrd`
 
 ## Removed
 
@@ -72,6 +73,7 @@
 * `PSBool` and functionality (now in `plutarch-ledger-api`)
 * `PFractional` type class (only one instance, unlikely to ever have more)
 * `PIsData PRational` instance (made no sense)
+* `PPartialOrd` (all its functionality is now in `POrd`)
 
 ### Fixed
 

--- a/Plutarch/BitString.hs
+++ b/Plutarch/BitString.hs
@@ -19,7 +19,7 @@ import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.ByteString (PByteString)
 import Plutarch.Internal.Eq (PEq)
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
-import Plutarch.Internal.Ord (POrd, PPartialOrd ((#<)))
+import Plutarch.Internal.Ord (POrd ((#<)))
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -60,8 +60,6 @@ newtype PBitString (s :: S) = PBitString (Term s PByteString)
       PlutusType
     , -- | @since WIP
       PEq
-    , -- | @since WIP
-      PPartialOrd
     , -- | @since WIP
       POrd
     )

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -50,7 +50,7 @@ import Plutarch.Internal.Lift (
   unsafeToUni,
  )
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
-import Plutarch.Internal.Ord (POrd, PPartialOrd ((#<), (#<=)))
+import Plutarch.Internal.Ord (POrd ((#<), (#<=), (#>=)))
 import Plutarch.Internal.Other (POpaque, pfix, pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -663,18 +663,22 @@ instance PEq (PDataNewtype a) where
   a #== b = pto a #== pto b
 
 -- | @since 1.7.0
-instance (PIsData a, PPartialOrd a) => PPartialOrd (PDataNewtype a) where
+instance (PIsData a, POrd a) => POrd (PDataNewtype a) where
+  {-# INLINEABLE (#<=) #-}
   a #<= b =
-    pmatch a \(PDataNewtype a') ->
-      pmatch b \(PDataNewtype b') ->
+    pmatch a $ \(PDataNewtype a') ->
+      pmatch b $ \(PDataNewtype b') ->
         pfromData a' #<= pfromData b'
+  {-# INLINEABLE (#<) #-}
   a #< b =
-    pmatch a \(PDataNewtype a') ->
-      pmatch b \(PDataNewtype b') ->
+    pmatch a $ \(PDataNewtype a') ->
+      pmatch b $ \(PDataNewtype b') ->
         pfromData a' #< pfromData b'
-
--- | @since 1.7.0
-instance (PIsData a, PPartialOrd a) => POrd (PDataNewtype a)
+  {-# INLINEABLE (#>=) #-}
+  a #>= b =
+    pmatch a $ \(PDataNewtype a') ->
+      pmatch b $ \(PDataNewtype b') ->
+        pfromData a' #>= pfromData b'
 
 -- | @since 1.7.0
 instance (PIsData a, PShow a) => PShow (PDataNewtype a) where

--- a/Plutarch/Builtin.hs
+++ b/Plutarch/Builtin.hs
@@ -50,7 +50,7 @@ import Plutarch.Internal.Lift (
   unsafeToUni,
  )
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
-import Plutarch.Internal.Ord (POrd ((#<), (#<=), (#>=)))
+import Plutarch.Internal.Ord (POrd ((#<), (#<=)))
 import Plutarch.Internal.Other (POpaque, pfix, pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -674,11 +674,6 @@ instance (PIsData a, POrd a) => POrd (PDataNewtype a) where
     pmatch a $ \(PDataNewtype a') ->
       pmatch b $ \(PDataNewtype b') ->
         pfromData a' #< pfromData b'
-  {-# INLINEABLE (#>=) #-}
-  a #>= b =
-    pmatch a $ \(PDataNewtype a') ->
-      pmatch b $ \(PDataNewtype b') ->
-        pfromData a' #>= pfromData b'
 
 -- | @since 1.7.0
 instance (PIsData a, PShow a) => PShow (PDataNewtype a) where

--- a/Plutarch/ByteString.hs
+++ b/Plutarch/ByteString.hs
@@ -56,7 +56,7 @@ import Plutarch.Internal.Lift (
  )
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Numeric ()
-import Plutarch.Internal.Ord (POrd, PPartialOrd ((#<), (#<=)))
+import Plutarch.Internal.Ord (POrd ((#<), (#<=)))
 import Plutarch.Internal.Other (POpaque, pfix)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -95,11 +95,12 @@ deriving via
 instance PEq PByteString where
   x #== y = punsafeBuiltin PLC.EqualsByteString # x # y
 
-instance PPartialOrd PByteString where
+-- | @since WIP
+instance POrd PByteString where
+  {-# INLINEABLE (#<=) #-}
   x #<= y = punsafeBuiltin PLC.LessThanEqualsByteString # x # y
+  {-# INLINEABLE (#<) #-}
   x #< y = punsafeBuiltin PLC.LessThanByteString # x # y
-
-instance POrd PByteString
 
 instance Semigroup (Term s PByteString) where
   x <> y = punsafeBuiltin PLC.AppendByteString # x # y
@@ -155,14 +156,11 @@ instance PEq PByte where
   x #== y = punsafeBuiltin PLC.EqualsInteger # x # y
 
 -- | @since WIP
-instance PPartialOrd PByte where
+instance POrd PByte where
   {-# INLINEABLE (#<=) #-}
   x #<= y = punsafeBuiltin PLC.LessThanEqualsInteger # x # y
   {-# INLINEABLE (#<) #-}
   x #< y = punsafeBuiltin PLC.LessThanInteger # x # y
-
--- | @since WIP
-instance POrd PByte
 
 {- | Type designating whether logical operations should use padding or
 truncation semantics. See
@@ -181,8 +179,6 @@ newtype PLogicOpSemantics (s :: S) = PLogicOpSemantics (Term s PBool)
       PlutusType
     , -- | @since WIP
       PEq
-    , -- | @since WIP
-      PPartialOrd
     , -- | @since WIP
       POrd
     )

--- a/Plutarch/Convert.hs
+++ b/Plutarch/Convert.hs
@@ -20,7 +20,7 @@ import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.ByteString (PByteString)
 import Plutarch.Internal.Eq (PEq)
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
-import Plutarch.Internal.Ord (POrd, PPartialOrd)
+import Plutarch.Internal.Ord (POrd)
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -51,8 +51,6 @@ newtype PEndianness (s :: S) = PEndianness (Term s PBool)
       PlutusType
     , -- | @since WIP
       PEq
-    , -- | @since WIP
-      PPartialOrd
     , -- | @since WIP
       POrd
     )

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -82,7 +82,7 @@ import Plutarch.Internal.Eq (PEq ((#==)))
 import Plutarch.Internal.Generic (PCode, PGeneric, gpfrom, gpto)
 import Plutarch.Internal.Lift (pconstant)
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
-import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=), (#>=)))
+import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=)))
 import Plutarch.Internal.Other (POpaque, popaque, pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -177,8 +177,6 @@ instance POrd (PDataRecord '[]) where
   _ #<= _ = pconstant True
   {-# INLINEABLE (#<) #-}
   _ #< _ = pconstant False
-  {-# INLINEABLE (#>=) #-}
-  (#>=) = (#<=)
   {-# INLINEABLE pmin #-}
   pmin t _ = t
   {-# INLINEABLE pmax #-}

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -61,7 +61,7 @@ import Plutarch.Internal.Lift (
   pconstant,
   toPlutarchReprClosed,
  )
-import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=), (#>=)))
+import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=)))
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -171,14 +171,6 @@ instance
     PDRight t1' -> pmatch t2 $ \case
       PDLeft _ -> pcon PFalse
       PDRight t2' -> pfromData t1' #< pfromData t2'
-  {-# INLINEABLE (#>=) #-}
-  t1 #>= t2 = pmatch t1 $ \case
-    PDLeft t1' -> pmatch t2 $ \case
-      PDLeft t2' -> pfromData t1' #>= pfromData t2'
-      PDRight _ -> pcon PFalse
-    PDRight t1' -> pmatch t2 $ \case
-      PDLeft _ -> pcon PTrue
-      PDRight t2' -> pfromData t1' #>= pfromData t2'
   {-# INLINEABLE pmax #-}
   pmax t1 t2 = pmatch t1 $ \case
     PDLeft t1' -> pmatch t2 $ \case

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -37,7 +37,11 @@ import Plutarch.Builtin (
   pfstBuiltin,
   psndBuiltin,
  )
-import Plutarch.Builtin.Bool (PBool (PFalse, PTrue), pif)
+import Plutarch.Builtin.Bool (
+  PBool (PFalse, PTrue),
+  pif,
+  pif',
+ )
 import Plutarch.Internal.Eq (PEq ((#==)))
 import Plutarch.Internal.Lift (
   DeriveDataPLiftable,
@@ -57,7 +61,7 @@ import Plutarch.Internal.Lift (
   pconstant,
   toPlutarchReprClosed,
  )
-import Plutarch.Internal.Ord (POrd, PPartialOrd ((#<), (#<=)))
+import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=), (#>=)))
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -144,14 +148,12 @@ data PEitherData (a :: S -> Type) (b :: S -> Type) (s :: S)
       PEq
     , -- | @since WIP
       PShow
-    , -- | @since WIP
-      POrd
     )
 
 -- | @since WIP
 instance
-  (PPartialOrd a, PPartialOrd b, PIsData a, PIsData b) =>
-  PPartialOrd (PEitherData a b)
+  (POrd a, POrd b, PIsData a, PIsData b) =>
+  POrd (PEitherData a b)
   where
   {-# INLINEABLE (#<=) #-}
   t1 #<= t2 = pmatch t1 $ \case
@@ -169,6 +171,30 @@ instance
     PDRight t1' -> pmatch t2 $ \case
       PDLeft _ -> pcon PFalse
       PDRight t2' -> pfromData t1' #< pfromData t2'
+  {-# INLINEABLE (#>=) #-}
+  t1 #>= t2 = pmatch t1 $ \case
+    PDLeft t1' -> pmatch t2 $ \case
+      PDLeft t2' -> pfromData t1' #>= pfromData t2'
+      PDRight _ -> pcon PFalse
+    PDRight t1' -> pmatch t2 $ \case
+      PDLeft _ -> pcon PTrue
+      PDRight t2' -> pfromData t1' #>= pfromData t2'
+  {-# INLINEABLE pmax #-}
+  pmax t1 t2 = pmatch t1 $ \case
+    PDLeft t1' -> pmatch t2 $ \case
+      PDLeft t2' -> pif' # (pfromData t1' #< pfromData t2') # t2 # t1
+      PDRight _ -> t2
+    PDRight t1' -> pmatch t2 $ \case
+      PDLeft _ -> t1
+      PDRight t2' -> pif' # (pfromData t1' #< pfromData t2') # t2 # t1
+  {-# INLINEABLE pmin #-}
+  pmin t1 t2 = pmatch t1 $ \case
+    PDLeft t1' -> pmatch t2 $ \case
+      PDLeft t2' -> pif' # (pfromData t1' #< pfromData t2') # t1 # t2
+      PDRight _ -> t1
+    PDRight t1' -> pmatch t2 $ \case
+      PDLeft _ -> t2
+      PDRight t2' -> pif' # (pfromData t1' #< pfromData t2') # t1 # t2
 
 -- | @since WIP
 instance PlutusType (PEitherData a b) where

--- a/Plutarch/Internal/Ord.hs
+++ b/Plutarch/Internal/Ord.hs
@@ -1,9 +1,8 @@
 module Plutarch.Internal.Ord (
-  PPartialOrd (..),
   POrd (..),
 ) where
 
-import Plutarch.Builtin.Bool (PBool, pif', pnot)
+import Plutarch.Builtin.Bool (PBool, pand', pif', pnot, por')
 import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.Internal.Eq (PEq)
 import Plutarch.Internal.Lift (pconstant)
@@ -18,98 +17,92 @@ import Plutarch.Internal.Term (
  )
 import PlutusCore qualified as PLC
 
-{- | Partial ordering relation.
+{- | Total ordering relation.
 
 = Laws
 
-'#<=' must form a partial order. More precisely:
+'#<=' must form a total order. More precisely:
 
-1. @x #<= x@ @=@ @True@ (@#<=@ is reflexive)
-2. @(x #<= y) #&& (y #<= x)@ @=@ @x #== y@ (@#<=@ is anti-symmetric)
-3. @(x #<= y) #&& (y #<= z)@ @=@ @x #<= z@ (@#<= is transitive)
+1. @x #<= x@ @=@ @pcon PTrue@ (reflexivity)
+2. @(x #<= y) #&& (y #<= z)@ @=@ @x #<= z@ (transitivity)
+3. @(x #<= y) #|| (y #<= x)@ @=@ @pcon PTrue@ (totality)
 
-Furthermore, '#<' must be an equivalent strict partial order to '#<=':
+Furthermore, '#<' must be an equivalent strict total order to '#<=':
 
-4. @x #<= y@ @=@ @(x #< y) #|| (x #== y)@
-5. @x #< x@ @=@ @False@ (@#<@ is irreflexive)
-6. @x #< y@ @=@ @pnot (y #< x)@ (@#<@ is asymmetric)
-7. @(x #< y) #&& (y #< z)@ @=@ @x #< z@ (@#<@ is transitive)
+4. @x #< x@ @=@ @pcon PFalse@ (irreflexivity)
+5. @(x #< y) #&& (y #< z)@ @=@ @x #< z@ (transitivity)
+6. @(x #< y) #|| (y #< x) #|| (x #== z)@ @=@ @pcon PTrue@ (trichotomy)
+7. @x #<= y@ @=@ @(x #< y) #|| (x #== y)@ (strict equivalence)
 
-Lastly, if you define '#>=' or '#>', ensure that the following also hold:
+If you define '#>=' or '#>', ensure the following also hold:
 
 8. @x #> y@ @=@ @y #< x@
 9. @x #>= y@ @=@ @pnot (x #< y)@
 
-The default implementations of '#>=' and '#>' ensure these laws.
+Lastly, if you define 'pmax' or 'pmin', ensure the following also hold:
+
+10. @pmax # x # y@ @=@ @pmax # y # x@ (commutativity, also for @pmin)
+11. @pmax # x #$ pmax y z@ @=@ @pmax # (pmax # x # y) # z@ (associativity,
+    also for @pmin)
+12. @pmax # x #$ pmin # y # z@ @=@ @pmin # (pmax # x # y) # (pmax # x # z)@
+    ('pmax' distributes over 'pmin', also equivalent for 'pmin')
+13. @pmin x y@ @=@ @pif' (x #< y) x y@
+14. @pmax x y@ @=@ @pif' (x #< y) y x@
+
+Laws 8-14 hold if you use the defaults provided by this type class.
+
+@since WIP
 -}
-class PEq t => PPartialOrd t where
+class PEq t => POrd t where
+  -- | @since WIP
+  {-# INLINEABLE (#<=) #-}
   (#<=) :: Term s t -> Term s t -> Term s PBool
   default (#<=) :: POrd (PInner t) => Term s t -> Term s t -> Term s PBool
   x #<= y = pto x #<= pto y
+
+  -- | @since WIP
+  {-# INLINEABLE (#<) #-}
   (#<) :: Term s t -> Term s t -> Term s PBool
   default (#<) :: POrd (PInner t) => Term s t -> Term s t -> Term s PBool
   x #< y = pto x #< pto y
 
   -- | @since WIP
+  {-# INLINEABLE (#>=) #-}
   (#>=) :: forall (s :: S). Term s t -> Term s t -> Term s PBool
   x #>= y = pnot #$ x #< y
 
   -- | @since WIP
+  {-# INLINEABLE (#>) #-}
   (#>) :: forall (s :: S). Term s t -> Term s t -> Term s PBool
   x #> y = y #< x
+
+  -- | @since WIP
+  {-# INLINEABLE pmax #-}
+  pmax :: forall (s :: S). Term s t -> Term s t -> Term s t
+  pmax x y = pif' # (x #< y) # y # x
+
+  -- | @since WIP
+  {-# INLINEABLE pmin #-}
+  pmin :: forall (s :: S). Term s t -> Term s t -> Term s t
+  pmin x y = pif' # (x #< y) # x # y
 
 infix 4 #<=
 infix 4 #<
 infix 4 #>=
 infix 4 #>
 
-{- | Total ordering relation.
-
-= Laws
-
-'pmax' and 'pmin' must form a commutative semiring without identity
-elements, where addition also distributes over multiplication. More
-precisely:
-
-1. @pmax x y@ @=@ @pmax y x@ (@pmax@ is commutative)
-2. @pmin x y@ @=@ @pmin y x@ (@pmin@ is commutative)
-3. @pmax x (pmax y z)@ @=@ @pmax (pmax x y) z@ (@pmax@ is associative)
-4. @pmin x (pmin y z)@ @=@ @pmin (pmin x y) z@ (@pmin@ is associative)
-5. @pmax x (pmin y z)@ @=@ @pmin (pmax x y) (pmax x z)@ (@pmax@ distributes
-   over @pmin@)
-6. @pmin x (pmax y z)@ @=@ @pmax (pmin x y) (pmin x z)@ (@pmin@ distributes
-   over @pmax@)
-
-Furthermore, the following must hold relative '#<':
-
-7. @pmin x y@ @=@ @if (x #< y) then x else y@
-8. @pmax x y@ @=@ @if (x #< y) then y else x@
-
-Laws 7 and 8 are also the defaults, as for most types, this is the best you
-can do.
--}
-class PPartialOrd t => POrd t where
-  -- | @since WIP
-  pmax :: forall (s :: S). Term s t -> Term s t -> Term s t
-  pmax x y = pif' # (x #< y) # y # x
-
-  -- | @since WIP
-  pmin :: forall (s :: S). Term s t -> Term s t -> Term s t
-  pmin x y = pif' # (x #< y) # x # y
-
-instance PPartialOrd PBool where
+instance POrd PBool where
   {-# INLINEABLE (#<) #-}
   x #< y = pif' # x # pconstant False # y
   {-# INLINEABLE (#<=) #-}
   x #<= y = pif' # x # y # pconstant True
+  {-# INLINEABLE pmin #-}
+  pmin x y = pand' # x # y
+  {-# INLINEABLE pmax #-}
+  pmax x y = por' # x # y
 
-instance POrd PBool
-
-instance PPartialOrd PInteger where
+instance POrd PInteger where
   {-# INLINEABLE (#<=) #-}
   x #<= y = punsafeBuiltin PLC.LessThanEqualsInteger # x # y
-
-  {-# INLIENABLE (#<) #-}
+  {-# INLINEABLE (#<) #-}
   x #< y = punsafeBuiltin PLC.LessThanInteger # x # y
-
-instance POrd PInteger

--- a/Plutarch/Internal/Ord.hs
+++ b/Plutarch/Internal/Ord.hs
@@ -1,7 +1,9 @@
 module Plutarch.Internal.Ord (
   POrd (..),
+  (#>),
 ) where
 
+import Data.Kind (Type)
 import Plutarch.Builtin.Bool (PBool, pand', pif', pnot, por')
 import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.Internal.Eq (PEq)
@@ -34,22 +36,21 @@ Furthermore, '#<' must be an equivalent strict total order to '#<=':
 6. @(x #< y) #|| (y #< x) #|| (x #== z)@ @=@ @pcon PTrue@ (trichotomy)
 7. @x #<= y@ @=@ @(x #< y) #|| (x #== y)@ (strict equivalence)
 
-If you define '#>=' or '#>', ensure the following also hold:
+If you define '#>=', ensure the following holds:
 
-8. @x #> y@ @=@ @y #< x@
-9. @x #>= y@ @=@ @pnot (x #< y)@
+8. @x #>= y@ @=@ @pnot (x #< y)@
 
 Lastly, if you define 'pmax' or 'pmin', ensure the following also hold:
 
-10. @pmax # x # y@ @=@ @pmax # y # x@ (commutativity, also for @pmin)
-11. @pmax # x #$ pmax y z@ @=@ @pmax # (pmax # x # y) # z@ (associativity,
+9. @pmax # x # y@ @=@ @pmax # y # x@ (commutativity, also for @pmin)
+10. @pmax # x #$ pmax y z@ @=@ @pmax # (pmax # x # y) # z@ (associativity,
     also for @pmin)
-12. @pmax # x #$ pmin # y # z@ @=@ @pmin # (pmax # x # y) # (pmax # x # z)@
+11. @pmax # x #$ pmin # y # z@ @=@ @pmin # (pmax # x # y) # (pmax # x # z)@
     ('pmax' distributes over 'pmin', also equivalent for 'pmin')
-13. @pmin x y@ @=@ @pif' (x #< y) x y@
-14. @pmax x y@ @=@ @pif' (x #< y) y x@
+12. @pmin x y@ @=@ @pif' (x #<= y) x y@
+13. @pmax x y@ @=@ @pif' (x #<= y) y x@
 
-Laws 8-14 hold if you use the defaults provided by this type class.
+Laws 8-13 hold if you use the defaults provided by this type class.
 
 @since WIP
 -}
@@ -72,23 +73,28 @@ class PEq t => POrd t where
   x #>= y = pnot #$ x #< y
 
   -- | @since WIP
-  {-# INLINEABLE (#>) #-}
-  (#>) :: forall (s :: S). Term s t -> Term s t -> Term s PBool
-  x #> y = y #< x
-
-  -- | @since WIP
   {-# INLINEABLE pmax #-}
   pmax :: forall (s :: S). Term s t -> Term s t -> Term s t
-  pmax x y = pif' # (x #< y) # y # x
+  pmax x y = pif' # (x #<= y) # y # x
 
   -- | @since WIP
   {-# INLINEABLE pmin #-}
   pmin :: forall (s :: S). Term s t -> Term s t -> Term s t
-  pmin x y = pif' # (x #< y) # x # y
+  pmin x y = pif' # (x #<= y) # x # y
 
 infix 4 #<=
 infix 4 #<
 infix 4 #>=
+
+-- | @since WIP
+(#>) ::
+  forall (a :: S -> Type) (s :: S).
+  POrd a =>
+  Term s a ->
+  Term s a ->
+  Term s PBool
+x #> y = y #< x
+
 infix 4 #>
 
 instance POrd PBool where

--- a/Plutarch/Positive.hs
+++ b/Plutarch/Positive.hs
@@ -20,7 +20,7 @@ import Plutarch.Internal.Eq (PEq)
 import Plutarch.Internal.Lift (DeriveNewtypePLiftable, PLiftable, PLifted (PLifted))
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Numeric (PIntegral, PNum (pfromInteger, (#-)))
-import Plutarch.Internal.Ord (POrd, PPartialOrd ((#<=)))
+import Plutarch.Internal.Ord (POrd ((#<=)))
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -58,7 +58,6 @@ newtype PPositive (s :: S) = PPositive (Term s PInteger)
     ( PlutusType
     , PIsData
     , PEq
-    , PPartialOrd
     , POrd
     , PIntegral
     , PShow

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -43,8 +43,7 @@ module Plutarch.Prelude (
 
   -- * Booleans and boolean functions
   PBool (..),
-  PEq ((#==)),
-  PPartialOrd (..),
+  PEq (..),
   POrd (..),
   pif,
   pif',
@@ -279,8 +278,7 @@ import Plutarch.Internal.Lift (
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Numeric (PIntegral (pdiv, pmod, pquot, prem))
 import Plutarch.Internal.Ord (
-  POrd (pmax, pmin),
-  PPartialOrd ((#<), (#<=), (#>), (#>=)),
+  POrd (pmax, pmin, (#<), (#<=), (#>), (#>=)),
  )
 import Plutarch.Internal.Other (POpaque (POpaque), pfix, popaque, pto)
 import Plutarch.Internal.PLam (pinl, plam)

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -46,6 +46,7 @@ module Plutarch.Prelude (
   PEq (..),
   POrd (..),
   (#>),
+  (#>=),
   pif,
   pif',
   pnot,
@@ -279,8 +280,9 @@ import Plutarch.Internal.Lift (
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Numeric (PIntegral (pdiv, pmod, pquot, prem))
 import Plutarch.Internal.Ord (
-  POrd (pmax, pmin, (#<), (#<=), (#>=)),
+  POrd (pmax, pmin, (#<), (#<=)),
   (#>),
+  (#>=),
  )
 import Plutarch.Internal.Other (POpaque (POpaque), pfix, popaque, pto)
 import Plutarch.Internal.PLam (pinl, plam)

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -45,6 +45,7 @@ module Plutarch.Prelude (
   PBool (..),
   PEq (..),
   POrd (..),
+  (#>),
   pif,
   pif',
   pnot,
@@ -278,7 +279,8 @@ import Plutarch.Internal.Lift (
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Numeric (PIntegral (pdiv, pmod, pquot, prem))
 import Plutarch.Internal.Ord (
-  POrd (pmax, pmin, (#<), (#<=), (#>), (#>=)),
+  POrd (pmax, pmin, (#<), (#<=), (#>=)),
+  (#>),
  )
 import Plutarch.Internal.Other (POpaque (POpaque), pfix, popaque, pto)
 import Plutarch.Internal.PLam (pinl, plam)

--- a/Plutarch/Rational.hs
+++ b/Plutarch/Rational.hs
@@ -46,8 +46,7 @@ import Plutarch.Internal.Numeric (
   pquot,
  )
 import Plutarch.Internal.Ord (
-  POrd (pmax, pmin),
-  PPartialOrd ((#<), (#<=)),
+  POrd (pmax, pmin, (#<), (#<=)),
  )
 import Plutarch.Internal.Other (pfix, pto)
 import Plutarch.Internal.PLam (plam)
@@ -187,7 +186,8 @@ instance PTryFrom PData (PAsData PRational) where
     res <- tcont . plet $ ptryPositive # denm
     pure (punsafeCoerce opq, res)
 
-instance PPartialOrd PRational where
+instance POrd PRational where
+  {-# INLINEABLE (#<=) #-}
   l' #<= r' =
     phoistAcyclic
       ( plam $ \l r -> unTermCont $ do
@@ -197,7 +197,7 @@ instance PPartialOrd PRational where
       )
       # l'
       # r'
-
+  {-# INLINEABLE (#<) #-}
   l' #< r' =
     phoistAcyclic
       ( plam $ \l r -> unTermCont $ do
@@ -207,8 +207,6 @@ instance PPartialOrd PRational where
       )
       # l'
       # r'
-
-instance POrd PRational
 
 instance PNum PRational where
   {-# INLINEABLE (#+) #-}

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -12,7 +12,7 @@ import Plutarch.Internal.Lift (
   PLifted (PLifted),
   pconstant,
  )
-import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=), (#>=)))
+import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=)))
 import Plutarch.Internal.PlutusType (PInner, PlutusType, pcon, pcon', pmatch')
 import Plutarch.Internal.Term (Term, plet)
 import Plutarch.Show (PShow (pshow'))
@@ -39,8 +39,6 @@ instance POrd PUnit where
   x #<= y = plet x $ \_ -> plet y $ \_ -> pcon PTrue
   {-# INLINEABLE (#<) #-}
   x #< y = plet x $ \_ -> plet y $ \_ -> pcon PFalse
-  {-# INLINEABLE (#>=) #-}
-  (#>=) = (#<=)
   {-# INLINEABLE pmax #-}
   pmax x y = plet x $ \_ -> plet y $ const x
   {-# INLINEABLE pmin #-}

--- a/Plutarch/Unit.hs
+++ b/Plutarch/Unit.hs
@@ -12,7 +12,7 @@ import Plutarch.Internal.Lift (
   PLifted (PLifted),
   pconstant,
  )
-import Plutarch.Internal.Ord (POrd, PPartialOrd ((#<), (#<=)))
+import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=), (#>=)))
 import Plutarch.Internal.PlutusType (PInner, PlutusType, pcon, pcon', pmatch')
 import Plutarch.Internal.Term (Term, plet)
 import Plutarch.Show (PShow (pshow'))
@@ -33,11 +33,18 @@ deriving via
 instance PEq PUnit where
   x #== y = plet x \_ -> plet y \_ -> pcon PTrue
 
-instance PPartialOrd PUnit where
-  x #<= y = plet x \_ -> plet y \_ -> pcon PTrue
-  x #< y = plet x \_ -> plet y \_ -> pcon PFalse
-
-instance POrd PUnit
+-- | @since WIP
+instance POrd PUnit where
+  {-# INLINEABLE (#<=) #-}
+  x #<= y = plet x $ \_ -> plet y $ \_ -> pcon PTrue
+  {-# INLINEABLE (#<) #-}
+  x #< y = plet x $ \_ -> plet y $ \_ -> pcon PFalse
+  {-# INLINEABLE (#>=) #-}
+  (#>=) = (#<=)
+  {-# INLINEABLE pmax #-}
+  pmax x y = plet x $ \_ -> plet y $ const x
+  {-# INLINEABLE pmin #-}
+  pmin = pmax
 
 instance Semigroup (Term s PUnit) where
   x <> y = plet x \_ -> plet y \_ -> pcon PUnit

--- a/plutarch-docs/src/Typeclasses/PEqAndPOrd.md
+++ b/plutarch-docs/src/Typeclasses/PEqAndPOrd.md
@@ -27,15 +27,13 @@ class PEq t where
 ```
 That would yield a `Term s PBool`, which you would probably use with `pif` (or similar).
 
-Similarly, `PPartialOrd` (and `POrd`) emulates `Ord`: (where `PPartialOrd` represents partial orders
-and `POrd` represents total orders)
+Similarly, `POrd` emulates `Ord`: 
 
 ```hs
-class PEq => PPartialOrd t where
+-- The actual POrd has more methods, but these are the only required ones.
+class PEq => POrd t where
   (#<) :: Term s t -> Term s t -> Term s PBool
   (#<=) :: Term s t -> Term s t -> Term s PBool
-
-class PPartialOrd => POrd t
 ```
 
 It works as you would expect:
@@ -57,7 +55,7 @@ data PMaybe' a s
 instance DerivePlutusType (PMaybe' a) where type DPTStrat _ = PlutusTypeScott
 ```
 
-For data encoded types, you can derive `PEq`, `PPartialOrd` and `POrd` via there data representation:
+For data encoded types, you can derive `PEq` and `POrd` via their data representation:
 
 ```haskell
 newtype PTriplet a s
@@ -72,7 +70,7 @@ newtype PTriplet a s
           )
       )
   deriving stock Generic
-  deriving anyclass (PlutusType, PEq, PPartialOrd)
+  deriving anyclass (PlutusType, PEq)
 
 instance DerivePlutusType (PTriplet a) where type DPTStrat _ = PlutusTypeData
 ```

--- a/plutarch-docs/src/Usage/DerivingForNewtypes.md
+++ b/plutarch-docs/src/Usage/DerivingForNewtypes.md
@@ -28,7 +28,7 @@ You ideally want to just have this `newtype` be represented as a `PByteString` u
 ```haskell
 newtype PPubKeyHash (s :: S) = PPubKeyHash (Term s (PDataNewtype PByteString))
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PShow)
+  deriving anyclass (PlutusType, PIsData, PEq, POrd, PShow)
 instance DerivePlutusType PPubKeyHash where type DPTStrat _ = PlutusTypeNewtype
 
 ```
@@ -49,7 +49,6 @@ Currently, `DerivePNewtype` lets you derive the following typeclasses for your P
 - `PIsData`
 - `PNum`
 - `POrd`
-- `PPartialOrd`
 - `PShow`
 - `PlutusType`
 

--- a/plutarch-docs/src/Usage/DerivingWithGenerics.md
+++ b/plutarch-docs/src/Usage/DerivingWithGenerics.md
@@ -33,7 +33,7 @@ Currently, generic deriving supports the following typeclasses:
 
 - [`PlutusType`](./../Typeclasses/PlutusType,PCon,PMatch.md#implementing-plutustype-for-your-own-types-scott-encoding) (Scott encoding only)
 - [`PEq`](./../Typeclasses/PEqAndPOrd.md)
-- [`POrd`/ `PPartialOrd`](./../Typeclasses/PEqAndPOrd.md)
+- [`POrd`](./../Typeclasses/PEqAndPOrd.md)
 - [`PTryFrom`](./../Typeclasses/PTryFrom.md)
 - `PShow`
 - `PIsData`

--- a/plutarch-ledger-api/CHANGELOG.md
+++ b/plutarch-ledger-api/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * `pmaybeDataToMaybe` to `Plutarch.LedgerApi.Utils`
 * `PSBool` and functionality, originally from Plutarch, now in
   `Plutarch.LedgerApi.Utils`
+* `POrd` instance for `PLovelace`
+* `pltPositive`, `pltNonZero`, `pleqPositive`, `pleqNonZero` to replace the old
+  `PPartialOrd` instances for `PValue`
 
 ### Changed
 

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/AssocMap.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/AssocMap.hs
@@ -1053,7 +1053,7 @@ pkeys = phoistAcyclic $
 -}
 pkvPairLt ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
-  (PIsData k, PPartialOrd k) =>
+  (PIsData k, POrd k) =>
   Term
     s
     ( PBuiltinPair (PAsData k) (PAsData v)

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Interval.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Interval.hs
@@ -67,10 +67,6 @@ newtype PInterval (a :: S -> Type) (s :: S)
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
-      POrd
-    , -- | @since 2.0.0
       PShow
     )
 
@@ -113,8 +109,6 @@ newtype PLowerBound (a :: S -> Type) (s :: S)
     , -- | @since 2.0.0
       PDataFields
     , -- | @since 2.0.0
-      POrd
-    , -- | @since 2.0.0
       PShow
     )
 
@@ -129,7 +123,7 @@ instance (PIsData a, PCountable a) => PEq (PLowerBound a) where
   lb1 #== lb2 = (pinclusiveLowerBound # lb1) #== (pinclusiveLowerBound # lb2)
 
 -- | @since WIP
-instance (PIsData a, PCountable a) => PPartialOrd (PLowerBound a) where
+instance (PIsData a, PCountable a) => POrd (PLowerBound a) where
   {-# INLINEABLE (#<=) #-}
   lb1 #<= lb2 = (pinclusiveLowerBound # lb1) #<= (pinclusiveLowerBound # lb2)
   {-# INLINEABLE (#<) #-}
@@ -168,8 +162,6 @@ newtype PUpperBound (a :: S -> Type) (s :: S)
     , -- | @since 2.0.0
       PDataFields
     , -- | @since 2.0.0
-      POrd
-    , -- | @since 2.0.0
       PShow
     )
 
@@ -184,7 +176,7 @@ instance (PIsData a, PEnumerable a) => PEq (PUpperBound a) where
   ub1 #== ub2 = (pinclusiveUpperBound # ub1) #== (pinclusiveUpperBound # ub2)
 
 -- | @since WIP
-instance (PIsData a, PEnumerable a) => PPartialOrd (PUpperBound a) where
+instance (PIsData a, PEnumerable a) => POrd (PUpperBound a) where
   {-# INLINEABLE (#<=) #-}
   ub1 #<= ub2 = (pinclusiveUpperBound # ub1) #<= (pinclusiveUpperBound # ub2)
   {-# INLINEABLE (#<) #-}
@@ -216,8 +208,6 @@ data PExtended (a :: S -> Type) (s :: S)
       PIsData
     , -- | @since 2.0.0
       PEq
-    , -- | @since 2.0.0
-      PPartialOrd
     , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Utils.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Utils.hs
@@ -132,7 +132,7 @@ instance PTryFrom PData a => PTryFrom PData (PMaybeData a)
 instance PTryFrom PData a => PTryFrom PData (PAsData (PMaybeData a))
 
 -- | @since 2.0.0
-instance (PIsData a, PPartialOrd a) => PPartialOrd (PMaybeData a) where
+instance (PIsData a, POrd a) => POrd (PMaybeData a) where
   {-# INLINEABLE (#<=) #-}
   t1 #<= t2 = pmatch t1 $ \case
     PDNothing -> pcon PTrue
@@ -147,9 +147,14 @@ instance (PIsData a, PPartialOrd a) => PPartialOrd (PMaybeData a) where
     PDJust t1' -> pmatch t2 $ \case
       PDNothing -> pcon PFalse
       PDJust t2' -> pfromData t1' #< pfromData t2'
-
--- | @since 2.0.0
-instance (PIsData a, PPartialOrd a) => POrd (PMaybeData a) where
+  {-# INLINEABLE (#>=) #-}
+  t1 #>= t2 = pmatch t1 $ \case
+    PDNothing -> pmatch t2 $ \case
+      PDNothing -> pcon PTrue
+      PDJust _ -> pcon PFalse
+    PDJust t1' -> pmatch t2 $ \case
+      PDNothing -> pcon PTrue
+      PDJust t2' -> pfromData t1' #>= pfromData t2'
   {-# INLINEABLE pmin #-}
   pmin t1 t2 = pmatch t1 $ \case
     PDNothing -> t1
@@ -170,15 +175,6 @@ instance (PIsData a, PPartialOrd a) => POrd (PMaybeData a) where
           (pfromData t1' #< pfromData t2')
           t2
           t1
-
-{-
-instance (PIsData a, POrd a) => PPartialOrd (PMaybeData a) where
-  x #< y = pmaybeLT False (#<) # x # y
-  x #<= y = pmaybeLT True (#<=) # x # y
-
--- | @since 2.0.0
-instance (PIsData a, POrd a) => POrd (PMaybeData a)
--}
 
 {- | A Rational type that corresponds to the data encoding used by 'Plutus.Rational'.
 
@@ -212,12 +208,13 @@ newtype PRationalData s
     )
 
 -- | @since 3.1.0
-instance PPartialOrd PRationalData where
+instance POrd PRationalData where
+  {-# INLINEABLE (#<=) #-}
   (#<=) = liftCompareOp (#<=)
+  {-# INLINEABLE (#<) #-}
   (#<) = liftCompareOp (#<)
-
--- | @since 3.1.0
-instance POrd PRationalData
+  {-# INLINEABLE (#>=) #-}
+  (#>=) = liftCompareOp (#>=)
 
 -- | @since 3.1.0
 instance DerivePlutusType PRationalData where

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Utils.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Utils.hs
@@ -147,14 +147,6 @@ instance (PIsData a, POrd a) => POrd (PMaybeData a) where
     PDJust t1' -> pmatch t2 $ \case
       PDNothing -> pcon PFalse
       PDJust t2' -> pfromData t1' #< pfromData t2'
-  {-# INLINEABLE (#>=) #-}
-  t1 #>= t2 = pmatch t1 $ \case
-    PDNothing -> pmatch t2 $ \case
-      PDNothing -> pcon PTrue
-      PDJust _ -> pcon PFalse
-    PDJust t1' -> pmatch t2 $ \case
-      PDNothing -> pcon PTrue
-      PDJust t2' -> pfromData t1' #>= pfromData t2'
   {-# INLINEABLE pmin #-}
   pmin t1 t2 = pmatch t1 $ \case
     PDNothing -> t1
@@ -213,8 +205,6 @@ instance POrd PRationalData where
   (#<=) = liftCompareOp (#<=)
   {-# INLINEABLE (#<) #-}
   (#<) = liftCompareOp (#<)
-  {-# INLINEABLE (#>=) #-}
-  (#>=) = liftCompareOp (#>=)
 
 -- | @since 3.1.0
 instance DerivePlutusType PRationalData where

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Address.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Address.hs
@@ -37,8 +37,6 @@ newtype PAddress (s :: S)
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0
       PShow

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Credential.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Credential.hs
@@ -28,8 +28,6 @@ data PCredential (s :: S)
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0
       PShow
@@ -74,8 +72,6 @@ data PStakingCredential (s :: S)
       PIsData
     , -- | @since 2.0.0
       PEq
-    , -- | @since 2.0.0
-      PPartialOrd
     , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Crypto.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Crypto.hs
@@ -27,8 +27,6 @@ newtype PPubKeyHash (s :: S) = PPubKeyHash (Term s (PDataNewtype PByteString))
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0
       PShow

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Scripts.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Scripts.hs
@@ -31,8 +31,6 @@ newtype PScriptHash (s :: S) = PScriptHash (Term s (PDataNewtype PByteString))
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0
       PShow
@@ -118,8 +116,6 @@ newtype PDatumHash (s :: S) = PDatumHash (Term s (PDataNewtype PByteString))
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0
       PShow
@@ -185,8 +181,6 @@ newtype PRedeemerHash (s :: S) = PRedeemerHash (Term s (PDataNewtype PByteString
       PIsData
     , -- | @since 3.1.0
       PEq
-    , -- | @since 3.1.0
-      PPartialOrd
     , -- | @since 3.1.0
       POrd
     , -- | @since 3.1.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
@@ -40,8 +40,6 @@ newtype PPosixTime (s :: S) = PPosixTime (Term s (PDataNewtype PInteger))
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0
       PShow

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Tx.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Tx.hs
@@ -32,8 +32,6 @@ newtype PTxId (s :: S) = PTxId (Term s (PDataRecord '["_0" ':= PByteString]))
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0
       PShow
@@ -131,8 +129,6 @@ newtype PTxOutRef (s :: S)
       PDataFields
     , -- | @since 2.0.0
       PEq
-    , -- | @since 2.0.0
-      PPartialOrd
     , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Tx.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Tx.hs
@@ -31,8 +31,6 @@ newtype PTxId (s :: S) = PTxId (Term s (PDataNewtype PByteString))
     , -- | @since 2.0.0
       PEq
     , -- | @since 2.0.0
-      PPartialOrd
-    , -- | @since 2.0.0
       POrd
     , -- | @since 2.0.0
       PShow
@@ -96,8 +94,6 @@ newtype PTxOutRef (s :: S)
       PDataFields
     , -- | @since 3.1.0
       PEq
-    , -- | @since 3.1.0
-      PPartialOrd
     , -- | @since 3.1.0
       POrd
     , -- | @since 3.1.0

--- a/plutarch-testlib/Plutarch/Test/Laws.hs
+++ b/plutarch-testlib/Plutarch/Test/Laws.hs
@@ -158,7 +158,7 @@ checkHaskellOrdEquivalent ::
   , Typeable (AsHaskell plutarchInput)
   , Ord (AsHaskell plutarchInput)
   , Typeable plutarchInput
-  , PPartialOrd plutarchInput
+  , POrd plutarchInput
   ) =>
   TestTree
 checkHaskellOrdEquivalent =

--- a/plutarch-testlib/Plutarch/Test/SpecTypes.hs
+++ b/plutarch-testlib/Plutarch/Test/SpecTypes.hs
@@ -41,7 +41,7 @@ newtype PTriplet (a :: S -> Type) (s :: S)
           )
       )
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd, PDataFields)
+  deriving anyclass (PlutusType, PIsData, PEq, POrd, PDataFields)
 
 -- | @since WIP
 instance DerivePlutusType (PTriplet a) where type DPTStrat _ = PlutusTypeData

--- a/plutarch-testlib/goldens/rational.bench.golden
+++ b/plutarch-testlib/goldens/rational.bench.golden
@@ -1,26 +1,26 @@
 literal {"exBudgetCPU":16100,"exBudgetMemory":200,"scriptSizeBytes":12}
-ops.+ {"exBudgetCPU":17724955,"exBudgetMemory":73893,"scriptSizeBytes":353}
-ops.- {"exBudgetCPU":17724955,"exBudgetMemory":73893,"scriptSizeBytes":353}
-ops.* {"exBudgetCPU":30342324,"exBudgetMemory":125261,"scriptSizeBytes":401}
-ops.harmonic-sum {"exBudgetCPU":44838927,"exBudgetMemory":184535,"scriptSizeBytes":395}
-ops.multi-product {"exBudgetCPU":50284461,"exBudgetMemory":208563,"scriptSizeBytes":407}
-ops.abs {"exBudgetCPU":7039207,"exBudgetMemory":29637,"scriptSizeBytes":291}
-ops.signum {"exBudgetCPU":7051834,"exBudgetMemory":29537,"scriptSizeBytes":324}
-compare {"exBudgetCPU":14565530,"exBudgetMemory":61573,"scriptSizeBytes":337}
-round.5/3 {"exBudgetCPU":9396178,"exBudgetMemory":37647,"scriptSizeBytes":371}
-round.4/3 {"exBudgetCPU":8639866,"exBudgetMemory":34544,"scriptSizeBytes":371}
-round.-5/2 {"exBudgetCPU":9056047,"exBudgetMemory":35647,"scriptSizeBytes":371}
-round.-1/4 {"exBudgetCPU":8613074,"exBudgetMemory":33746,"scriptSizeBytes":371}
-truncate.5/4 {"exBudgetCPU":7061147,"exBudgetMemory":29335,"scriptSizeBytes":281}
-truncate.7/4 {"exBudgetCPU":7817459,"exBudgetMemory":32438,"scriptSizeBytes":281}
-truncate.1/4 {"exBudgetCPU":6304835,"exBudgetMemory":26232,"scriptSizeBytes":281}
-truncate.-7/4 {"exBudgetCPU":8030667,"exBudgetMemory":33140,"scriptSizeBytes":281}
-properFraction.-1/2 {"exBudgetCPU":20027130,"exBudgetMemory":83307,"scriptSizeBytes":409}
-properFraction.-3/2 {"exBudgetCPU":20783442,"exBudgetMemory":86410,"scriptSizeBytes":409}
-properFraction.-4/3 {"exBudgetCPU":20783442,"exBudgetMemory":86410,"scriptSizeBytes":409}
+ops.+ {"exBudgetCPU":17716237,"exBudgetMemory":73893,"scriptSizeBytes":353}
+ops.- {"exBudgetCPU":17716237,"exBudgetMemory":73893,"scriptSizeBytes":353}
+ops.* {"exBudgetCPU":30327794,"exBudgetMemory":125261,"scriptSizeBytes":401}
+ops.harmonic-sum {"exBudgetCPU":44818585,"exBudgetMemory":184535,"scriptSizeBytes":395}
+ops.multi-product {"exBudgetCPU":50258307,"exBudgetMemory":208563,"scriptSizeBytes":407}
+ops.abs {"exBudgetCPU":7036301,"exBudgetMemory":29637,"scriptSizeBytes":291}
+ops.signum {"exBudgetCPU":7048928,"exBudgetMemory":29537,"scriptSizeBytes":324}
+compare {"exBudgetCPU":14559718,"exBudgetMemory":61573,"scriptSizeBytes":337}
+round.5/3 {"exBudgetCPU":9393272,"exBudgetMemory":37647,"scriptSizeBytes":371}
+round.4/3 {"exBudgetCPU":8636960,"exBudgetMemory":34544,"scriptSizeBytes":371}
+round.-5/2 {"exBudgetCPU":9053141,"exBudgetMemory":35647,"scriptSizeBytes":371}
+round.-1/4 {"exBudgetCPU":8610168,"exBudgetMemory":33746,"scriptSizeBytes":371}
+truncate.5/4 {"exBudgetCPU":7058241,"exBudgetMemory":29335,"scriptSizeBytes":281}
+truncate.7/4 {"exBudgetCPU":7814553,"exBudgetMemory":32438,"scriptSizeBytes":281}
+truncate.1/4 {"exBudgetCPU":6301929,"exBudgetMemory":26232,"scriptSizeBytes":281}
+truncate.-7/4 {"exBudgetCPU":8027761,"exBudgetMemory":33140,"scriptSizeBytes":281}
+properFraction.-1/2 {"exBudgetCPU":20018412,"exBudgetMemory":83307,"scriptSizeBytes":409}
+properFraction.-3/2 {"exBudgetCPU":20774724,"exBudgetMemory":86410,"scriptSizeBytes":409}
+properFraction.-4/3 {"exBudgetCPU":20774724,"exBudgetMemory":86410,"scriptSizeBytes":409}
 data.id.0.5 {"exBudgetCPU":16100,"exBudgetMemory":200,"scriptSizeBytes":12}
 data.id.2 {"exBudgetCPU":16100,"exBudgetMemory":200,"scriptSizeBytes":12}
-data.id.11/3 {"exBudgetCPU":7525529,"exBudgetMemory":31437,"scriptSizeBytes":276}
+data.id.11/3 {"exBudgetCPU":7522623,"exBudgetMemory":31437,"scriptSizeBytes":276}
 div by 0.1/0 {"exBudgetCPU":278933,"exBudgetMemory":136,"scriptSizeBytes":276}
 div by 0.recip 0 {"exBudgetCPU":187980,"exBudgetMemory":134,"scriptSizeBytes":123}
-div by 0.1/(1-1) {"exBudgetCPU":5157866,"exBudgetMemory":20164,"scriptSizeBytes":335}
+div by 0.1/(1-1) {"exBudgetCPU":5154960,"exBudgetMemory":20164,"scriptSizeBytes":335}

--- a/plutarch-testlib/goldens/rational.uplc.golden
+++ b/plutarch-testlib/goldens/rational.uplc.golden
@@ -99,8 +99,8 @@ ops.+ program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -217,8 +217,8 @@ ops.- program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -354,8 +354,8 @@ ops.* program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -480,8 +480,8 @@ ops.harmonic-sum program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -614,8 +614,8 @@ ops.multi-product program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -716,13 +716,13 @@ ops.abs program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -843,13 +843,13 @@ ops.signum program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -968,8 +968,8 @@ compare program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -1104,13 +1104,13 @@ round.5/3 program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -1253,13 +1253,13 @@ round.4/3 program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -1402,13 +1402,13 @@ round.-5/2 program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -1551,13 +1551,13 @@ round.-1/4 program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -1666,13 +1666,13 @@ truncate.5/4 program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -1781,13 +1781,13 @@ truncate.7/4 program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -1896,13 +1896,13 @@ truncate.1/4 program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -2011,13 +2011,13 @@ truncate.-7/4 program
                                                                                !2
                                                                                !1)))))
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !1
                                                                  !2)
                                                               (!15
-                                                                 (lessThanInteger
+                                                                 (lessThanEqualsInteger
                                                                     !2
                                                                     !1)
                                                                  !2
@@ -2171,8 +2171,8 @@ properFraction.-1/2 program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -2318,8 +2318,8 @@ properFraction.-3/2 program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -2465,8 +2465,8 @@ properFraction.-4/3 program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1
@@ -2563,13 +2563,13 @@ data.id.11/3 program
                                                                             !2
                                                                             !1)))))
                                                            (!15
-                                                              (lessThanInteger
+                                                              (lessThanEqualsInteger
                                                                  !2
                                                                  !1)
                                                               !1
                                                               !2)
                                                            (!15
-                                                              (lessThanInteger
+                                                              (lessThanEqualsInteger
                                                                  !2
                                                                  !1)
                                                               !2
@@ -2672,13 +2672,13 @@ div by 0.1/0 program
                                                                             !2
                                                                             !1)))))
                                                            (!15
-                                                              (lessThanInteger
+                                                              (lessThanEqualsInteger
                                                                  !2
                                                                  !1)
                                                               !1
                                                               !2)
                                                            (!15
-                                                              (lessThanInteger
+                                                              (lessThanEqualsInteger
                                                                  !2
                                                                  !1)
                                                               !2
@@ -2814,8 +2814,8 @@ div by 0.1/(1-1) program
                        (\!0 ->
                           (\!0 ->
                              !5
-                               (!8 (lessThanInteger !2 !1) !1 !2)
-                               (!8 (lessThanInteger !2 !1) !2 !1))
+                               (!8 (lessThanEqualsInteger !2 !1) !1 !2)
+                               (!8 (lessThanEqualsInteger !2 !1) !2 !1))
                             (!6 !2))
                          (!5 !2)))
                  (!1

--- a/plutarch-testlib/goldens/show.bench.golden
+++ b/plutarch-testlib/goldens/show.bench.golden
@@ -35,4 +35,4 @@ pshowAndErr.nil {"exBudgetCPU":100,"exBudgetMemory":100,"scriptSizeBytes":21}
 pshowAndErr.1,2,3 {"exBudgetCPU":100,"exBudgetMemory":100,"scriptSizeBytes":24}
 pair.int-str {"exBudgetCPU":21559683,"exBudgetMemory":77597,"scriptSizeBytes":450}
 pair.int-list {"exBudgetCPU":26928874,"exBudgetMemory":85994,"scriptSizeBytes":429}
-rational.1/2 {"exBudgetCPU":13225220,"exBudgetMemory":54284,"scriptSizeBytes":556}
+rational.1/2 {"exBudgetCPU":13222314,"exBudgetMemory":54284,"scriptSizeBytes":556}

--- a/plutarch-testlib/goldens/show.uplc.golden
+++ b/plutarch-testlib/goldens/show.uplc.golden
@@ -5219,13 +5219,13 @@ rational.1/2 program
                                                                                                                             !2
                                                                                                                             !1)))))
                                                                                                            (!30
-                                                                                                              (lessThanInteger
+                                                                                                              (lessThanEqualsInteger
                                                                                                                  !2
                                                                                                                  !1)
                                                                                                               !1
                                                                                                               !2)
                                                                                                            (!30
-                                                                                                              (lessThanInteger
+                                                                                                              (lessThanEqualsInteger
                                                                                                                  !2
                                                                                                                  !1)
                                                                                                               !2

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/TryFrom.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/TryFrom.hs
@@ -283,7 +283,7 @@ fullCheck = unTermCont $ fst <$> TermCont (ptryFrom $ pforgetData sampleStructur
 
 newtype PNatural (s :: S) = PMkNatural (Term s PInteger)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PIsData, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PIsData, PEq, POrd)
 instance DerivePlutusType PNatural where type DPTStrat _ = PlutusTypeNewtype
 
 -- | partial
@@ -344,6 +344,6 @@ theField = unTermCont $ do
 
 newtype PWrapInt (s :: S) = PWrapInt (Term s PInteger)
   deriving stock (Generic)
-  deriving anyclass (PlutusType, PEq, PPartialOrd, POrd)
+  deriving anyclass (PlutusType, PEq, POrd)
 instance DerivePlutusType PWrapInt where type DPTStrat _ = PlutusTypeNewtype
 instance PTryFrom PData (PAsData PWrapInt)


### PR DESCRIPTION
Fixes #766. As part of this, there were a few other small changes:

* `#>` is now a function instead of a method. Since it's just an argument rearrangement, it's not possible for it to be implemented more efficiently per instance anyway.
* `PValue` gained new functions to replace its old `PPartialOrd` instances. As these are meant to mirror functionality from `plutus-ledger-api`, we make mention of that.
* The default implementations for `pmax` and `pmin` now use `#<=` instead of `#<`, which gives us slight perf bumps.

Things that would be nice (and need follow-up tickets):

* Checks for `POrd` actually being a total order (namely, that the laws for its mandatory methods hold)
* Goldens/benches/whatever to compare whether a custom implementation of a `POrd` method is actually better than the default, for each optional method
* Checks that `pltPositive` and similar functions mirror their `plutus-ledger-api` equivalents