### PR TITLE
Suggestions: remove redundant `PAsData` from ledger, `DerivePLiftableAsDataRec`, etc

### DIFF
--- a/Plutarch/Internal/IsData.hs
+++ b/Plutarch/Internal/IsData.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Plutarch.Internal.IsData (
-  PInnerMostIsData,
+  PInnermostIsData,
   PIsData,
   pfromDataImpl,
   pdataImpl,
@@ -46,7 +46,7 @@ import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (PLamN (plam))
 import Plutarch.Internal.PlutusType (
   PCovariant,
-  PInnerMost,
+  PInnermost,
   PVariant,
   PlutusType (PInner),
  )
@@ -68,9 +68,9 @@ import Plutarch.Unsafe (punsafeDowncast)
 import PlutusCore qualified as PLC
 import PlutusTx qualified as PTx
 
-type family PInnerMostIsData' msg a b :: Constraint where
-  PInnerMostIsData' _ _ PData = ()
-  PInnerMostIsData' ('Just msg) a b =
+type family PInnermostIsData' msg a b :: Constraint where
+  PInnermostIsData' _ _ PData = ()
+  PInnermostIsData' ('Just msg) a b =
     TypeError
       ( 'Text msg
           ':$$: 'Text "Inner most representation of \""
@@ -80,7 +80,7 @@ type family PInnerMostIsData' msg a b :: Constraint where
             ':<>: 'Text "\""
       )
       ~ ()
-  PInnerMostIsData' 'Nothing a b =
+  PInnermostIsData' 'Nothing a b =
     TypeError
       ( 'Text "Inner most representation of \""
           ':<>: 'ShowType a
@@ -90,8 +90,8 @@ type family PInnerMostIsData' msg a b :: Constraint where
       )
       ~ ()
 
