### PR TITLE
Improve DeriveAsTag

### DIFF
--- a/Plutarch/Repr/Tag.hs
+++ b/Plutarch/Repr/Tag.hs
@@ -35,10 +35,14 @@ import Plutarch.Internal.Lift (
   pconstant,
  )
 import Plutarch.Internal.PlutusType (PlutusType (PInner, pcon', pmatch'))
-import Plutarch.Internal.Term (S, Term)
-import Plutarch.Repr.Internal (groupHandlers)
+import Plutarch.Internal.Term (
+  RawTerm (RCase),
+  S,
+  Term (Term),
+  TermResult (TermResult),
+  asRawTerm,
+ )
 import Plutarch.Repr.Newtype (DeriveNewtypePlutusType (DeriveNewtypePlutusType))
-import Plutarch.TermCont (pletC, unTermCont)
 
 -- | @since 1.10.0
 newtype PTag (struct :: [S -> Type]) (s :: S) = PTag
@@ -74,32 +78,27 @@ instance SOP.Generic (PFoo s)
 
 @since 1.10.0
 -}
-instance (forall s. TagTypeConstraints s a struct) => PlutusType (DeriveAsTag a) where
+instance (forall (s :: S). TagTypeConstraints s a struct) => PlutusType (DeriveAsTag a) where
   type PInner (DeriveAsTag a) = PInteger
