### PR TITLE
Add test to show NoTracing eliminates traces and properties for Semigroup and Monoid

### DIFF
--- a/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1.hs
@@ -9,6 +9,9 @@ import Plutarch.Test.Laws (
   checkLedgerProperties,
   checkLedgerPropertiesPCountable,
   checkLedgerPropertiesPEnumerable,
+  checkPAdditiveGroupLaws,
+  checkPAdditiveMonoidLaws,
+  checkPAdditiveSemigroupLaws,
  )
 import Plutarch.Test.Suite.PlutarchLedgerApi.V1.Interval qualified as Interval
 import Plutarch.Test.Suite.PlutarchLedgerApi.V1.Value qualified as Value
@@ -33,6 +36,9 @@ tests =
         [ checkLedgerPropertiesPCountable @PLA.PPosixTime
         , checkLedgerPropertiesPEnumerable @PLA.PPosixTime
         , checkLedgerProperties @PLA.PPosixTime
+        , checkPAdditiveSemigroupLaws @PLA.PPosixTime
+        , checkPAdditiveMonoidLaws @PLA.PPosixTime
+        , checkPAdditiveGroupLaws @PLA.PPosixTime
         ]
     , -- We only care about intervals of PPosixTime, so we don't check anything else
       testGroup


### PR DESCRIPTION
This is to satisfy the only outstanding Milestone 2 requirement before submission.