### PR TITLE
Add separate optimizeTerm function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * `PLiftable PRational` instance
 * `PDataFields`, `DerivePDataLiftable`, `PDataNewtype` now exported from the prelude
 * New methods for `Data` and Scott encoding derivation
+* `optimizeTerm` for separate optimization via UPLC from compilation
 
 ## Changed
 


### PR DESCRIPTION
This adds `optimizeTerm`, which runs the UPLC optimizer currently used in `compileOptimized`, but rebuilds a `Term` around it afterwards.