-class (PInnerMostIsData' msg a (PInnerMost a), PInnerMost a ~ PData) => PInnerMostIsData msg a
-instance (PInnerMostIsData' msg a (PInnerMost a), PInnerMost a ~ PData) => PInnerMostIsData msg a
+class (PInnermostIsData' msg a (PInnermost a), PInnermost a ~ PData) => PInnermostIsData msg a
+instance (PInnermostIsData' msg a (PInnermost a), PInnermost a ~ PData) => PInnermostIsData msg a
 
 {- | Laws:
  - If @PSubtype PData a@, then @pdataImpl a@ must be `pupcast`.
@@ -141,12 +141,12 @@ prememberData Proxy = let _ = witness (Proxy @(PVariant p)) in punsafeCoerce
 -- | Like 'prememberData' but generalised.
 prememberData' ::
   forall a (p :: (S -> Type) -> S -> Type) (s :: S).
-  (PInnerMostIsData 'Nothing a, PSubtype PData a, PVariant p) =>
+  (PInnermostIsData 'Nothing a, PSubtype PData a, PVariant p) =>
   Proxy p ->
   Term s (p a) ->
   Term s (p (PAsData a))
 prememberData' Proxy =
-  let _ = witness (Proxy @(PInnerMostIsData 'Nothing a, PSubtype PData a, PVariant p))
+  let _ = witness (Proxy @(PInnermostIsData 'Nothing a, PSubtype PData a, PVariant p))
    in punsafeCoerce
 
 instance PIsData PData where
@@ -209,7 +209,7 @@ instance PIsData PUnit where
 
 instance
   forall (a :: S -> Type).
-  ( PInnerMostIsData ('Just "PBuiltinList only implements PIsData when inner most type of its elements are PData") a
+  ( PInnermostIsData ('Just "PBuiltinList only implements PIsData when inner most type of its elements are PData") a
   , PSubtype PData a
   ) =>
   PIsData (PBuiltinList a)

--- a/Plutarch/Internal/PlutusType.hs
+++ b/Plutarch/Internal/PlutusType.hs
@@ -5,7 +5,7 @@
 
 module Plutarch.Internal.PlutusType (
   PlutusType,
-  PInnerMost,
+  PInnermost,
   PlutusTypeStratConstraint,
   PCon,
   PMatch,
@@ -90,11 +90,11 @@ import Plutarch.Internal.Term (PType, S, Term, pdelay, pforce, plam', plet, puns
 import Plutarch.Internal.Witness (witness)
 import PlutusCore qualified as PLC
 
-type family PInnerMost' (a :: S -> Type) (b :: S -> Type) :: S -> Type where
-  PInnerMost' a a = a
-  PInnerMost' a _b = PInnerMost' (PInner a) a
+type family PInnermost' (a :: S -> Type) (b :: S -> Type) :: S -> Type where
+  PInnermost' a a = a
+  PInnermost' a _b = PInnermost' (PInner a) a
 
-type PInnerMost a = PInnerMost' (PInner a) a
+type PInnermost a = PInnermost' (PInner a) a
 
 class PlutusTypeStrat (strategy :: Type) where
   type PlutusTypeStratConstraint strategy :: PType -> Constraint

--- a/Plutarch/Internal/PlutusType.hs
+++ b/Plutarch/Internal/PlutusType.hs
@@ -5,6 +5,7 @@
 
 module Plutarch.Internal.PlutusType (
   PlutusType,
+  PInnerMost,
   PlutusTypeStratConstraint,
   PCon,
   PMatch,
@@ -88,6 +89,12 @@ import Plutarch.Internal.Quantification (PFix (PFix), PForall (PForall), PSome (
 import Plutarch.Internal.Term (PType, S, Term, pdelay, pforce, plam', plet, punsafeCoerce, (#), (:-->) (PLam))
 import Plutarch.Internal.Witness (witness)
 import PlutusCore qualified as PLC
+
+type family PInnerMost' (a :: S -> Type) (b :: S -> Type) :: S -> Type where
+  PInnerMost' a a = a
+  PInnerMost' a _b = PInnerMost' (PInner a) a
+
+type PInnerMost a = PInnerMost' (PInner a) a
 
 class PlutusTypeStrat (strategy :: Type) where
   type PlutusTypeStratConstraint strategy :: PType -> Constraint

--- a/Plutarch/Repr/Data.hs
+++ b/Plutarch/Repr/Data.hs
@@ -7,7 +7,7 @@ module Plutarch.Repr.Data (
   PDataRec (PDataRec, unPDataRec),
   DeriveAsDataRec (DeriveAsDataRec, unDeriveAsDataRec),
   DeriveAsDataStruct (DeriveAsDataStruct, unDeriveAsDataStruct),
-  DerivePLiftableAsDataRec (DerivePLiftableAsDataRec),
+  DerivePLiftableAsRec (DerivePLiftableAsRec),
 ) where
 
 import Data.Kind (Type)
@@ -384,11 +384,11 @@ instance
       SOP.SOP . SOP.Z <$> unRTH y x
 
 -- | @since WIP
-newtype DerivePLiftableAsDataRec (wrapper :: S -> Type) (h :: Type) (s :: S)
-  = DerivePLiftableAsDataRec (wrapper s)
+newtype DerivePLiftableAsRec (wrapper :: S -> Type) (h :: Type) (s :: S)
+  = DerivePLiftableAsRec (wrapper s)
   deriving stock (Generic)
   deriving anyclass (SOP.Generic)
-  deriving (PlutusType) via (DeriveFakePlutusType (DerivePLiftableAsDataRec wrapper h))
+  deriving (PlutusType) via (DeriveFakePlutusType (DerivePLiftableAsRec wrapper h))
 
 -- | @since WIP
 instance
@@ -400,12 +400,12 @@ instance
   , '[struct'] ~ Code (wrapper Any)
   , struct ~ UnTermRec struct'
   , hstruct ~ RecAsHaskell struct
-  , PInner wrapper ~ PDataRec struct
+  , AsHaskell (PInner wrapper) ~ SOP SOP.I '[hstruct]
   ) =>
-  PLiftable (DerivePLiftableAsDataRec wrapper h)
+  PLiftable (DerivePLiftableAsRec wrapper h)
   where
-  type AsHaskell (DerivePLiftableAsDataRec wrapper h) = h
-  type PlutusRepr (DerivePLiftableAsDataRec wrapper h) = PlutusRepr (PInner wrapper)
+  type AsHaskell (DerivePLiftableAsRec wrapper h) = h
+  type PlutusRepr (DerivePLiftableAsRec wrapper h) = PlutusRepr (PInner wrapper)
   haskToRepr :: h -> PlutusRepr (PInner wrapper)
   haskToRepr x = haskToRepr @(PInner wrapper) $ SOP.from x
   reprToHask :: PlutusRepr (PInner wrapper) -> Either LiftError h

--- a/Plutarch/Repr/Data.hs
+++ b/Plutarch/Repr/Data.hs
@@ -1,21 +1,17 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE UndecidableSuperClasses #-}
 
 module Plutarch.Repr.Data (
-  PInnerMostIsData,
   PDataStruct (PDataStruct, unPDataStruct),
   PDataRec (PDataRec, unPDataRec),
   DeriveAsDataRec (DeriveAsDataRec, unDeriveAsDataRec),
   DeriveAsDataStruct (DeriveAsDataStruct, unDeriveAsDataStruct),
-  PInnerMost,
 ) where
 
-import Data.Kind (Constraint, Type)
+import Data.Kind (Type)
 import Data.Maybe (catMaybes)
 import Data.Proxy (Proxy (Proxy))
 import GHC.Exts (Any)
-import GHC.TypeError (ErrorMessage (ShowType, Text, (:$$:), (:<>:)), TypeError)
 import Generics.SOP (
   All,
   All2,
@@ -39,7 +35,7 @@ import Plutarch.Builtin.Data (
   psndBuiltin,
  )
 import Plutarch.Internal.Eq (PEq, (#==))
-import Plutarch.Internal.IsData (PIsData)
+import Plutarch.Internal.IsData (PInnerMostIsData, PIsData)
 import Plutarch.Internal.Lift (pconstant)
 import Plutarch.Internal.ListLike (phead, ptail)
 import Plutarch.Internal.Other (pto)
@@ -70,28 +66,9 @@ import Plutarch.Repr.Internal (
  )
 import Plutarch.TermCont (pfindPlaceholder, pletC, unTermCont)
 
--- TODO: move this to Plutarch.Internal
-type family PInnerMost' (a :: S -> Type) (b :: S -> Type) :: S -> Type where
-  PInnerMost' a a = a
-  PInnerMost' a _b = PInnerMost' (PInner a) a
-
-type PInnerMost a = PInnerMost' (PInner a) a
-
-type family PInnerMostIsData' a b :: Constraint where
-  PInnerMostIsData' _ PData = ()
-  PInnerMostIsData' a b =
-    TypeError
-      ( 'Text "Data representation can only hold types whose inner most representation is PData"
-          ':$$: 'Text "Inner most representation of \""
-            ':<>: 'ShowType a
-            ':<>: 'Text "\" is \""
-            ':<>: 'ShowType b
-            ':<>: 'Text "\""
-      )
-      ~ ()
-
-class (PInnerMostIsData' a (PInnerMost a), PInnerMost a ~ PData) => PInnerMostIsData a
-instance (PInnerMostIsData' a (PInnerMost a), PInnerMost a ~ PData) => PInnerMostIsData a
+type PInnerMostIsDataDataRepr =
+  PInnerMostIsData
+    ('Just "Data representation can only hold types whose inner most representation is PData")
 
 -- | @since 1.10.0
 newtype PDataStruct (struct :: [[S -> Type]]) (s :: S) = PDataStruct {unPDataStruct :: PStruct struct s}
@@ -100,7 +77,7 @@ newtype PDataStruct (struct :: [[S -> Type]]) (s :: S) = PDataStruct {unPDataStr
 newtype PDataRec (struct :: [S -> Type]) (s :: S) = PDataRec {unPDataRec :: PRec struct s}
 
 -- | @since 1.10.0
-instance (SListI2 struct, All2 PInnerMostIsData struct) => PlutusType (PDataStruct struct) where
+instance (SListI2 struct, All2 PInnerMostIsDataDataRepr struct) => PlutusType (PDataStruct struct) where
   type PInner (PDataStruct struct) = PData
   type PCovariant' (PDataStruct struct) = All2 PCovariant'' struct
   type PContravariant' (PDataStruct struct) = All2 PContravariant'' struct
@@ -109,7 +86,7 @@ instance (SListI2 struct, All2 PInnerMostIsData struct) => PlutusType (PDataStru
   pmatch' x f = pmatchDataStruct (punsafeCoerce x) (f . PDataStruct)
 
 -- | @since 1.10.0
-instance (SListI struct, All PInnerMostIsData struct) => PlutusType (PDataRec struct) where
+instance (SListI struct, All PInnerMostIsDataDataRepr struct) => PlutusType (PDataRec struct) where
   type PInner (PDataRec struct) = PBuiltinList PData
   type PCovariant' (PDataRec struct) = All PCovariant'' struct
   type PContravariant' (PDataRec struct) = All PContravariant'' struct
@@ -140,7 +117,7 @@ instance
   ( SOP.Generic (a Any)
   , '[struct'] ~ Code (a Any)
   , struct ~ UnTermRec struct'
-  , All PInnerMostIsData struct
+  , All PInnerMostIsDataDataRepr struct
   , SListI struct
   , forall s. StructSameRepr s a '[struct]
   , RecTypePrettyError (Code (a Any))
@@ -164,7 +141,7 @@ instance
   forall (a :: S -> Type) (struct :: [[S -> Type]]).
   ( SOP.Generic (a Any)
   , struct ~ UnTermStruct (a Any)
-  , All2 PInnerMostIsData struct
+  , All2 PInnerMostIsDataDataRepr struct
   , SListI2 struct
   , forall s. StructSameRepr s a struct
   ) =>
@@ -191,25 +168,25 @@ instance
 
 pconDataRec ::
   forall (struct :: [S -> Type]) (s :: S).
-  All PInnerMostIsData struct =>
+  All PInnerMostIsDataDataRepr struct =>
   PRec struct s ->
   Term s (PDataRec struct)
 pconDataRec (PRec xs) =
   let
     collapesdData :: [Term s PData]
-    collapesdData = SOP.hcollapse $ SOP.hcmap (Proxy @PInnerMostIsData) (K . punsafeCoerce) xs
+    collapesdData = SOP.hcollapse $ SOP.hcmap (Proxy @PInnerMostIsDataDataRepr) (K . punsafeCoerce) xs
     builtinList = foldr (\x xs -> pconsBuiltin # x # xs) (pconstant []) collapesdData
    in
     punsafeCoerce builtinList
 
 pconDataStruct ::
   forall (struct :: [[S -> Type]]) (s :: S).
-  (SListI2 struct, All2 PInnerMostIsData struct) =>
+  (SListI2 struct, All2 PInnerMostIsDataDataRepr struct) =>
   PStruct struct s ->
   Term s (PDataStruct struct)
 pconDataStruct (PStruct xs) =
   let
-    collapesdData = SOP.hcollapse $ SOP.hcmap (Proxy @PInnerMostIsData) (K . punsafeCoerce) xs
+    collapesdData = SOP.hcollapse $ SOP.hcmap (Proxy @PInnerMostIsDataDataRepr) (K . punsafeCoerce) xs
     builtinList = foldr (\x xs -> pconsBuiltin # x # xs) (pconstant []) collapesdData
     idx = pconstant $ toInteger $ SOP.hindex xs
    in
@@ -234,7 +211,7 @@ newtype H s struct = H
 
 pmatchDataRec ::
   forall (struct :: [S -> Type]) b s.
-  All PInnerMostIsData struct =>
+  All PInnerMostIsDataDataRepr struct =>
   Term s (PDataRec struct) ->
   (PRec struct s -> Term s b) ->
   Term s b
@@ -312,13 +289,13 @@ newtype StructureHandler s r struct = StructureHandler
 -- This is probably general enough to be used for non-Data encoded types
 pmatchDataStruct ::
   forall (struct :: [[S -> Type]]) b s.
-  All2 PInnerMostIsData struct =>
+  All2 PInnerMostIsDataDataRepr struct =>
   Term s (PDataStruct struct) ->
   (PStruct struct s -> Term s b) ->
   Term s b
 pmatchDataStruct (punsafeCoerce -> x) f = unTermCont $ do
   let
-    go :: forall y ys. All PInnerMostIsData y => StructureHandler s b ys -> StructureHandler s b (y ': ys)
+    go :: forall y ys. All PInnerMostIsDataDataRepr y => StructureHandler s b ys -> StructureHandler s b (y ': ys)
     go (StructureHandler rest) = StructureHandler $ \i ds cps ->
       let
         dataRecAsBuiltinList :: Term s (PBuiltinList PData) -> Term s (PDataRec y)
@@ -332,7 +309,7 @@ pmatchDataStruct (punsafeCoerce -> x) f = unTermCont $ do
     -- This builds "handlers"--that is each cases of SOP data
     -- By building this we can figure out which cases share same computation, hence which branches to group
     handlers' :: StructureHandler s b struct
-    handlers' = SOP.cpara_SList (Proxy @(All PInnerMostIsData)) (StructureHandler $ \_ _ _ -> Nil) go
+    handlers' = SOP.cpara_SList (Proxy @(All PInnerMostIsDataDataRepr)) (StructureHandler $ \_ _ _ -> Nil) go
 
     handlers :: Term s (PBuiltinList PData) -> [(Integer, Term s b)]
     handlers d = SOP.hcollapse $ unSBR handlers' 0 d f

--- a/Plutarch/Repr/Derive.hs
+++ b/Plutarch/Repr/Derive.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Plutarch.Repr.Derive (DerivePLiftableAsRepr (DerivePLiftableAsRepr)) where
+
+import Data.Kind (Type)
+import GHC.Exts (Any)
+import GHC.Generics (Generic)
+import Generics.SOP (Code, SOP)
+import Generics.SOP qualified as SOP
+import Plutarch.Internal.Lift (
+  AsHaskell,
+  LiftError,
+  PLiftable,
+  PlutusRepr,
+  haskToRepr,
+  plutToRepr,
+  punsafeCoercePLifted,
+  reprToHask,
+  reprToPlut,
+ )
+import Plutarch.Internal.PlutusType (DeriveFakePlutusType (DeriveFakePlutusType), PInner, PlutusType)
+import Plutarch.Internal.Term (S)
+import Plutarch.Repr.Internal (StructAsHaskell, UnTermStruct')
+
+-- | @since WIP
+newtype DerivePLiftableAsRepr (wrapper :: S -> Type) (h :: Type) (s :: S)
+  = DerivePLiftableAsRepr (wrapper s)
+  deriving stock (Generic)
+  deriving anyclass (SOP.Generic)
+  deriving (PlutusType) via (DeriveFakePlutusType (DerivePLiftableAsRepr wrapper h))
+
+-- | @since WIP
+instance
+  forall wrapper h (struct' :: [[Type]]) (struct :: [[S -> Type]]) (hstruct :: [[Type]]).
+  ( PLiftable (PInner wrapper)
+  , SOP.Generic (wrapper Any)
+  , SOP.Generic h
+  , hstruct ~ Code h
+  , struct' ~ Code (wrapper Any)
+  , struct ~ UnTermStruct' struct'
+  , hstruct ~ StructAsHaskell struct
+  , AsHaskell (PInner wrapper) ~ SOP SOP.I hstruct
+  ) =>
+  PLiftable (DerivePLiftableAsRepr wrapper h)
+  where
+  type AsHaskell (DerivePLiftableAsRepr wrapper h) = h
+  type PlutusRepr (DerivePLiftableAsRepr wrapper h) = PlutusRepr (PInner wrapper)
+  haskToRepr :: h -> PlutusRepr (PInner wrapper)
+  haskToRepr x = haskToRepr @(PInner wrapper) $ SOP.from x
+  reprToHask :: PlutusRepr (PInner wrapper) -> Either LiftError h
+  reprToHask x = SOP.to <$> reprToHask @(PInner wrapper) x
+  reprToPlut x = punsafeCoercePLifted $ reprToPlut @(PInner wrapper) x
+  plutToRepr x = plutToRepr @(PInner wrapper) $ punsafeCoercePLifted x

--- a/Plutarch/Repr/Internal.hs
+++ b/Plutarch/Repr/Internal.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE UndecidableSuperClasses #-}
 
 module Plutarch.Repr.Internal (
+  RecAsHaskell,
   PStruct (PStruct, unPStruct),
   PRec (PRec, unPRec),
   pletL,
@@ -41,7 +42,7 @@ import Generics.SOP qualified as SOP
 import Plutarch.Builtin.Bool (PBool, pif)
 import Plutarch.Builtin.Integer (PInteger, pconstantInteger)
 import Plutarch.Internal.Eq (PEq, (#==))
-import Plutarch.Internal.Lift (pconstant)
+import Plutarch.Internal.Lift (AsHaskell, pconstant)
 import Plutarch.Internal.Term (Dig, S, Term, plet)
 import Plutarch.Internal.TermCont (hashOpenTerm, unTermCont)
 
@@ -196,3 +197,9 @@ pands :: [Term s PBool] -> Term s PBool
 pands [] = pconstant True
 pands [x'] = x'
 pands (x' : xs') = pif x' (pands xs') (pconstant False)
+
+--------------------------------------------------------------------------------
+
+type family RecAsHaskell a where
+  RecAsHaskell (x ': xs) = AsHaskell x ': RecAsHaskell xs
+  RecAsHaskell '[] = '[]

--- a/Plutarch/Repr/Internal.hs
+++ b/Plutarch/Repr/Internal.hs
@@ -4,6 +4,7 @@
 
 module Plutarch.Repr.Internal (
   RecAsHaskell,
+  StructAsHaskell,
   PStruct (PStruct, unPStruct),
   PRec (PRec, unPRec),
   pletL,
@@ -13,6 +14,7 @@ module Plutarch.Repr.Internal (
   StructSameRepr,
   UnTermRec,
   UnTermStruct,
+  UnTermStruct',
   RecTypePrettyError,
 ) where
 
@@ -200,6 +202,10 @@ pands (x' : xs') = pif x' (pands xs') (pconstant False)
 
 --------------------------------------------------------------------------------
 
-type family RecAsHaskell a where
+type family RecAsHaskell (x :: [S -> Type]) where
   RecAsHaskell (x ': xs) = AsHaskell x ': RecAsHaskell xs
   RecAsHaskell '[] = '[]
+
+type family StructAsHaskell (x :: [[S -> Type]]) where
+  StructAsHaskell (x ': xs) = RecAsHaskell x ': StructAsHaskell xs
+  StructAsHaskell '[] = '[]

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
@@ -151,11 +151,11 @@ deriving via
 
 -- | @since 3.3.0
 data PTxInfo (s :: S) = PTxInfo
-  { ptxInfo'inputs :: Term s (PAsData (PBuiltinList (PAsData PTxInInfo)))
-  , ptxInfo'outputs :: Term s (PAsData (PBuiltinList (PAsData PTxOut)))
+  { ptxInfo'inputs :: Term s (PAsData (PBuiltinList PTxInInfo))
+  , ptxInfo'outputs :: Term s (PAsData (PBuiltinList PTxOut))
   , ptxInfo'fee :: Term s (PAsData (Value.PValue 'AssocMap.Sorted 'Value.Positive))
   , ptxInfo'mint :: Term s (PAsData (Value.PValue 'AssocMap.Sorted 'Value.NoGuarantees)) -- value minted by transaction
-  , ptxInfo'dCert :: Term s (PAsData (PBuiltinList (PAsData DCert.PDCert)))
+  , ptxInfo'dCert :: Term s (PAsData (PBuiltinList DCert.PDCert))
   , ptxInfo'wdrl :: Term s (PAsData (PBuiltinList (PAsData (PBuiltinPair (PAsData Credential.PStakingCredential) (PAsData PInteger))))) -- Staking withdrawals
   , ptxInfo'validRange :: Term s (Interval.PInterval Time.PPosixTime)
   , ptxInfo'signatories :: Term s (PAsData (PBuiltinList (PAsData Crypto.PPubKeyHash)))

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -132,6 +132,7 @@ library
     Plutarch.Rational
     Plutarch.Reducible
     Plutarch.Repr.Data
+    Plutarch.Repr.Derive
     Plutarch.Repr.Internal
     Plutarch.Repr.Newtype
     Plutarch.Repr.Scott


### PR DESCRIPTION
```hs
data Foo =
  Foo Integer Integer
  deriving stock (Generic, Show)
  deriving anyclass (SOP.Generic)

data PFoo (s :: S) = PFoo
  { foo'a :: Term s (PAsData PInteger)
  , foo'b :: Term s (PAsData PInteger)
  }
  deriving stock (Generic)
  deriving anyclass (SOP.Generic, PIsData, PEq, PShow)
  deriving PlutusType via (DeriveAsDataRec PFoo)
  deriving PLiftable via (DerivePLiftableAsDataRec PFoo Foo)
```