### PR TITLE
Choener/explicit eq no digest

### DIFF
--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -20,11 +20,15 @@ module Plutarch.DataRepr.Internal (
   PlutusTypeData,
 ) where
 
+import Control.Arrow (second)
 import Data.Coerce (coerce)
 import Data.Functor.Compose qualified as F
 import Data.Functor.Const (Const (Const))
+import Data.HashMap.Strict qualified as HM
+import Data.Hashable (Hashed)
 import Data.Kind (Type)
-import Data.List (groupBy, maximumBy, sortOn)
+import Data.List (maximumBy)
+import Data.Ord (comparing)
 import Data.Proxy (Proxy (Proxy))
 import Data.SOP.NP (cana_NP)
 import Data.String (fromString)
@@ -97,7 +101,7 @@ import Plutarch.Internal.PlutusType (
  )
 import Plutarch.Internal.Show (PShow (pshow'))
 import Plutarch.Internal.Term (
-  Dig,
+  RawTerm,
   Term,
   pdelay,
   perror,
@@ -478,7 +482,7 @@ pmatchLT d1 d2 handlers = unTermCont $ do
         : applyHandlers args1 args2 rest
 
 reprHandlersGo ::
-  (Dig, Term s out) ->
+  (Hashed RawTerm, Term s out) ->
   Integer ->
   [Term s out] ->
   Term s PInteger ->
@@ -494,17 +498,18 @@ reprHandlersGo common idx (handler : rest) c =
           handler
           $ reprHandlersGo common (idx + 1) rest c
 
-hashHandlers :: [Term s out] -> TermCont s [(Dig, Term s out)]
+hashHandlers :: [Term s out] -> TermCont s [(Hashed RawTerm, Term s out)]
 hashHandlers [] = pure []
 hashHandlers (handler : rest) = do
   hash <- hashOpenTerm handler
   hashes <- hashHandlers rest
   pure $ (hash, handler) : hashes
 
-findCommon :: [Term s out] -> TermCont s (Dig, Term s out)
+findCommon :: [Term s out] -> TermCont s (Hashed RawTerm, Term s out)
 findCommon handlers = do
   l <- hashHandlers handlers
-  pure $ head . maximumBy (\x y -> length x `compare` length y) . groupBy (\x y -> fst x == fst y) . sortOn fst $ l
+  let counted :: HM.HashMap (Hashed RawTerm) [Term _ _] = HM.fromListWith (++) $ map (second (: [])) l
+  pure . second head . maximumBy (comparing (length . snd)) $ HM.toList counted
 
 mkLTHandler :: forall def s. All (Compose POrd PDataRecord) def => NP (DualReprHandler s PBool) def
 mkLTHandler = cana_NP (Proxy @(Compose POrd PDataRecord)) rer $ Const ()

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -109,6 +109,10 @@ module Plutarch.Prelude (
   PLiftable (..),
   DeriveDataPLiftable,
   DeriveNewtypePLiftable,
+  DeriveAsDataRec (..),
+  DeriveAsDataStruct (..),
+  DeriveAsSOPRec (..),
+  DeriveAsSOPStruct (..),
   PLifted (..),
   reprToPlutUni,
   plutToReprUni,
@@ -307,6 +311,8 @@ import Plutarch.List
 import Plutarch.Maybe
 import Plutarch.Pair
 import Plutarch.Rational
+import Plutarch.Repr.Data (DeriveAsDataRec (..), DeriveAsDataStruct (..))
+import Plutarch.Repr.SOP (DeriveAsSOPRec (..), DeriveAsSOPStruct (..))
 import Plutarch.TermCont
 import Plutarch.Trace
 import Plutarch.Unroll

--- a/Plutarch/Repr/Data.hs
+++ b/Plutarch/Repr/Data.hs
@@ -10,7 +10,6 @@ module Plutarch.Repr.Data (
 ) where
 
 import Data.Kind (Type)
-import Data.Maybe (catMaybes)
 import Data.Proxy (Proxy (Proxy))
 import GHC.Exts (Any)
 import Generics.SOP (
@@ -68,6 +67,7 @@ import Plutarch.Internal.Term (
   (#),
   (#$),
  )
+import Plutarch.Internal.TermCont (pfindAllPlaceholders)
 import Plutarch.Repr.Internal (
   PRec (PRec, unPRec),
   PStruct (PStruct, unPStruct),
@@ -78,7 +78,7 @@ import Plutarch.Repr.Internal (
   UnTermStruct,
   groupHandlers,
  )
-import Plutarch.TermCont (pfindPlaceholder, pletC, unTermCont)
+import Plutarch.TermCont (pletC, unTermCont)
 import PlutusLedgerApi.V3 qualified as PLA
 
 type PInnermostIsDataDataRepr =
@@ -295,14 +295,7 @@ pmatchDataRec (punsafeCoerce -> x) f = pgetInternalConfig $ \cfg -> unTermCont $
 
   usedFields <-
     if internalConfig'dataRecPMatchOptimization cfg
-      then
-        catMaybes
-          <$> traverse
-            ( \idx -> do
-                found <- pfindPlaceholder idx placeholderApplied
-                pure $ if found then Just idx else Nothing
-            )
-            [0 .. (snd placeholder)]
+      then pfindAllPlaceholders placeholderApplied
       else pure [0 .. (snd placeholder)]
 
   let

--- a/cabal.project
+++ b/cabal.project
@@ -22,7 +22,7 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
-index-state: 2025-07-30T14:13:57Z
+index-state: 2025-04-16T12:27:40Z
 
 packages:
   ./.

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Interval.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Interval.hs
@@ -37,7 +37,6 @@ import Data.Kind (Type)
 import GHC.Generics (Generic)
 import Generics.SOP qualified as SOP
 import Plutarch.Prelude hiding (psingleton, pto)
-import Plutarch.Repr.Data
 import PlutusLedgerApi.V3 qualified as Plutus
 
 -- | @since 2.0.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Utils.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Utils.hs
@@ -45,7 +45,6 @@ import GHC.Generics (Generic)
 import Generics.SOP qualified as SOP
 import Plutarch.Internal.PlutusType (PlutusType (pcon', pmatch'))
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import Plutarch.Unsafe (punsafeCoerce)
 import PlutusLedgerApi.V3 qualified as Plutus
 

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1.hs
@@ -83,7 +83,6 @@ import Plutarch.LedgerApi.V1.Time qualified as Time
 import Plutarch.LedgerApi.V1.Tx qualified as Tx
 import Plutarch.LedgerApi.Value qualified as Value
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V1 qualified as Plutus
 
 -- | @since 3.1.1

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Address.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Address.hs
@@ -10,7 +10,6 @@ import Generics.SOP qualified as SOP
 import Plutarch.LedgerApi.Utils (PMaybeData)
 import Plutarch.LedgerApi.V1.Credential (PCredential, PStakingCredential)
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V1 qualified as Plutus
 
 -- | @since 2.0.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Contexts.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Contexts.hs
@@ -11,7 +11,6 @@ import Plutarch.LedgerApi.V1.DCert qualified as DCert
 import Plutarch.LedgerApi.V1.Tx qualified as Tx
 import Plutarch.LedgerApi.Value qualified as Value
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V1 qualified as Plutus
 
 -- | @since 3.1.1

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Credential.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Credential.hs
@@ -11,7 +11,6 @@ import Generics.SOP qualified as SOP
 import Plutarch.LedgerApi.V1.Crypto (PPubKeyHash)
 import Plutarch.LedgerApi.V1.Scripts (PScriptHash)
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V1 qualified as Plutus
 
 -- | @since 2.0.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/DCert.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/DCert.hs
@@ -10,7 +10,6 @@ import Generics.SOP qualified as SOP
 import Plutarch.LedgerApi.V1.Credential (PStakingCredential)
 import Plutarch.LedgerApi.V1.Crypto (PPubKeyHash)
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V1 qualified as Plutus
 
 -- | @since 3.1.1

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Tx.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Tx.hs
@@ -9,7 +9,6 @@ module Plutarch.LedgerApi.V1.Tx (
 import GHC.Generics (Generic)
 import Generics.SOP qualified as SOP
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V1 qualified as Plutus
 
 {- | Hashed with @BLAKE2b-256@.

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V2.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V2.hs
@@ -85,7 +85,6 @@ import Plutarch.LedgerApi.V1.Tx qualified as V1Tx
 import Plutarch.LedgerApi.V2.Tx qualified as V2Tx
 import Plutarch.LedgerApi.Value qualified as Value
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V2 qualified as Plutus
 
 -- | @since 3.1.1

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V2/Tx.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V2/Tx.hs
@@ -14,7 +14,6 @@ import Plutarch.LedgerApi.V1.Address (PAddress)
 import Plutarch.LedgerApi.V1.Scripts (PDatum, PDatumHash, PScriptHash)
 import Plutarch.LedgerApi.Value qualified as Value
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V2 qualified as Plutus
 
 -- | @since 2.0.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Contexts.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Contexts.hs
@@ -56,7 +56,6 @@ import Plutarch.LedgerApi.V2.Tx (PTxOut)
 import Plutarch.LedgerApi.V3.Tx (PTxId, PTxOutRef)
 import Plutarch.LedgerApi.Value qualified as Value
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V3 qualified as Plutus
 
 -- | @since 3.1.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Tx.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/Tx.hs
@@ -9,7 +9,6 @@ import Data.ByteString (ByteString)
 import GHC.Generics (Generic)
 import Generics.SOP qualified as SOP
 import Plutarch.Prelude
-import Plutarch.Repr.Data (DeriveAsDataStruct (DeriveAsDataStruct))
 import PlutusLedgerApi.V3 qualified as Plutus
 import PlutusTx.Builtins.Internal qualified as PlutusTx
 

--- a/plutarch-orphanage/plutarch-orphanage.cabal
+++ b/plutarch-orphanage/plutarch-orphanage.cabal
@@ -73,7 +73,7 @@ library
   build-depends:
     , bytestring
     , containers
-    , plutus-core           >=1.51.0.0
+    , plutus-core           >=1.45.0.0
     , plutus-ledger-api
     , plutus-tx
     , prettyprinter

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -8,6 +8,13 @@ license:            MIT
 extra-source-files: README.md
 tested-with:        GHC ==9.6.4
 
+flag check-phoist
+  description:
+    Checks every single phoistAcyclic. This is fairly costly for large scripts!
+
+  default:     False
+  manual:      True
+
 common c
   default-language:   GHC2021
   default-extensions:
@@ -69,6 +76,9 @@ common c
     -fprint-equality-relations -fprint-explicit-kinds
     -fprint-explicit-foralls -Wno-missing-import-lists
     -Wno-missing-export-lists
+
+  if flag(check-phoist)
+    cpp-options: -DCHECKPHOIST
 
 library
   import:          c
@@ -154,13 +164,15 @@ library
     , data-default
     , flat
     , generics-sop
+    , hashable
     , lens
     , mtl
-    , plutus-core        >=1.51.0.0
+    , plutus-core           >=1.51.0.0
     , plutus-ledger-api
     , plutus-tx
     , prettyprinter
     , QuickCheck
     , random
     , sop-core
+    , unordered-containers
     , vector

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -167,7 +167,7 @@ library
     , hashable
     , lens
     , mtl
-    , plutus-core           >=1.51.0.0
+    , plutus-core           >=1.45.0.0
     , plutus-ledger-api
     , plutus-tx
     , prettyprinter


### PR DESCRIPTION
In this branch, I have replaced the digest-based system of keeping track of `HoistedTerm`s with, essentially, `(Hash HoistedTerm, RawTerm)` and storage in a `HashMap`. Collisions are now handled first checking the cheap hash, then the full term.

In addition, `phoistAcyclic` checks have been made optional (though this should maybe be a runtime option, not a compilation option as is now).

Finally, I added `pfindAllPlaceholders` which is more cheap than repeatedly traversing the tree with `pfindPlaceholder`.

Apart from compilation performance-related changes, I re-added some functions that Djed uses.

===

The second commit changes the plutus-core version to 1.45, which works out fine in all tests and corresponds to mainnet.
