### PR TITLE
liberate builtins from instances

### DIFF
--- a/Plutarch/Builtin/Bool.hs
+++ b/Plutarch/Builtin/Bool.hs
@@ -21,18 +21,7 @@ module Plutarch.Builtin.Bool (
 ) where
 
 import Data.Kind (Type)
-import Plutarch.Internal.Lift (
-  DeriveBuiltinPLiftable,
-  PLiftable,
-  PLifted (PLifted),
-  pconstant,
- )
 import Plutarch.Internal.PLam (plam)
-import Plutarch.Internal.PlutusType (
-  PlutusType (PInner, pcon', pmatch'),
-  pcon,
-  pmatch,
- )
 import Plutarch.Internal.Term (
   PDelayed,
   S,
@@ -55,23 +44,6 @@ data PBool (s :: S) = PTrue | PFalse
     ( -- | @since WIP
       Show
     )
-
--- | @since WIP
-deriving via
-  (DeriveBuiltinPLiftable PBool Bool)
-  instance
-    PLiftable PBool
-
--- | @since WIP
-instance PlutusType PBool where
-  type PInner PBool = PBool
-  {-# INLINEABLE pcon' #-}
-  pcon' =
-    pconstant . \case
-      PTrue -> True
-      PFalse -> False
-  {-# INLINEABLE pmatch' #-}
-  pmatch' b f = pforce $ pif' # b # pdelay (f PTrue) # pdelay (f PFalse)
 
 -- | @since WIP
 pbuiltinIfThenElse ::
@@ -98,9 +70,13 @@ pif ::
   Term s a ->
   Term s a ->
   Term s a
-pif cond ifT ifF = pmatch cond $ \case
-  PTrue -> ifT
-  PFalse -> ifF
+pif cond ifT ifF =
+  -- TODO: fix. Yes, this is definition of pmatch inlined. Golfing module structure.
+  (pforce $ pif' # b # pdelay (f PTrue) # pdelay (f PFalse))
+    cond
+    $ \case
+      PTrue -> ifT
+      PFalse -> ifF
 
 {- | Boolean negation.
 

--- a/Plutarch/Builtin/Integer.hs
+++ b/Plutarch/Builtin/Integer.hs
@@ -10,10 +10,7 @@ module Plutarch.Builtin.Integer (
 ) where
 
 import GHC.Generics (Generic)
-import Plutarch.Internal.Lift (DeriveBuiltinPLiftable, PLiftable, PLifted (PLifted))
-import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Other (POpaque)
-import Plutarch.Internal.PlutusType (DPTStrat, DerivePlutusType, PlutusType)
 import Plutarch.Internal.Term (S, Term, (:-->))
 import Plutarch.Unsafe (punsafeBuiltin)
 import PlutusCore qualified as PLC
@@ -24,16 +21,6 @@ import PlutusCore qualified as PLC
 -}
 newtype PInteger s = PInteger (Term s POpaque)
   deriving stock (Generic)
-  deriving anyclass (PlutusType)
-
-instance DerivePlutusType PInteger where
-  type DPTStrat _ = PlutusTypeNewtype
-
--- | @since WIP
-deriving via
-  (DeriveBuiltinPLiftable PInteger Integer)
-  instance
-    PLiftable PInteger
 
 {- | Performs modulo exponentiation. More precisely, @pexpModInteger b e m@
 performs @b@ to the power of @e@, modulo @m@. The result is always

--- a/Plutarch/Internal/Lift.hs
+++ b/Plutarch/Internal/Lift.hs
@@ -39,7 +39,10 @@ import Data.Kind (Type)
 import Data.Text (Text)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
+
 import {-# SOURCE #-} Plutarch.Builtin (PData)
+import Plutarch.Builtin.Bool (PBool)
+import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.Internal.Evaluate (EvalError, evalScriptHuge)
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Other (POpaque, popaque)
@@ -375,3 +378,18 @@ mkPLifted t = PLifted (popaque t)
 @since WIP
 -}
 newtype PLiftedClosed (a :: S -> Type) = PLiftedClosed {unPLiftedClosed :: forall (s :: S). PLifted s a}
+
+--------------------------------------------------------------------------------
+-- Instances
+
+-- | @since WIP
+deriving via
+  (DeriveBuiltinPLiftable PBool Bool)
+  instance
+    PLiftable PBool
+
+-- | @since WIP
+deriving via
+  (DeriveBuiltinPLiftable PInteger Integer)
+  instance
+    PLiftable PInteger

--- a/Plutarch/Internal/PlutusType.hs
+++ b/Plutarch/Internal/PlutusType.hs
@@ -31,6 +31,8 @@ import Data.Kind (Constraint, Type)
 import Data.Proxy (Proxy (Proxy))
 import GHC.TypeLits (ErrorMessage (ShowType, Text, (:<>:)), TypeError)
 import Generics.SOP (All2)
+import Plutarch.Builtin.Integer (PInteger)
+import Plutarch.Builtin.Pool (PBool)
 import Plutarch.Internal.Generic (PCode)
 import Plutarch.Internal.Quantification (PFix (PFix), PForall (PForall), PSome (PSome))
 import Plutarch.Internal.Term (PType, Term, plam', plet, punsafeCoerce, (#), (:-->) (PLam))
@@ -124,3 +126,24 @@ instance PlutusType (PFix f) where
   type PInner (PFix f) = f (PFix f)
   pcon' (PFix x) = x
   pmatch' x f = f (PFix x)
+
+--------------------------------------------------------------------------------
+
+-- | @since WIP
+instance PlutusType PBool where
+  type PInner PBool = PBool
+  {-# INLINEABLE pcon' #-}
+  pcon' =
+    _
+      pconstant
+      . \case
+        PTrue -> True
+        PFalse -> False
+  {-# INLINEABLE pmatch' #-}
+  pmatch' b f = pforce $ pif' # b # pdelay (f PTrue) # pdelay (f PFalse)
+
+-- | @since WIP
+deriving instance anyclass PlutusType PInteger
+
+instance DerivePlutusType PInteger where
+  type DPTStrat _ = PlutusTypeNewtype

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -68,6 +68,7 @@ common c
     -Wno-unrecognised-warning-flags -Wno-unrecognised-pragmas
     -Wno-operator-whitespace -fprint-equality-relations
     -fprint-explicit-kinds -fprint-explicit-foralls
+    -Wno-missing-export-lists
 
 library
   import:          c


### PR DESCRIPTION
PlutusType and PLiftable instances for PBool and PInteger now resides with class definition