### PR TITLE
Add law check for POrd, fix bad wording of transitivity laws for POrd

### DIFF
--- a/Plutarch/Internal/Ord.hs
+++ b/Plutarch/Internal/Ord.hs
@@ -26,13 +26,13 @@ import PlutusCore qualified as PLC
 '#<=' must form a total order. More precisely:
 
 1. @x #<= x@ @=@ @pcon PTrue@ (reflexivity)
-2. @(x #<= y) #&& (y #<= z)@ @=@ @x #<= z@ (transitivity)
+2. @(y #< x) #|| (z #< y) #|| (x #<= z)@ @=@ @pcon PTrue@ (transitivity)
 3. @(x #<= y) #|| (y #<= x)@ @=@ @pcon PTrue@ (totality)
 
 Furthermore, '#<' must be an equivalent strict total order to '#<=':
 
 4. @x #< x@ @=@ @pcon PFalse@ (irreflexivity)
-5. @(x #< y) #&& (y #< z)@ @=@ @x #< z@ (transitivity)
+5. @(y #<= x) #|| (z #<= y) #|| (x #< z)@ @=@ @pcon PTrue@ (transitivity)
 6. @(x #< y) #|| (y #< x) #|| (x #== z)@ @=@ @pcon PTrue@ (trichotomy)
 7. @x #<= y@ @=@ @(x #< y) #|| (x #== y)@ (strict equivalence)
 

--- a/plutarch-orphanage/CHANGELOG.md
+++ b/plutarch-orphanage/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 * `V3` version of `MintValue` that does not include zero Ada
-* QuickCheck type class instances for `AssetClass`
+* QuickCheck type class instances for `AssetClass`, `PlutusTx.Ratio.Rational`
 * `UnsortedAssocMap` wrapper to `PlutusLedgerApi.V1.Orphans`
 
 ### Changed

--- a/plutarch-orphanage/src/PlutusLedgerApi/Orphans/Common.hs
+++ b/plutarch-orphanage/src/PlutusLedgerApi/Orphans/Common.hs
@@ -18,6 +18,7 @@ import PlutusPrelude (Pretty)
 import PlutusTx.AssocMap qualified as AssocMap
 import PlutusTx.Builtins qualified as Builtins
 import PlutusTx.Prelude qualified as PlutusTx
+import PlutusTx.Ratio (fromGHC, toGHC)
 import Test.QuickCheck (
   Arbitrary (arbitrary, shrink),
   Arbitrary1 (liftArbitrary, liftShrink),
@@ -34,6 +35,13 @@ import Test.QuickCheck (
   sized,
   variant,
  )
+
+-- | @since WIP
+instance Arbitrary PlutusTx.Rational where
+  {-# INLINEABLE arbitrary #-}
+  arbitrary = fromGHC <$> arbitrary
+  {-# INLINEABLE shrink #-}
+  shrink = fmap fromGHC . shrink . toGHC
 
 -- | @since 1.0.0
 instance Arbitrary PlutusTx.BuiltinByteString where

--- a/plutarch-testlib/Plutarch/Test/Laws.hs
+++ b/plutarch-testlib/Plutarch/Test/Laws.hs
@@ -73,52 +73,52 @@ checkPOrdLaws =
   where
     leqReflexive :: Property
     leqReflexive = forAllShrinkShow arbitrary shrink prettyShow $ \(x :: AsHaskell a) ->
-      plift (pconstant @a x #<= pconstant x)
+      plift (precompileTerm (plam $ \arg1 -> arg1 #<= arg1) # pconstant @a x)
     -- We have to restate (x <= y && y <= z) -> x <= z, which gives (after some
     -- DeMorganing) x > y || y > z || x <= z
     leqTransitive :: Property
     leqTransitive = forAllShrinkShow arbitrary shrink prettyShow $ \(t :: Triplet (AsHaskell a)) ->
       let (x, y, z) = toTriple t
        in plift
-            ( let liftedX = pconstant @a x
-                  liftedY = pconstant y
-                  liftedZ = pconstant z
-               in (liftedX #> liftedY) #|| (liftedY #> liftedZ) #|| (liftedX #<= liftedZ)
+            ( precompileTerm (plam $ \arg1 arg2 arg3 -> (arg1 #> arg2) #|| (arg2 #> arg3) #|| (arg1 #<= arg3))
+                # pconstant @a x
+                # pconstant y
+                # pconstant z
             )
     leqTotal :: Property
     leqTotal = forAllShrinkShow arbitrary shrink prettyShow $ \(x :: AsHaskell a, y :: AsHaskell a) ->
       plift
-        ( let liftedX = pconstant @a x
-              liftedY = pconstant y
-           in (liftedX #<= liftedY) #|| (liftedY #<= liftedX)
+        ( precompileTerm (plam $ \arg1 arg2 -> (arg1 #<= arg2) #|| (arg2 #<= arg1))
+            # pconstant @a x
+            # pconstant y
         )
     ltIrreflexive :: Property
     ltIrreflexive = forAllShrinkShow arbitrary shrink prettyShow $ \(x :: AsHaskell a) ->
-      plift (pnot #$ pconstant @a x #< pconstant x)
+      plift (precompileTerm (plam $ \arg1 -> pnot #$ arg1 #< arg1) # pconstant @a x)
     -- We have to restate (x < y && y < z) -> x < z, which gives (after some
     -- DeMorganing) x >= y || y >= z || x < z
     ltTransitive :: Property
     ltTransitive = forAllShrinkShow arbitrary shrink prettyShow $ \(x :: AsHaskell a, y :: AsHaskell a, z :: AsHaskell a) ->
       plift
-        ( let liftedX = pconstant @a x
-              liftedY = pconstant y
-              liftedZ = pconstant z
-           in (liftedX #>= liftedY) #|| (liftedY #>= liftedZ) #|| (liftedX #< liftedZ)
+        ( precompileTerm (plam $ \arg1 arg2 arg3 -> (arg1 #>= arg2) #|| (arg2 #>= arg3) #|| (arg1 #< arg3))
+            # pconstant @a x
+            # pconstant y
+            # pconstant z
         )
     ltTrichotomous :: Property
     ltTrichotomous = forAllShrinkShow arbitrary shrink prettyShow $ \(x :: AsHaskell a, y :: AsHaskell a) ->
       plift
-        ( let liftedX = pconstant @a x
-              liftedY = pconstant y
-           in (liftedX #< liftedY) #|| (liftedY #< liftedX) #|| (liftedX #== liftedY)
+        ( precompileTerm (plam $ \arg1 arg2 -> (arg1 #< arg2) #|| (arg2 #< arg1) #|| (arg1 #== arg2))
+            # pconstant @a x
+            # pconstant y
         )
     ltEquivLeq :: Property
     ltEquivLeq = forAllShrinkShow arbitrary shrink prettyShow $ \(x :: AsHaskell a, y :: AsHaskell a) ->
-      plift (pconstant @a x #<= pconstant y)
+      plift (precompileTerm (plam $ \arg1 arg2 -> arg1 #<= arg2) # pconstant @a x # pconstant y)
         === plift
-          ( let liftedX = pconstant @a x
-                liftedY = pconstant y
-             in (liftedX #< liftedY) #|| (liftedX #== liftedY)
+          ( precompileTerm (plam $ \arg1 arg2 -> (arg1 #< arg2) #|| (arg1 #== arg2))
+              # pconstant @a x
+              # pconstant y
           )
 
 {- | Verifies that the specified Plutarch and Haskell types satisfy the laws of

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/POrd.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/POrd.hs
@@ -12,8 +12,9 @@ import Plutarch.LedgerApi.V1 (
  )
 import Plutarch.Prelude
 import Plutarch.Test.Golden (GoldenTestTree, goldenEval, goldenGroup, plutarchGolden)
-import Plutarch.Test.Laws (checkHaskellOrdEquivalent)
+import Plutarch.Test.Laws (checkHaskellOrdEquivalent, checkPOrdLaws)
 import Plutarch.Test.SpecTypes (PTriplet (PTriplet), Triplet (Triplet))
+import PlutusLedgerApi.QuickCheck.Utils ()
 import PlutusLedgerApi.V1 (Credential (PubKeyCredential, ScriptCredential))
 import Test.Tasty (TestTree, testGroup)
 
@@ -62,6 +63,10 @@ tests =
         , checkHaskellOrdEquivalent @(PMaybeData PInteger)
         , checkHaskellOrdEquivalent @(PTriplet PInteger)
         , checkHaskellOrdEquivalent @PAddress
+        ]
+    , testGroup
+        "Laws"
+        [ testGroup "PRational" (checkPOrdLaws @PRational)
         ]
     ]
 


### PR DESCRIPTION
Closes #769. As part of this, we also corrected the wording for transitivity laws (curse me for confusing IF with IFF again), and added an instance for the PlutusTx `Rational` to the orphanage.