### PR TITLE
`PValidateData PBool` optimization

### DIFF
--- a/Plutarch/Internal/Parse.hs
+++ b/Plutarch/Internal/Parse.hs
@@ -37,7 +37,9 @@ import Plutarch.Builtin.Data (
   pheadBuiltin,
   pheadTailBuiltin,
  )
-import Plutarch.Builtin.Integer (PInteger, pconstantInteger)
+import Plutarch.Builtin.Integer (PInteger)
+import Plutarch.Builtin.Opaque (popaque)
+import Plutarch.Internal.Case (punsafeCase)
 import Plutarch.Internal.Eq ((#==))
 import Plutarch.Internal.Fix (pfix)
 import Plutarch.Internal.IsData (PIsData)
@@ -154,16 +156,16 @@ second field of @Constr@ is not checked at all.
 @since 1.12.0
 -}
 instance PValidateData PBool where
-  pwithValidated opq x = pmatch (pasConstr # opq) $ \(PBuiltinPair i' _) ->
-    plet i' $ \i ->
-      pif
-        (i #== pconstantInteger 0)
-        x
-        ( pif
-            (i #== pconstantInteger 1)
-            x
-            perror
-        )
+  -- Note (Koz, 24/11/2025): This slightly weird implementation relies on `Case`
+  -- over `Integer` treating the first 'arm' of the match as `0`, the second as
+  -- `1`, and so on. Since we error on anything other than those two, we can use
+  -- this for speed.
+  pwithValidated opq x =
+    punsafeCase
+      (pmatch (pasConstr # opq) $ \(PBuiltinPair i _) -> i)
+      [ popaque x
+      , popaque x
+      ]
 
 {- | Checks that we have a @Constr@ with a second field of at least length 2.
 Furthermore, checks that the first element validates as per @a@, while the

--- a/plutarch-testlib/goldens/bool.bench.golden
+++ b/plutarch-testlib/goldens/bool.bench.golden
@@ -21,3 +21,5 @@ pcond.direct-2 {"exBudgetCPU":157390,"exBudgetMemory":801,"scriptSizeBytes":17}
 pcond.pcond-2 {"exBudgetCPU":157390,"exBudgetMemory":801,"scriptSizeBytes":17}
 pcond.direct-3 {"exBudgetCPU":157390,"exBudgetMemory":801,"scriptSizeBytes":28}
 pcond.pcond-3 {"exBudgetCPU":157390,"exBudgetMemory":801,"scriptSizeBytes":28}
+PValidateData.pparseData (PFalse) {"exBudgetCPU":505323,"exBudgetMemory":2597,"scriptSizeBytes":46}
+PValidateData.pparseData (PTrue) {"exBudgetCPU":653656,"exBudgetMemory":3198,"scriptSizeBytes":46}

--- a/plutarch-testlib/goldens/bool.bench.golden
+++ b/plutarch-testlib/goldens/bool.bench.golden
@@ -21,5 +21,5 @@ pcond.direct-2 {"exBudgetCPU":157390,"exBudgetMemory":801,"scriptSizeBytes":17}
 pcond.pcond-2 {"exBudgetCPU":157390,"exBudgetMemory":801,"scriptSizeBytes":17}
 pcond.direct-3 {"exBudgetCPU":157390,"exBudgetMemory":801,"scriptSizeBytes":28}
 pcond.pcond-3 {"exBudgetCPU":157390,"exBudgetMemory":801,"scriptSizeBytes":28}
-PValidateData.pparseData (PFalse) {"exBudgetCPU":505323,"exBudgetMemory":2597,"scriptSizeBytes":46}
-PValidateData.pparseData (PTrue) {"exBudgetCPU":653656,"exBudgetMemory":3198,"scriptSizeBytes":46}
+PValidateData.pparseData (PFalse) {"exBudgetCPU":388990,"exBudgetMemory":2196,"scriptSizeBytes":34}
+PValidateData.pparseData (PTrue) {"exBudgetCPU":388990,"exBudgetMemory":2196,"scriptSizeBytes":34}

--- a/plutarch-testlib/goldens/bool.uplc.eval.golden
+++ b/plutarch-testlib/goldens/bool.uplc.eval.golden
@@ -21,3 +21,5 @@ pcond.direct-2 program 1.1.0 1
 pcond.pcond-2 program 1.1.0 1
 pcond.direct-3 program 1.1.0 1
 pcond.pcond-3 program 1.1.0 1
+PValidateData.pparseData (PFalse) program 1.1.0 (Constr 0 [])
+PValidateData.pparseData (PTrue) program 1.1.0 (Constr 1 [])

--- a/plutarch-testlib/goldens/bool.uplc.golden
+++ b/plutarch-testlib/goldens/bool.uplc.golden
@@ -41,21 +41,13 @@ PValidateData.pparseData (PFalse) program
   1.1.0
   ((\!0 ->
       case
-        (unConstrData (constrData 0 !1))
-        [ (\!0 !0 ->
-             case
-               (equalsInteger !2 0)
-               [ (case (equalsInteger !2 1) [error, (constrData 0 !3)])
-               , (constrData 0 !3) ]) ])
+        (case (unConstrData (constrData 0 !1)) [(\!0 !0 -> !2)])
+        [(constrData 0 !1), (constrData 0 !1)])
      [])
 PValidateData.pparseData (PTrue) program
   1.1.0
   ((\!0 ->
       case
-        (unConstrData (constrData 1 !1))
-        [ (\!0 !0 ->
-             case
-               (equalsInteger !2 0)
-               [ (case (equalsInteger !2 1) [error, (constrData 1 !3)])
-               , (constrData 1 !3) ]) ])
+        (case (unConstrData (constrData 1 !1)) [(\!0 !0 -> !2)])
+        [(constrData 1 !1), (constrData 1 !1)])
      [])

--- a/plutarch-testlib/goldens/bool.uplc.golden
+++ b/plutarch-testlib/goldens/bool.uplc.golden
@@ -37,3 +37,25 @@ pcond.direct-3 program
 pcond.pcond-3 program
   1.1.0
   (case (lessThanInteger 1 2) [(case (lessThanInteger 2 3) [3, 2]), 1])
+PValidateData.pparseData (PFalse) program
+  1.1.0
+  ((\!0 ->
+      case
+        (unConstrData (constrData 0 !1))
+        [ (\!0 !0 ->
+             case
+               (equalsInteger !2 0)
+               [ (case (equalsInteger !2 1) [error, (constrData 0 !3)])
+               , (constrData 0 !3) ]) ])
+     [])
+PValidateData.pparseData (PTrue) program
+  1.1.0
+  ((\!0 ->
+      case
+        (unConstrData (constrData 1 !1))
+        [ (\!0 !0 ->
+             case
+               (equalsInteger !2 0)
+               [ (case (equalsInteger !2 1) [error, (constrData 1 !3)])
+               , (constrData 1 !3) ]) ])
+     [])

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Bool.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Bool.hs
@@ -1,6 +1,7 @@
 module Plutarch.Test.Suite.Plutarch.Bool (tests) where
 
 import Plutarch.Builtin.Bool (pand, por)
+import Plutarch.Internal.Parse (pparseData)
 import Plutarch.Prelude
 import Plutarch.Test.Golden (goldenEval, goldenEvalFail, goldenGroup, plutarchGolden)
 import Test.Tasty (TestTree, testGroup)
@@ -67,6 +68,11 @@ tests =
             , goldenEval "pcond-2" (pcond [(pconstant @PInteger 1 #< 2, pconstant @PInteger 1)] 2)
             , goldenEval "direct-3" (pif (pconstant @PInteger 1 #< 2) (pconstant @PInteger 1) (pif (pconstant @PInteger 2 #< 3) 2 3))
             , goldenEval "pcond-3" (pcond [(pconstant @PInteger 1 #< 2, pconstant @PInteger 1), (pconstant @PInteger 2 #< 3, 2)] 3)
+            ]
+        , goldenGroup
+            "PValidateData"
+            [ goldenEval "pparseData (PFalse)" (pparseData @PBool . pforgetData $ pconstrBuiltin # 0 # pcon PNil)
+            , goldenEval "pparseData (PTrue)" (pparseData @PBool . pforgetData $ pconstrBuiltin # 1 # pcon PNil)
             ]
         ]
     ]


### PR DESCRIPTION
I noticed that instead of a stack of two `pif`s, we can use a single case. This improves this significantly:

```
-PValidateData.pparseData (PFalse) {"exBudgetCPU":505323,"exBudgetMemory":2597,"scriptSizeBytes":46}
-PValidateData.pparseData (PTrue) {"exBudgetCPU":653656,"exBudgetMemory":3198,"scriptSizeBytes":46}
+PValidateData.pparseData (PFalse) {"exBudgetCPU":388990,"exBudgetMemory":2196,"scriptSizeBytes":34}
+PValidateData.pparseData (PTrue) {"exBudgetCPU":388990,"exBudgetMemory":2196,"scriptSizeBytes":34}
```