### PR TITLE
PSemigroup and PMonoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 * New numerical hierarchy in `Plutarch.Internal.Numeric`, plus new instances
 * `PNatural` type, corresponding to the Haskell `Natural`
 * Support for SoP encoding of data
+* `PSemigroup` and `PMonoid`, as improved Plutarch versions of `Semigroup` and
+  `Monoid`
 
 ## Changed
 

--- a/Plutarch/BitString.hs
+++ b/Plutarch/BitString.hs
@@ -28,6 +28,7 @@ import Plutarch.Internal.PlutusType (
   PlutusType,
   pcon,
  )
+import Plutarch.Internal.Semigroup (PMonoid, PSemigroup)
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -63,6 +64,10 @@ newtype PBitString (s :: S) = PBitString (Term s PByteString)
       PEq
     , -- | @since WIP
       POrd
+    , -- | @since WIP
+      PSemigroup
+    , -- | @since WIP
+      PMonoid
     )
 
 -- | @since WIP

--- a/Plutarch/Builtin/String.hs
+++ b/Plutarch/Builtin/String.hs
@@ -6,10 +6,8 @@ import Data.Kind (Type)
 import Data.String (IsString, fromString)
 import Data.Text qualified as Text
 import GHC.Generics (Generic)
-
 import Plutarch.Builtin.ByteString (PByteString)
 import Plutarch.Builtin.Opaque (POpaque)