-  pcon' :: forall s. DeriveAsTag a s -> Term s (PInner (DeriveAsTag a))
-  pcon' (DeriveAsTag x) =
-    pconstant @PInteger $ toInteger $ SOP.hindex $ SOP.from x
-
-  pmatch' :: forall s b. Term s (PInner (DeriveAsTag a)) -> (DeriveAsTag a s -> Term s b) -> Term s b
-  pmatch' tag f = unTermCont $ do
-    -- plet here because tag might be a big computation
-    tag' <- pletC tag
-    let
-      g :: SOP I (Code (a s)) -> Term s b
-      g = f . DeriveAsTag . SOP.to
-
-      go :: forall x xs. IsEmpty x => TagMatchHandler s b xs -> TagMatchHandler s b (x ': xs)
-      go (TagMatchHandler rest) =
-        TagMatchHandler $ \idx handle ->
-          K (idx, handle $ SOP $ Z Nil) :* rest (idx + 1) (\(SOP x) -> handle $ SOP $ S x)
-
+  pcon' :: forall (s :: S). DeriveAsTag a s -> Term s PInteger
+  pcon' (DeriveAsTag x) = pconstant . toInteger . SOP.hindex . SOP.from $ x
+  pmatch' :: forall (s :: S) (b :: S -> Type). Term s PInteger -> (DeriveAsTag a s -> Term s b) -> Term s b
+  pmatch' tag f = Term $ \level -> do
+    TermResult rawTag depsTag <- asRawTerm tag level
+    rawHandlerTRs <- traverse (`asRawTerm` level) handlers
+    let (rawHandlers, depsHandlers) = unzip . fmap (\(TermResult x y) -> (x, y)) $ rawHandlerTRs
+    let allDeps = depsTag <> mconcat depsHandlers
+    pure . TermResult (RCase rawTag rawHandlers) $ allDeps
+    where
+      handlers :: [Term s b]
+      handlers = SOP.hcollapse . unTagMatchHandler handlers' $ toHandler
+      toHandler :: SOP I (Code (a s)) -> Term s b
+      toHandler = f . DeriveAsTag . SOP.to
       handlers' :: TagMatchHandler s b struct
-      handlers' = SOP.cpara_SList (Proxy @IsEmpty) (TagMatchHandler $ \_ _ -> Nil) go
-
-      handlers :: [(Integer, Term s b)]
-      handlers = SOP.hcollapse $ unTagMatchHandler handlers' 0 g
-
-    pure $ groupHandlers handlers tag'
+      handlers' = SOP.cpara_SList (Proxy @IsEmpty) (TagMatchHandler (const Nil)) go
+      go :: forall x xs. IsEmpty x => TagMatchHandler s b xs -> TagMatchHandler s b (x ': xs)
+      go (TagMatchHandler rest) = TagMatchHandler $ \handle ->
+        K (handle . SOP $ Z Nil) :* rest (\(SOP x) -> handle . SOP $ S x)
 
 -- | @since 1.10.0
 newtype TagLiftHelper r struct = TagLiftHelper
@@ -130,7 +129,7 @@ class (SOP.Generic (a s), TagTypePrettyError (Code (a s)), Code (a s) ~ struct, 
 instance (SOP.Generic (a s), TagTypePrettyError (Code (a s)), Code (a s) ~ struct, All IsEmpty struct) => TagTypeConstraints s a struct
 
 newtype TagMatchHandler s b struct = TagMatchHandler
-  { unTagMatchHandler :: Integer -> (SOP I struct -> Term s b) -> NP (K (Integer, Term s b)) struct
+  { unTagMatchHandler :: (SOP I struct -> Term s b) -> NP (K (Term s b)) struct
   }
 
 instance

--- a/plutarch-testlib/goldens/derive-as-tag.bench.golden
+++ b/plutarch-testlib/goldens/derive-as-tag.bench.golden
@@ -1,0 +1,2 @@
+pcon {"exBudgetCPU":16100,"exBudgetMemory":200,"scriptSizeBytes":7}
+pmatch {"exBudgetCPU":164433,"exBudgetMemory":801,"scriptSizeBytes":15}

--- a/plutarch-testlib/goldens/derive-as-tag.bench.golden
+++ b/plutarch-testlib/goldens/derive-as-tag.bench.golden
@@ -1,2 +1,2 @@
 pcon {"exBudgetCPU":16100,"exBudgetMemory":200,"scriptSizeBytes":7}
-pmatch {"exBudgetCPU":164433,"exBudgetMemory":801,"scriptSizeBytes":15}
+pmatch {"exBudgetCPU":48100,"exBudgetMemory":400,"scriptSizeBytes":15}

--- a/plutarch-testlib/goldens/derive-as-tag.uplc.eval.golden
+++ b/plutarch-testlib/goldens/derive-as-tag.uplc.eval.golden
@@ -1,0 +1,2 @@
+pcon program 1.1.0 2
+pmatch program 1.1.0 True

--- a/plutarch-testlib/goldens/derive-as-tag.uplc.golden
+++ b/plutarch-testlib/goldens/derive-as-tag.uplc.golden
@@ -1,2 +1,2 @@
 pcon program 1.1.0 2
-pmatch program 1.1.0 (case (equalsInteger 3 3) [False, True])
+pmatch program 1.1.0 (case 3 [False, False, False, True, False])

--- a/plutarch-testlib/goldens/derive-as-tag.uplc.golden
+++ b/plutarch-testlib/goldens/derive-as-tag.uplc.golden
@@ -1,0 +1,2 @@
+pcon program 1.1.0 2
+pmatch program 1.1.0 (case (equalsInteger 3 3) [False, True])

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/DeriveAsTag.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/DeriveAsTag.hs
@@ -12,8 +12,9 @@ import Plutarch.Internal.Lift (
   PLiftable,
   PLifted (PLifted),
  )
-import Plutarch.Prelude (PEq, PlutusType, S)
+import Plutarch.Prelude (PBool (PFalse, PTrue), PEq, PlutusType, S, pcon, pmatch)
 import Plutarch.Repr.Tag (DeriveAsTag (DeriveAsTag))
+import Plutarch.Test.Golden (goldenEval, plutarchGolden)
 import Plutarch.Test.Laws (checkPLiftableLaws, checkPLiftableLawsForDeriveTags, checkPlutusTypeLaws)
 import Prettyprinter (Pretty (pretty))
 import Test.QuickCheck.Arbitrary (Arbitrary (arbitrary))
@@ -45,9 +46,15 @@ tests :: TestTree
 tests =
   testGroup
     "DeriveAsTag"
-    ( mconcat
+    [ testGroup "Laws" . mconcat $
         [ checkPLiftableLawsForDeriveTags @PFoo
         , checkPLiftableLaws @PFoo
         , checkPlutusTypeLaws @PFoo
         ]
-    )
+    , plutarchGolden
+        "Tag encoding and decoding"
+        "derive-as-tag"
+        [ goldenEval "pcon" (pcon C)
+        , goldenEval "pmatch" (pmatch (pcon D) (\x -> if x == D then pcon PTrue else pcon PFalse))
+        ]
+    ]


### PR DESCRIPTION
Fixes #888. I also added a golden test to show the improvement:

```
-pmatch {"exBudgetCPU":164433,"exBudgetMemory":801,"scriptSizeBytes":15}
+pmatch {"exBudgetCPU":48100,"exBudgetMemory":400,"scriptSizeBytes":15}
```