### PR TITLE
Milestone 1 remainder

### DIFF
--- a/Plutarch/BitString.hs
+++ b/Plutarch/BitString.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE UndecidableInstances #-}
+
 module Plutarch.BitString (
   -- * Type
   PBitString (..),
@@ -12,12 +14,18 @@ module Plutarch.BitString (
   pfindFirstSetBit',
 ) where
 
+import Data.ByteString (ByteString)
 import GHC.Generics (Generic)
 import Plutarch.Builtin.Bool (PBool, pif)
 import Plutarch.Builtin.ByteString (PByteString)
 import Plutarch.Builtin.Data (PBuiltinList)
 import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.Internal.Eq (PEq)
+import Plutarch.Internal.Lift (
+  DeriveNewtypePLiftable,
+  PLiftable,
+  PLifted (PLifted),
+ )
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Numeric (pzero)
 import Plutarch.Internal.Ord (POrd ((#<)))
@@ -73,6 +81,12 @@ newtype PBitString (s :: S) = PBitString (Term s PByteString)
 -- | @since WIP
 instance DerivePlutusType PBitString where
   type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since WIP
+deriving via
+  DeriveNewtypePLiftable PBitString PByteString ByteString
+  instance
+    PLiftable PBitString
 
 {- | Bit access operation, as defined in [CIP-122](https://github.com/cardano-foundation/CIPs/tree/master/CIP-0122#readbit).
 

--- a/Plutarch/Internal/Semigroup.hs
+++ b/Plutarch/Internal/Semigroup.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module Plutarch.Internal.Semigroup (
   -- * Type classes
@@ -40,6 +41,11 @@ import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.Builtin.String (PString)
 import Plutarch.Builtin.Unit (PUnit, punit)
 import Plutarch.Internal.Eq (PEq ((#==)))
+import Plutarch.Internal.Lift (
+  DeriveNewtypePLiftable,
+  PLiftable (AsHaskell),
+  PLifted (PLifted),
+ )
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Numeric (
   PNatural,
@@ -232,6 +238,12 @@ instance DerivePlutusType (PAnd a) where
   type DPTStrat _ = PlutusTypeNewtype
 
 -- | @since WIP
+deriving via
+  DeriveNewtypePLiftable (PAnd a) a (AsHaskell a)
+  instance
+    PLiftable a => PLiftable (PAnd a)
+
+-- | @since WIP
 instance PSemigroup (PAnd PBool) where
   {-# INLINEABLE (#<>) #-}
   x #<> y = pif' # pto x # y # x
@@ -285,6 +297,12 @@ newtype POr (a :: S -> Type) (s :: S)
 -- | @since WIP
 instance DerivePlutusType (POr a) where
   type DPTStrat _ = PlutusTypeNewtype
+
+-- | @since WIP
+deriving via
+  DeriveNewtypePLiftable (POr a) a (AsHaskell a)
+  instance
+    PLiftable a => PLiftable (POr a)
 
 -- | @since WIP
 instance PSemigroup (POr PBool) where
@@ -342,6 +360,12 @@ instance DerivePlutusType (PXor a) where
   type DPTStrat _ = PlutusTypeNewtype
 
 -- | @since WIP
+deriving via
+  DeriveNewtypePLiftable (PXor a) a (AsHaskell a)
+  instance
+    PLiftable a => PLiftable (PXor a)
+
+-- | @since WIP
 instance PSemigroup (PXor PBool) where
   {-# INLINEABLE (#<>) #-}
   x #<> y = pif' # pto x # (pcon . PXor $ pnot # pto y) # y
@@ -371,6 +395,11 @@ instance PSemigroup (PXor PByteString) where
   -- argument (if the exponent is odd) or the empty 'PByteString' (if it isn't).
   {-# INLINEABLE pstimes #-}
   pstimes = pxortimes mempty
+
+-- | @since WIP
+instance PMonoid (PXor PByteString) where
+  {-# INLINEABLE pmempty #-}
+  pmempty = pcon . PXor $ mempty
 
 -- Helpers
 

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -257,6 +257,9 @@ module Plutarch.Prelude (
   -- * Semigroup and monoid
   PSemigroup (..),
   PMonoid (..),
+  PAnd (..),
+  POr (..),
+  PXor (..),
 ) where
 
 import Plutarch.Builtin

--- a/plutarch-testlib/plutarch-testlib.cabal
+++ b/plutarch-testlib/plutarch-testlib.cabal
@@ -117,6 +117,7 @@ test-suite tests
     Plutarch.Test.Suite.Plutarch.Rational
     Plutarch.Test.Suite.Plutarch.Recursion
     Plutarch.Test.Suite.Plutarch.Scripts
+    Plutarch.Test.Suite.Plutarch.Semigroup
     Plutarch.Test.Suite.Plutarch.Show
     Plutarch.Test.Suite.Plutarch.String
     Plutarch.Test.Suite.Plutarch.Tracing

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Semigroup.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Semigroup.hs
@@ -1,0 +1,47 @@
+-- Needed because ByteString isn't Pretty
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Plutarch.Test.Suite.Plutarch.Semigroup (tests) where
+
+import Data.ByteString (ByteString)
+import Plutarch.BitString (PBitString)
+import Plutarch.Prelude
+import Plutarch.Test.Laws (checkPMonoidLaws, checkPSemigroupLaws)
+import Prettyprinter (Pretty (pretty), viaShow)
+import Test.Tasty (TestTree, testGroup)
+
+tests :: TestTree
+tests =
+  testGroup
+    "PSemigroup and PMonoid"
+    [ testGroup
+        "PByteString"
+        [ checkPSemigroupLaws @PByteString
+        , checkPMonoidLaws @PByteString
+        ]
+    , testGroup
+        "PBitString"
+        [ checkPSemigroupLaws @PBitString
+        , checkPMonoidLaws @PBitString
+        ]
+    , testGroup
+        "PAnd PByteString"
+        [ checkPSemigroupLaws @(PAnd PByteString)
+        , checkPMonoidLaws @(PAnd PByteString)
+        ]
+    , testGroup
+        "POr PByteString"
+        [ checkPSemigroupLaws @(POr PByteString)
+        , checkPMonoidLaws @(POr PByteString)
+        ]
+    , testGroup
+        "PXor PByteString"
+        [ checkPSemigroupLaws @(PXor PByteString)
+        , checkPMonoidLaws @(PXor PByteString)
+        ]
+    ]
+
+-- Orphan Pretty for ByteString, sigh
+instance Pretty ByteString where
+  {-# INLINEABLE pretty #-}
+  pretty = viaShow

--- a/plutarch-testlib/test/Test.hs
+++ b/plutarch-testlib/test/Test.hs
@@ -16,6 +16,7 @@ import Plutarch.Test.Suite.Plutarch.Positive qualified as Positive
 import Plutarch.Test.Suite.Plutarch.Rational qualified as Rational
 import Plutarch.Test.Suite.Plutarch.Recursion qualified as Recursion
 import Plutarch.Test.Suite.Plutarch.Scripts qualified as Scripts
+import Plutarch.Test.Suite.Plutarch.Semigroup qualified as Semigroup
 import Plutarch.Test.Suite.Plutarch.Show qualified as Show
 import Plutarch.Test.Suite.Plutarch.String qualified as String
 import Plutarch.Test.Suite.Plutarch.Tracing qualified as Tracing
@@ -59,6 +60,7 @@ main = do
         , TryFrom.tests
         , Unit.tests
         , Uplc.tests
+        , Semigroup.tests
         ]
     , testGroup
         "PlutarchLedgerApi"


### PR DESCRIPTION
This finishes all requirements for Milestone 1. More specifically:

* Laws and law tests for `PSemigroup` and `PMonoid` for `PByteString` wrappers
* Missing `PMonoid (PXor PByteString)` instance