-
 import Plutarch.Internal.Term (
   Config (NoTracing, Tracing),
   S,

--- a/Plutarch/Internal/Numeric.hs
+++ b/Plutarch/Internal/Numeric.hs
@@ -22,6 +22,7 @@ module Plutarch.Internal.Numeric (
   ptryNatural,
   pnatural,
   ppositiveToNatural,
+  pnaturalToPositiveCPS,
   pbySquaringDefault,
   pdiv,
   pmod,
@@ -683,6 +684,24 @@ pquot = punsafeBuiltin PLC.QuotientInteger
 -- | @since WIP
 prem :: forall (s :: S). Term s (PInteger :--> PInteger :--> PInteger)
 prem = punsafeBuiltin PLC.RemainderInteger
+
+{- | Specialized form of @pmaybe@ for 'PNatural'. Given a default, and a way to
+turn a 'PPositive' into an answer, produce the default when given 'pzero',
+and apply the function otherwise.
+
+@since WIP
+-}
+pnaturalToPositiveCPS ::
+  forall (a :: S -> Type) (s :: S).
+  Term s a ->
+  (Term s PPositive -> Term s a) ->
+  Term s PNatural ->
+  Term s a
+pnaturalToPositiveCPS def f n = plet n $ \n' ->
+  pif
+    (n' #== pzero)
+    def
+    (f . punsafeCoerce $ n)
 
 {- | Partial version of 'pnatural'. Errors if argument is negative.
 

--- a/Plutarch/Internal/Numeric.hs
+++ b/Plutarch/Internal/Numeric.hs
@@ -37,6 +37,7 @@ import Numeric.Natural (Natural)
 import Plutarch.Builtin.BLS (
   PBuiltinBLS12_381_G1_Element,
   PBuiltinBLS12_381_G2_Element,
+  PBuiltinBLS12_381_MlResult,
   pbls12_381_G1_add,
   pbls12_381_G1_compressed_zero,
   pbls12_381_G1_neg,
@@ -47,6 +48,7 @@ import Plutarch.Builtin.BLS (
   pbls12_381_G2_neg,
   pbls12_381_G2_scalarMul,
   pbls12_381_G2_uncompress,
+  pbls12_381_mulMlResult,
  )
 import Plutarch.Builtin.Bool (pcond, pif)
 import Plutarch.Builtin.Integer (
@@ -209,11 +211,11 @@ instance PLiftable PNatural where
 
 If you define a custom @pscalePositive@, ensure the following also hold:
 
-3. @pscalePositive # x # pone@ @=@ @x@
-4. @(pscalePositive # x # n) #+ (pscalePositive # x # m)@ @=@
-   @pscalePositive # x # (n #+ m)@
-5. @pscalePositive # (pscalePositive # x # n) # m@ @=@
-   @pscalePositive # x # (n #* m)@
+3. @pscalePositive x pone@ @=@ @x@
+4. @(pscalePositive x n) #+ (pscalePositive x m)@ @=@
+   @pscalePositive x (n #+ m)@
+5. @pscalePositive (pscalePositive x n) m@ @=@
+   @pscalePositive x (n #* m)@
 
 The default implementation ensures these laws are satisfied.
 
@@ -282,17 +284,16 @@ instance PAdditiveSemigroup PBuiltinBLS12_381_G2_Element where
 = Laws
 
 1. @pzero #+ x@ @=@ @x@ (@pzero@ is the identity of @#+@)
-2. @pscalePositive # pzero # n@ @=@
+2. @pscalePositive pzero n@ @=@
    @pzero@ (@pzero@ does not scale up)
 
 If you define 'pscaleNatural', ensure the following as well:
 
-3. @pscaleNatural # x #$ ppositiveToNatural # p@ @=@
-   @pscalePositive # x # p@
-4. @pscaleNatural # x # pzero@ @=@ @pzero@
+3. @pscaleNatural x (ppositiveToNatural # p)@ @=@
+   @pscalePositive x p@
+4. @pscaleNatural x pzero@ @=@ @pzero@
 
-The default implementation of 'pscaleNatural' ensures these laws are
-followed.
+The default implementation of 'pscaleNatural' ensures these laws hold.
 
 @since WIP
 -}
@@ -361,9 +362,9 @@ implementations of both @pnegate@ and @#-@ uphold these.
 Lastly, if you define a custom @pscaleInteger@, the following laws
 must hold:
 
-6. @pscaleInteger # x # pzero@ @=@ @pzero@
-7. @pscaleInteger # x #$ pnegate y@ @=@
-   @pnegate #$ pscaleInteger # x # y@
+6. @pscaleInteger x pzero@ @=@ @pzero@
+7. @pscaleInteger x (pnegate # y)@ @=@
+   @pnegate # (pscaleInteger x y)@
 
 @since WIP
 -}
@@ -428,11 +429,11 @@ instance PAdditiveGroup PBuiltinBLS12_381_G2_Element where
 
 If you define a custom @ppowPositive@, ensure the following also hold:
 
-3. @ppowPositive # x # pone@ @=@ @x@
-4. @(ppowPositive # x # n) #* (ppowPositive # x # m)@ @=@
-   @pscalePositive # x # (n #+ m)@
-5. @ppowPositive # (ppowPositive # x # n) # m@ @=@
-   @pscalePositive # x # (n #* m)@
+3. @ppowPositive x pone@ @=@ @x@
+4. @(ppowPositive x n) #* (ppowPositive x m)@ @=@
+   @ppowPositive x (n #+ m)@
+5. @ppowPositive (ppowPositive x n) m@ @=@
+   @ppowPositive x (n #* m)@
 
 The default implementation ensures these laws are satisfied.
 
@@ -480,6 +481,11 @@ instance PMultiplicativeSemigroup PInteger where
   {-# INLINEABLE (#*) #-}
   x #* y = pmultiplyInteger # x # y
 
+-- | @since WIP
+instance PMultiplicativeSemigroup PBuiltinBLS12_381_MlResult where
+  {-# INLINEABLE (#*) #-}
+  x #* y = pbls12_381_mulMlResult # x # y
+
 {- | The notion of one (multiplicative identity), and exponentiation by
  - naturals.
 
@@ -487,13 +493,13 @@ instance PMultiplicativeSemigroup PInteger where
 
 1. @pone #* x@ @=@ @x@ (@pone@ is the left identity of @#*@)
 2. @x #* pone@ @=@ @x@ (@pone@ is the right identity of @#*@)
-3. @ppowPositive # pone # p@ @=@ @pone@ (@pone@ does not scale up)
+3. @ppowPositive pone p@ @=@ @pone@ (@pone@ does not scale up)
 
 If you define 'ppowNatural', ensure the following as well:
 
-4. @ppowNatural # x #$ ppositiveToNatural # p@ @=@
-   @ppowPositive # x # p@
-5. @ppowNatural # x # pzero@ @=@ @pone@
+4. @ppowNatural x (ppositiveToNatural # p)@ @=@
+   @ppowPositive x p@
+5. @ppowNatural x pzero@ @=@ @pone@
 
 @since WIP
 -}

--- a/Plutarch/Internal/Semigroup.hs
+++ b/Plutarch/Internal/Semigroup.hs
@@ -1,0 +1,41 @@
+module Plutarch.Internal.Semigroup (
+  -- * Type classes
+  PSemigroup (..),
+  PMonoid (..),
+) where
+
+import Data.Kind (Type)
+import Plutarch.Internal.Numeric (
+  PNatural,
+  PPositive,
+  pbySquaringDefault,
+  pnaturalToPositiveCPS,
+ )
+import Plutarch.Internal.Other (pto)
+import Plutarch.Internal.PlutusType (PInner)
+import Plutarch.Internal.Term (S, Term)
+import Plutarch.Unsafe (punsafeDowncast)
+
+class PSemigroup (a :: S -> Type) where
+  (#<>) :: forall (s :: S). Term s a -> Term s a -> Term s a
+  default (#<>) ::
+    forall (s :: S).
+    PSemigroup (PInner a) =>
+    Term s a ->
+    Term s a ->
+    Term s a
+  x #<> y = punsafeDowncast $ pto x #<> pto y
+  {-# INLINEABLE pstimes #-}
+  pstimes :: forall (s :: S). Term s PPositive -> Term s a -> Term s a
+  pstimes p x = pbySquaringDefault (#<>) x p
+
+class PSemigroup a => PMonoid (a :: S -> Type) where
+  pmempty :: forall (s :: S). Term s a
+  default pmempty ::
+    forall (s :: S).
+    PMonoid (PInner a) =>
+    Term s a
+  pmempty = punsafeDowncast pmempty
+  {-# INLINEABLE pmtimes #-}
+  pmtimes :: forall (s :: S). Term s PNatural -> Term s a -> Term s a
+  pmtimes n x = pnaturalToPositiveCPS pmempty (`pstimes` x) n

--- a/Plutarch/Internal/Semigroup.hs
+++ b/Plutarch/Internal/Semigroup.hs
@@ -104,7 +104,7 @@ instance PSemigroup PUnit where
   {-# INLINEABLE (#<>) #-}
   x #<> y = plet x $ \_ -> plet y $ const punit
   {-# INLINEABLE pstimes #-}
-  pstimes _ x = plet x $ const punit
+  pstimes p x = plet p $ \_ -> plet x $ const punit
 
 -- | @since WIP
 instance PSemigroup PString where
@@ -182,7 +182,7 @@ instance PMonoid PUnit where
   {-# INLINEABLE pmempty #-}
   pmempty = punit
   {-# INLINEABLE pmtimes #-}
-  pmtimes _ x = plet x $ const punit
+  pmtimes n x = plet n $ \_ -> plet x $ const punit
 
 -- | @since WIP
 instance PMonoid PString where
@@ -238,7 +238,7 @@ instance PSemigroup (PAnd PBool) where
 
   -- \| 'PBool' is idempotent under AND.
   {-# INLINEABLE pstimes #-}
-  pstimes _ x = x
+  pstimes p x = plet p $ const x
 
 -- | @since WIP
 instance PMonoid (PAnd PBool) where
@@ -256,14 +256,12 @@ instance PSemigroup (PAnd PByteString) where
 
   -- \| 'PByteString' is idempotent under AND regardless of semantics.
   {-# INLINEABLE pstimes #-}
-  pstimes _ x = x
+  pstimes p x = plet p $ const x
 
 -- | @since WIP
 instance PMonoid (PAnd PByteString) where
   {-# INLINEABLE pmempty #-}
   pmempty = pcon . PAnd $ mempty
-  {-# INLINEABLE pmtimes #-}
-  pmtimes _ x = x
 
 {- | Wrapper for types which have logical OR semantics somehow.
 
@@ -295,14 +293,12 @@ instance PSemigroup (POr PBool) where
 
   -- \| 'PBool' is idempotent under OR.
   {-# INLINEABLE pstimes #-}
-  pstimes _ x = x
+  pstimes p x = plet p $ const x
 
 -- | @since WIP
 instance PMonoid (POr PBool) where
   {-# INLINEABLE pmempty #-}
   pmempty = pcon . POr . pcon $ PFalse
-  {-# INLINEABLE pmtimes #-}
-  pmtimes _ x = x
 
 {- | This uses padding semantics as specified in CIP-122, as this allows a
 'PMonoid' instance as well.
@@ -315,14 +311,12 @@ instance PSemigroup (POr PByteString) where
 
   -- \| 'PByteString' is idempotent under OR regardless of semantics.
   {-# INLINEABLE pstimes #-}
-  pstimes _ x = x
+  pstimes p x = plet p $ const x
 
 -- | @since WIP
 instance PMonoid (POr PByteString) where
   {-# INLINEABLE pmempty #-}
   pmempty = pcon . POr $ mempty
-  {-# INLINEABLE pmtimes #-}
-  pmtimes _ x = x
 
 {- | Wrapper for types which have logical XOR semantics somehow.
 

--- a/Plutarch/Internal/Semigroup.hs
+++ b/Plutarch/Internal/Semigroup.hs
@@ -4,18 +4,65 @@ module Plutarch.Internal.Semigroup (
   PMonoid (..),
 ) where
 
+import Data.ByteString qualified as BS
 import Data.Kind (Type)
+import Data.Text qualified as Text
+import Plutarch.Builtin.BLS (
+  PBuiltinBLS12_381_G1_Element,
+  PBuiltinBLS12_381_G2_Element,
+  PBuiltinBLS12_381_MlResult,
+ )
+import Plutarch.Builtin.Bool (pif)
+import Plutarch.Builtin.ByteString (
+  PByteString,
+  pindexBS,
+  plengthBS,
+  preplicateBS,
+ )
+import Plutarch.Builtin.String (PString)
+import Plutarch.Builtin.Unit (PUnit, punit)
+import Plutarch.Internal.Eq ((#==))
 import Plutarch.Internal.Numeric (
   PNatural,
   PPositive,
   pbySquaringDefault,
   pnaturalToPositiveCPS,
+  pscaleNatural,
+  pscalePositive,
+  pzero,
+  (#*),
+  (#+),
  )
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PlutusType (PInner)
-import Plutarch.Internal.Term (S, Term)
+import Plutarch.Internal.Term (
+  S,
+  Term,
+  plet,
+  punsafeBuiltin,
+  punsafeConstantInternal,
+  (#),
+  (#$),
+ )
 import Plutarch.Unsafe (punsafeDowncast)
+import PlutusCore qualified as PLC
 
+{- | = Laws
+
+The only mandatory law is that '#<>' must be associative:
+
+@x #<> (y #<> z)@ @=@ @(x #<> y) #<> z@
+
+If you define 'pstimes', ensure the following also hold:
+
+1. @pstimes pone x@ @=@ @x@
+2. @(pstimes p1 x) #<> (pstimes p2 x)@ @=@ @pstimes (p1 #+ p2) x@
+3. @pstimes p1 (pstimes p2 x)@ @=@ @pstimes (p1 #* p2) x@
+
+The default implementation automatically ensures these laws hold.
+
+@since WIP
+-}
 class PSemigroup (a :: S -> Type) where
   (#<>) :: forall (s :: S). Term s a -> Term s a -> Term s a
   default (#<>) ::
@@ -29,6 +76,75 @@ class PSemigroup (a :: S -> Type) where
   pstimes :: forall (s :: S). Term s PPositive -> Term s a -> Term s a
   pstimes p x = pbySquaringDefault (#<>) x p
 
+infixr 6 #<>
+
+-- | @since WIP
+instance PSemigroup PUnit where
+  {-# INLINEABLE (#<>) #-}
+  x #<> y = plet x $ \_ -> plet y $ const punit
+  {-# INLINEABLE pstimes #-}
+  pstimes _ x = plet x $ const punit
+
+-- | @since WIP
+instance PSemigroup PString where
+  {-# INLINEABLE (#<>) #-}
+  x #<> y = punsafeBuiltin PLC.AppendString # x # y
+
+-- | @since WIP
+instance PSemigroup PByteString where
+  {-# INLINEABLE (#<>) #-}
+  x #<> y = punsafeBuiltin PLC.AppendByteString # x # y
+  {-# INLINEABLE pstimes #-}
+  pstimes p bs = plet bs $ \bs' ->
+    pif
+      (plengthBS # bs' #== 1)
+      (preplicateBS # pto p #$ pindexBS # bs' # 0)
+      (pbySquaringDefault (#<>) bs' p)
+
+{- | BLS points form a group technically, but a @PGroup@ notion would be too
+niche to be useful. Unlike other types which could be semigroups (or monoids)
+in many ways, BLS points have only one (essentially their additive
+instances), so we can provide these.
+
+@since WIP
+-}
+instance PSemigroup PBuiltinBLS12_381_G1_Element where
+  {-# INLINEABLE (#<>) #-}
+  (#<>) = (#+)
+  {-# INLINEABLE pstimes #-}
+  pstimes p x = pscalePositive x p
+
+-- | @since WIP
+instance PSemigroup PBuiltinBLS12_381_G2_Element where
+  {-# INLINEABLE (#<>) #-}
+  (#<>) = (#+)
+  {-# INLINEABLE pstimes #-}
+  pstimes p x = pscalePositive x p
+
+{- | Since multiplication of Miller loop results exists, they are technically
+semigroups, though confusingly in a /different/ way to BLS curve points.
+
+@since WIP
+-}
+instance PSemigroup PBuiltinBLS12_381_MlResult where
+  {-# INLINEABLE (#<>) #-}
+  (#<>) = (#*)
+
+{- | = Laws
+
+1. @pmempty #<> x@ @=@ @x #<> pmempty@ @=@ @x@
+2. @pstimes n pmempty@ @=@ @pmempty@
+
+If you define 'pmtimes', ensure the following as well:
+
+3. @pmtimes (ppositiveToNatural # p) x@ @=@
+   @pstimes p x@
+4. @pmtimes pzero x@ @=@ @pmempty@
+
+The default implementation of 'pmtimes' ensures these laws hold.
+
+@since WIP
+-}
 class PSemigroup a => PMonoid (a :: S -> Type) where
   pmempty :: forall (s :: S). Term s a
   default pmempty ::
@@ -39,3 +155,34 @@ class PSemigroup a => PMonoid (a :: S -> Type) where
   {-# INLINEABLE pmtimes #-}
   pmtimes :: forall (s :: S). Term s PNatural -> Term s a -> Term s a
   pmtimes n x = pnaturalToPositiveCPS pmempty (`pstimes` x) n
+
+-- | @since WIP
+instance PMonoid PUnit where
+  {-# INLINEABLE pmempty #-}
+  pmempty = punit
+  {-# INLINEABLE pmtimes #-}
+  pmtimes _ x = plet x $ const punit
+
+-- | @since WIP
+instance PMonoid PString where
+  {-# INLINEABLE pmempty #-}
+  pmempty = punsafeConstantInternal $ PLC.someValue Text.empty
+
+-- | @since WIP
+instance PMonoid PByteString where
+  {-# INLINEABLE pmempty #-}
+  pmempty = punsafeConstantInternal $ PLC.someValue BS.empty
+
+-- | @since WIP
+instance PMonoid PBuiltinBLS12_381_G1_Element where
+  {-# INLINEABLE pmempty #-}
+  pmempty = pzero
+  {-# INLINEABLE pmtimes #-}
+  pmtimes n x = pscaleNatural x n
+
+-- | @since WIP
+instance PMonoid PBuiltinBLS12_381_G2_Element where
+  {-# INLINEABLE pmempty #-}
+  pmempty = pzero
+  {-# INLINEABLE pmtimes #-}
+  pmtimes n x = pscaleNatural x n

--- a/Plutarch/Pair.hs
+++ b/Plutarch/Pair.hs
@@ -6,7 +6,11 @@ import Data.Kind (Type)
 import GHC.Generics (Generic)
 import Generics.SOP qualified as SOP
 import Plutarch.Internal.Eq (PEq)
-import Plutarch.Internal.PlutusType (PlutusType)
+import Plutarch.Internal.PlutusType (PlutusType, pcon, pmatch)
+import Plutarch.Internal.Semigroup (
+  PMonoid (pmempty),
+  PSemigroup (pstimes, (#<>)),
+ )
 import Plutarch.Internal.Show (PShow)
 import Plutarch.Internal.Term (S, Term)
 import Plutarch.Repr.SOP (DeriveAsSOPStruct (DeriveAsSOPStruct))
@@ -14,7 +18,7 @@ import Plutarch.Repr.SOP (DeriveAsSOPStruct (DeriveAsSOPStruct))
 {- |
   Plutus encoding of Pairs.
 
-  Note: This is represented differently than 'BuiltinPair'. It is scott-encoded.
+  Note: This is represented differently than 'BuiltinPair'. It is SoP encoded.
 -}
 data PPair (a :: S -> Type) (b :: S -> Type) (s :: S)
   = PPair (Term s a) (Term s b)
@@ -36,3 +40,24 @@ deriving via
   DeriveAsSOPStruct (PPair a b)
   instance
     PlutusType (PPair a b)
+
+-- | @since WIP
+instance
+  (PSemigroup a, PSemigroup b) =>
+  PSemigroup (PPair a b)
+  where
+  {-# INLINEABLE (#<>) #-}
+  x #<> y = pmatch x $ \(PPair x1 x2) ->
+    pmatch y $ \(PPair y1 y2) ->
+      pcon . PPair (x1 #<> y1) $ (x2 #<> y2)
+  {-# INLINEABLE pstimes #-}
+  pstimes p x = pmatch x $ \(PPair x1 x2) ->
+    pcon . PPair (pstimes p x1) $ pstimes p x2
+
+-- | @since WIP
+instance
+  (PMonoid a, PMonoid b) =>
+  PMonoid (PPair a b)
+  where
+  {-# INLINEABLE pmempty #-}
+  pmempty = pcon . PPair pmempty $ pmempty

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -253,6 +253,10 @@ module Plutarch.Prelude (
   ptraceInfoIfTrue,
   ptraceInfoShowId,
   ptraceShowId,
+
+  -- * Semigroup and monoid
+  PSemigroup (..),
+  PMonoid (..),
 ) where
 
 import Plutarch.Builtin
@@ -280,6 +284,7 @@ import Plutarch.Internal.PLam
 import Plutarch.Internal.PlutusType
 import Plutarch.Internal.Quantification
 import Plutarch.Internal.ScottEncoding
+import Plutarch.Internal.Semigroup
 import Plutarch.Internal.Show
 import Plutarch.Internal.Term
 import Plutarch.Internal.TryFrom

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Value.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Value.hs
@@ -305,6 +305,11 @@ instance PEq (PValue 'AssocMap.Sorted 'NoGuarantees) where
       -- TODO benchmark with '(==)'
       # pto (punionResolvingCollisionsWith AssocMap.Commutative # plam (-) # a # b)
 
+-- | @since WIP
+instance PSemigroup (PValue 'AssocMap.Sorted 'Positive) where
+  {-# INLINEABLE (#<>) #-}
+  (#<>) = (<>)
+
 -- | @since 2.0.0
 instance Semigroup (Term s (PValue 'AssocMap.Sorted 'Positive)) where
   a <> b =
@@ -314,6 +319,11 @@ instance Semigroup (Term s (PValue 'AssocMap.Sorted 'Positive)) where
 instance PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted 'Positive)) where
   a <> b =
     punsafeDowncast (pto $ punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b)
+
+-- | @since WIP
+instance PSemigroup (PValue 'AssocMap.Sorted 'NonZero) where
+  {-# INLINEABLE (#<>) #-}
+  (#<>) = (<>)
 
 -- | @since 2.0.0
 instance Semigroup (Term s (PValue 'AssocMap.Sorted 'NonZero)) where
@@ -325,6 +335,11 @@ instance PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted 'NonZero)) where
   a <> b =
     pnormalize #$ punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b
 
+-- | @since WIP
+instance PSemigroup (PValue 'AssocMap.Sorted 'NoGuarantees) where
+  {-# INLINEABLE (#<>) #-}
+  (#<>) = (<>)
+
 -- | @since 2.0.0
 instance Semigroup (Term s (PValue 'AssocMap.Sorted 'NoGuarantees)) where
   a <> b =
@@ -334,6 +349,14 @@ instance Semigroup (Term s (PValue 'AssocMap.Sorted 'NoGuarantees)) where
 instance PlutusTx.Semigroup (Term s (PValue 'AssocMap.Sorted 'NoGuarantees)) where
   a <> b =
     punionResolvingCollisionsWith AssocMap.Commutative # plam (+) # a # b
+
+-- | @since WIP
+instance
+  PSemigroup (PValue 'AssocMap.Sorted normalization) =>
+  PMonoid (PValue 'AssocMap.Sorted normalization)
+  where
+  {-# INLINEABLE pmempty #-}
+  pmempty = pcon (PValue AssocMap.pempty)
 
 -- | @since 2.0.0
 instance

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -109,6 +109,7 @@ library
     Plutarch.Internal.PrettyStack
     Plutarch.Internal.Quantification
     Plutarch.Internal.ScottEncoding
+    Plutarch.Internal.Semigroup
     Plutarch.Internal.Show
     Plutarch.Internal.Subtype
     Plutarch.Internal.Term


### PR DESCRIPTION
This adds `PSemigroup` and `PMonoid` instances, partly to satisfy Milestone 1 requirements, and partly due to the added safety and flexibility this gives us. I've added all the non-contentious instances, plus the ones needed to demonstrate Milestone 1 generalizability requirements, but I am open to others.