### PR TITLE
Remove deprecated bits, PVariant and friends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Revision history for plutarch
 
+# 1.12.0 -- 
+
+## Removed
+
+* `PCon` and `PMatch`, as they were deprecated (for a long time)
+* `PVariant`, `PCovariant`, `PContravariant`, and all related types and type
+  classes (not useful)
+* `prememberData`, `pforgetData'` and `prememberData'` (as they were broken for
+  a while)
+
 # 1.11.0 -- 21-08-2025 
 
 ## Added

--- a/Plutarch/Internal/IsData.hs
+++ b/Plutarch/Internal/IsData.hs
@@ -10,11 +10,9 @@ module Plutarch.Internal.IsData (
   pdata,
   pfromData,
   pforgetData,
-  prememberData,
-  pforgetData',
-  prememberData',
 ) where
 
+import Data.Kind (Constraint, Type)
 import GHC.TypeError (ErrorMessage (ShowType, Text, (:$$:), (:<>:)), TypeError)
 import Plutarch.Builtin.Bool (PBool, pif')
 import Plutarch.Builtin.ByteString (PByteString)
@@ -33,24 +31,17 @@ import Plutarch.Builtin.Data (
  )
 import Plutarch.Builtin.Integer (PInteger, pconstantInteger)
 import Plutarch.Builtin.Unit (PUnit, punit)
-
-import Data.Kind (Constraint, Type)
-import Data.Proxy (Proxy (Proxy))
-
 import Plutarch.Internal.Eq (PEq ((#==)))
 import Plutarch.Internal.ListLike (
   PListLike (pcons, phead, pnil, ptail),
  )
-
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (PLamN (plam))
 import Plutarch.Internal.PlutusType (
-  PCovariant,
   PInnermost,
-  PVariant,
   PlutusType (PInner),
  )
-import Plutarch.Internal.Subtype (PSubtype, pupcast, pupcastF)
+import Plutarch.Internal.Subtype (PSubtype, pupcast)
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -62,9 +53,7 @@ import Plutarch.Internal.Term (
   (#),
   (#$),
  )
-import Plutarch.Internal.Witness (witness)
 import Plutarch.Unsafe (punsafeDowncast)
-
 import PlutusCore qualified as PLC
 import PlutusTx qualified as PTx
 
@@ -115,39 +104,6 @@ pdata = punsafeCoerce . pdataImpl
 
 pforgetData :: forall s a. Term s (PAsData a) -> Term s PData
 pforgetData = punsafeCoerce
-
--- FIXME: remove, broken
-
-{- | Like 'pforgetData', except it works for complex types.
- Equivalent to 'pupcastF'.
--}
-pforgetData' ::
-  forall a (p :: (S -> Type) -> S -> Type) (s :: S).
-  PCovariant p =>
-  Proxy p ->
-  Term s (p (PAsData a)) ->
-  Term s (p PData)
-pforgetData' _ = let _ = witness (Proxy @(PCovariant p)) in punsafeCoerce
-
--- | Inverse of 'pforgetData''.
-prememberData ::
-  forall (p :: (S -> Type) -> S -> Type) (s :: S).
-  PVariant p =>
-  Proxy p ->
-  Term s (p PData) ->
-  Term s (p (PAsData PData))
-prememberData Proxy = let _ = witness (Proxy @(PVariant p)) in punsafeCoerce
-
--- | Like 'prememberData' but generalised.
-prememberData' ::
-  forall a (p :: (S -> Type) -> S -> Type) (s :: S).
-  (PInnermostIsData 'Nothing a, PSubtype PData a, PVariant p) =>
-  Proxy p ->
-  Term s (p a) ->
-  Term s (p (PAsData a))
-prememberData' Proxy =
-  let _ = witness (Proxy @(PInnermostIsData 'Nothing a, PSubtype PData a, PVariant p))
-   in punsafeCoerce
 
 instance PIsData PData where
   pfromDataImpl = pupcast
@@ -215,4 +171,4 @@ instance
   PIsData (PBuiltinList a)
   where
   pfromDataImpl x = punsafeCoerce $ pasList # pforgetData x
-  pdataImpl x = plistData # pupcastF @PData @a (Proxy @PBuiltinList) x
+  pdataImpl x = plistData # punsafeCoerce x

--- a/Plutarch/Internal/Subtype.hs
+++ b/Plutarch/Internal/Subtype.hs
@@ -5,8 +5,6 @@ module Plutarch.Internal.Subtype (
   PSubtype,
   PSubtype',
   pupcast,
-  pupcastF,
-  pdowncastF,
 ) where
 
 import Data.Kind (Constraint)
@@ -15,10 +13,7 @@ import GHC.TypeError (
   ErrorMessage (ShowType, Text, (:<>:)),
   TypeError,
  )
-
 import Plutarch.Internal.PlutusType (
-  PContravariant,
-  PCovariant,
   PlutusType (PInner),
  )
 import Plutarch.Internal.Term (PType, Term, punsafeCoerce)
@@ -66,15 +61,3 @@ type family PSubtype (a :: PType) (b :: PType) :: Constraint where
 
 pupcast :: forall a b s. PSubtype a b => Term s b -> Term s a
 pupcast = let _ = witness (Proxy @(PSubtype a b)) in punsafeCoerce
-
-pupcastF :: forall a b (p :: PType -> PType) s. (PSubtype a b, PCovariant p) => Proxy p -> Term s (p b) -> Term s (p a)
-pupcastF _ =
-  let _ = witness (Proxy @(PSubtype a b))
-      _ = witness (Proxy @(PCovariant p))
-   in punsafeCoerce
-
-pdowncastF :: forall a b (p :: PType -> PType) s. (PSubtype a b, PContravariant p) => Proxy p -> Term s (p a) -> Term s (p b)
-pdowncastF _ =
-  let _ = witness (Proxy @(PSubtype a b))
-      _ = witness (Proxy @(PContravariant p))
-   in punsafeCoerce

--- a/Plutarch/Internal/TryFrom.hs
+++ b/Plutarch/Internal/TryFrom.hs
@@ -11,8 +11,6 @@ module Plutarch.Internal.TryFrom (
   PSubtype,
   PSubtype',
   pupcast,
-  pupcastF,
-  pdowncastF,
 ) where
 
 import Data.Functor.Const (Const)
@@ -52,9 +50,7 @@ import Plutarch.Internal.Subtype (
   PSubtype,
   PSubtype',
   PSubtypeRelation (PNoSubtypeRelation, PSubtypeRelation),
-  pdowncastF,
   pupcast,
-  pupcastF,
  )
 import Plutarch.Internal.Term (
   PType,

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -157,8 +157,6 @@ module Plutarch.Prelude (
 
   -- * PlutusType
   DerivePlutusType (DPTStrat),
-  PCon,
-  PMatch,
   PlutusType (PInner),
   pcon,
   pmatch,

--- a/Plutarch/Repr/Data.hs
+++ b/Plutarch/Repr/Data.hs
@@ -42,13 +42,7 @@ import Plutarch.Internal.ListLike (phead, ptail)
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
-  PContravariant',
-  PContravariant'',
-  PCovariant',
-  PCovariant'',
   PInner,
-  PVariant',
-  PVariant'',
   PlutusType,
   pcon,
   pcon',
@@ -94,18 +88,12 @@ newtype PDataRec (struct :: [S -> Type]) (s :: S) = PDataRec {unPDataRec :: PRec
 -- | @since 1.10.0
 instance (SListI2 struct, All2 PInnermostIsDataDataRepr struct) => PlutusType (PDataStruct struct) where
   type PInner (PDataStruct struct) = PData
-  type PCovariant' (PDataStruct struct) = All2 PCovariant'' struct
-  type PContravariant' (PDataStruct struct) = All2 PContravariant'' struct
-  type PVariant' (PDataStruct struct) = All2 PVariant'' struct
   pcon' (PDataStruct x) = punsafeCoerce $ pconDataStruct x
   pmatch' x f = pmatchDataStruct (punsafeCoerce x) (f . PDataStruct)
 
 -- | @since 1.10.0
 instance (SListI struct, All PInnermostIsDataDataRepr struct) => PlutusType (PDataRec struct) where
   type PInner (PDataRec struct) = PBuiltinList PData
-  type PCovariant' (PDataRec struct) = All PCovariant'' struct
-  type PContravariant' (PDataRec struct) = All PContravariant'' struct
-  type PVariant' (PDataRec struct) = All PVariant'' struct
   pcon' (PDataRec x) = punsafeCoerce $ pconDataRec x
   pmatch' x f = pmatchDataRec (punsafeCoerce x) (f . PDataRec)
 
@@ -167,9 +155,6 @@ instance
   PlutusType (DeriveAsDataRec a)
   where
   type PInner (DeriveAsDataRec a) = PDataRec (UnTermRec (Head (Code (a Any))))
-  type PCovariant' (DeriveAsDataRec a) = PCovariant' a
-  type PContravariant' (DeriveAsDataRec a) = PContravariant' a
-  type PVariant' (DeriveAsDataRec a) = PVariant' a
   pcon' (DeriveAsDataRec x) =
     pcon $ PDataRec $ PRec $ SOP.unZ $ SOP.unSOP $ SOP.hcoerce $ SOP.from x
   pmatch' x f =
@@ -215,9 +200,6 @@ instance
   PlutusType (DeriveAsDataStruct a)
   where
   type PInner (DeriveAsDataStruct a) = PDataStruct (UnTermStruct (a Any))
-  type PCovariant' (DeriveAsDataStruct a) = PCovariant' a
-  type PContravariant' (DeriveAsDataStruct a) = PContravariant' a
-  type PVariant' (DeriveAsDataStruct a) = PVariant' a
   pcon' (DeriveAsDataStruct x) =
     pcon @(PDataStruct (UnTermStruct (a Any))) $ PDataStruct $ PStruct $ SOP.hcoerce $ SOP.from x
   pmatch' x f =

--- a/Plutarch/Repr/Newtype.hs
+++ b/Plutarch/Repr/Newtype.hs
@@ -19,10 +19,7 @@ import Generics.SOP (
 import Generics.SOP qualified as SOP
 import Generics.SOP.Constraint (Head)
 import Plutarch.Internal.PlutusType (
-  PContravariant',
-  PCovariant',
   PInner,
-  PVariant',
   PlutusType,
   pcon',
   pmatch',
@@ -51,9 +48,6 @@ instance
   PlutusType (DeriveNewtypePlutusType a)
   where
   type PInner (DeriveNewtypePlutusType a) = UnTermSingle (Head (Head (Code (a Any))))
-  type PCovariant' (DeriveNewtypePlutusType a) = PCovariant' a
-  type PContravariant' (DeriveNewtypePlutusType a) = PContravariant' a
-  type PVariant' (DeriveNewtypePlutusType a) = PVariant' a
 
   -- This breaks without type signature because of (s :: S) needs to be bind.
   pcon' :: forall s. DeriveNewtypePlutusType a s -> Term s (PInner (DeriveNewtypePlutusType a))

--- a/Plutarch/Repr/SOP.hs
+++ b/Plutarch/Repr/SOP.hs
@@ -34,13 +34,7 @@ import Plutarch.Internal.Eq (PEq, (#==))
 import Plutarch.Internal.Lift
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
-  PContravariant',
-  PContravariant'',
-  PCovariant',
-  PCovariant'',
   PInner,
-  PVariant',
-  PVariant'',
   PlutusType,
   pcon,
   pcon',
@@ -84,9 +78,6 @@ newtype PSOPStruct (struct :: [[S -> Type]]) (s :: S) = PSOPStruct
 -- | @since 1.10.0
 instance (SListI2 struct, PSOPStructConstraint struct) => PlutusType (PSOPStruct struct) where
   type PInner (PSOPStruct struct) = POpaque
-  type PCovariant' (PSOPStruct struct) = All2 PCovariant'' struct
-  type PContravariant' (PSOPStruct struct) = All2 PContravariant'' struct
-  type PVariant' (PSOPStruct struct) = All2 PVariant'' struct
   pcon' (PSOPStruct x) = punsafeCoerce $ pconSOPStruct x
   pmatch' x f = pmatchSOPStruct (punsafeCoerce x) (f . PSOPStruct)
 
@@ -111,9 +102,6 @@ newtype PSOPRec (struct :: [S -> Type]) (s :: S) = PSOPRec
 -- | @since 1.10.0
 instance SListI struct => PlutusType (PSOPRec struct) where
   type PInner (PSOPRec struct) = POpaque
-  type PCovariant' (PSOPRec struct) = All PCovariant'' struct
-  type PContravariant' (PSOPRec struct) = All PContravariant'' struct
-  type PVariant' (PSOPRec struct) = All PVariant'' struct
   pcon' (PSOPRec x) = punsafeCoerce $ pconSOPRec x
   pmatch' x f = pmatchSOPRec (punsafeCoerce x) (f . PSOPRec)
 
@@ -152,9 +140,6 @@ instance
   PlutusType (DeriveAsSOPStruct a)
   where
   type PInner (DeriveAsSOPStruct a) = PSOPStruct (UnTermStruct (a Any))
-  type PCovariant' (DeriveAsSOPStruct a) = PCovariant' a
-  type PContravariant' (DeriveAsSOPStruct a) = PContravariant' a
-  type PVariant' (DeriveAsSOPStruct a) = PVariant' a
   pcon' (DeriveAsSOPStruct x) =
     pcon @(PSOPStruct (UnTermStruct (a Any))) $ PSOPStruct $ PStruct $ SOP.hcoerce $ SOP.from x
   pmatch' x f =
@@ -184,9 +169,6 @@ instance
   PlutusType (DeriveAsSOPRec a)
   where
   type PInner (DeriveAsSOPRec a) = PSOPRec (UnTermRec (Head (Code (a Any))))
-  type PCovariant' (DeriveAsSOPRec a) = PCovariant' a
-  type PContravariant' (DeriveAsSOPRec a) = PContravariant' a
-  type PVariant' (DeriveAsSOPRec a) = PVariant' a
   pcon' (DeriveAsSOPRec x) =
     pcon $ PSOPRec $ PRec $ SOP.unZ $ SOP.unSOP $ SOP.hcoerce $ SOP.from x
   pmatch' x f =

--- a/Plutarch/Repr/Scott.hs
+++ b/Plutarch/Repr/Scott.hs
@@ -20,13 +20,7 @@ import Generics.SOP.Constraint (All, All2, Head, SListI, SListI2)
 import Plutarch.Internal.Eq (PEq, (#==))
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
-  PContravariant',
-  PContravariant'',
-  PCovariant',
-  PCovariant'',
   PInner,
-  PVariant',
-  PVariant'',
   PlutusType,
   pcon,
   pcon',
@@ -67,9 +61,6 @@ newtype PScottStruct (struct :: [[S -> Type]]) (s :: S) = PScottStruct
 -- | @since 1.10.0
 instance forall struct. (SListI2 struct, PScottStructConstraint struct) => PlutusType (PScottStruct struct) where
   type PInner (PScottStruct struct) = PForall (PScottStructInner struct) -- try `Any`
-  type PCovariant' (PScottStruct struct) = All2 PCovariant'' struct
-  type PContravariant' (PScottStruct struct) = All2 PContravariant'' struct
-  type PVariant' (PScottStruct struct) = All2 PVariant'' struct
   pcon' (PScottStruct x) = punsafeCoerce $ pconScottStruct @struct x
   pmatch' x f = pmatchScottStruct @struct (punsafeCoerce x) (f . PScottStruct)
 
@@ -98,9 +89,6 @@ newtype PScottRec (struct :: [S -> Type]) (s :: S) = PScottRec
 -- | @since 1.10.0
 instance SListI struct => PlutusType (PScottRec struct) where
   type PInner (PScottRec struct) = PForall (PScottRecInner struct)
-  type PCovariant' (PScottRec struct) = All PCovariant'' struct
-  type PContravariant' (PScottRec struct) = All PContravariant'' struct
-  type PVariant' (PScottRec struct) = All PVariant'' struct
   pcon' (PScottRec x) = punsafeCoerce $ pconScottRec x
   pmatch' x f = pmatchScottRec (punsafeCoerce x) (f . PScottRec)
 
@@ -142,9 +130,6 @@ instance
   PlutusType (DeriveAsScottStruct a)
   where
   type PInner (DeriveAsScottStruct a) = PScottStruct (UnTermStruct (a Any))
-  type PCovariant' (DeriveAsScottStruct a) = (PCovariant' a)
-  type PContravariant' (DeriveAsScottStruct a) = (PContravariant' a)
-  type PVariant' (DeriveAsScottStruct a) = (PVariant' a)
   pcon' (DeriveAsScottStruct x) =
     pcon @(PScottStruct (UnTermStruct (a Any))) $ PScottStruct $ PStruct $ SOP.hcoerce $ SOP.from x
   pmatch' x f =
@@ -169,9 +154,6 @@ instance
   PlutusType (DeriveAsScottRec a)
   where
   type PInner (DeriveAsScottRec a) = PScottRec (UnTermRec (Head (Code (a Any))))
-  type PCovariant' (DeriveAsScottRec a) = (PCovariant' a)
-  type PContravariant' (DeriveAsScottRec a) = (PContravariant' a)
-  type PVariant' (DeriveAsScottRec a) = (PVariant' a)
   pcon' (DeriveAsScottRec x) =
     pcon $ PScottRec $ PRec $ SOP.unZ $ SOP.unSOP $ SOP.hcoerce $ SOP.from x
   pmatch' x f =

--- a/Plutarch/Repr/Tag.hs
+++ b/Plutarch/Repr/Tag.hs
@@ -37,10 +37,7 @@ import Plutarch.Internal.Lift (
   pconstant,
  )
 import Plutarch.Internal.PlutusType (
-  PContravariant',
-  PCovariant',
   PInner,
-  PVariant',
   PlutusType,
   pcon',
   pmatch',
@@ -86,9 +83,6 @@ instance SOP.Generic (PFoo s)
 -}
 instance (forall s. TagTypeConstraints s a struct) => PlutusType (DeriveAsTag a) where
   type PInner (DeriveAsTag a) = PInteger
-  type PCovariant' (DeriveAsTag a) = (PCovariant' a)
-  type PContravariant' (DeriveAsTag a) = (PContravariant' a)
-  type PVariant' (DeriveAsTag a) = (PVariant' a)
   pcon' :: forall s. DeriveAsTag a s -> Term s (PInner (DeriveAsTag a))
   pcon' (DeriveAsTag x) =
     pconstant @PInteger $ toInteger $ SOP.hindex $ SOP.from x

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               plutarch
-version:            1.11.0
+version:            1.12.0
 author:
   Las Safin <me@las.rs>, Koz Ross <koz@mlabs.city>, Seungheon Oh <seungheon.oh@mlabs.city>, Philip DiSarro <philipdisarro@gmail.com>
 


### PR DESCRIPTION
Closes #808 . In the process, I have also removed the following:

* `PMatch` and `PCon`. These two were deprecated for multiple releases already, so it's not like we didn't warn people.
* `prememberData`, `pforgetData'` and `prememberData'`, as they have been broken for a while.