### PR TITLE
Rework Tag strategy interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 * `DerivePlutusType` and everything related
 * `Plutarch.DataRepr`
+* `DeriveAsTag`, use `DeriveTagPlutusType` and `DeriveTagPLiftable` instead
 
 ## Added
 
 * `DeriveAsDataStruct``DeriveAsDataRec`, `DeriveAsSOPStruct`, `DeriveAsSOPRec` to `Plutarch.Prelude`
 * `pmatchListN`, `pmatchList`, `pmatchListUnsafe` for matching on list efficiently and ergonomically.
 * Added `ConstantHoist` option to the compilation option to allow configuring how threshold for constant to be hoisted.
+* `DeriveTagPlutusType` and `DeriveTagPLiftable`
 
 ## Changed
 

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -98,8 +98,9 @@ module Plutarch.Prelude (
 
   -- * Lifting and lowering
   PLiftable (..),
-  DeriveDataPLiftable,
-  DeriveNewtypePLiftable,
+  DeriveDataPLiftable (..),
+  DeriveNewtypePLiftable (..),
+  DeriveTagPLiftable (..),
   PLifted (..),
   reprToPlutUni,
   plutToReprUni,
@@ -152,6 +153,7 @@ module Plutarch.Prelude (
   DeriveAsDataRec (DeriveAsDataRec),
   DeriveAsSOPStruct (DeriveAsSOPStruct),
   DeriveAsSOPRec (DeriveAsSOPRec),
+  DeriveTagPlutusType (DeriveTagPlutusType),
 
   -- * Numeric
   Positive,
@@ -291,6 +293,7 @@ import Plutarch.Pair
 import Plutarch.Rational
 import Plutarch.Repr.Data
 import Plutarch.Repr.SOP
+import Plutarch.Repr.Tag
 import Plutarch.TermCont
 import Plutarch.Trace
 import Plutarch.Unroll

--- a/plutarch-docs/src/Typeclasses/PLiftable.md
+++ b/plutarch-docs/src/Typeclasses/PLiftable.md
@@ -201,6 +201,20 @@ To use `DeriveNewtypePLiftable` the following must hold:
 * `inner` has `PLiftable` instance
 * `AsHaskell inner` is coercible to `h`
 
+### Via `DeriveTagPLiftable`
+
+```haskell
+data Foo = A | B
+  deriving stock (Generic)
+  deriving anyclass (SOP.Generic)
+
+data PFoo s = PB | PA
+  deriving stock (Generic)
+  deriving anyclass (SOP.Generic)
+  deriving (PlutusType) via DeriveTagPlutusType PFoo
+  deriving (PLiftable) via DeriveTagPLiftable PFoo Foo
+```
+
 ### Manual derivation
 
 In the (unlikely) case that your type fits neither of the above, you will have


### PR DESCRIPTION
Split `DeriveAsTag` into `DeriveTagPlutusType` and `DeriveTagPLiftable`. We split in two instead of just adding a haskell-level param to the old strategy in case someone wants only `PlutusType` (I actually need that split for uplc-benchmark so there is a usecase)

The problem with old interface was that it was forcing `AsHaskell` of tag-encoded type to be the plutarch type parametrized with `Any` and that is quite annoying if there's an outside package that provides the haskell-level types.

It is in `Tag` module instead of `Lift` because I lost with cyclical modules.