### PR TITLE
Disallow duplicate keys in PSortedMap and sorted Values

### DIFF
--- a/plutarch-ledger-api/CHANGELOG.md
+++ b/plutarch-ledger-api/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   cases.
 * Exposed definitions from the `Plutarch.LedgerApi.V1.MintValue` and
   `Plutarch.LedgerApi.V3.MintValue` modules.
+* In `Plutarch.LedgerApi.AssocMap`, `passertSorted` has been deprecated in favor
+  of `ppromoteToSortedMap`.
+* In `Plutarch.LedgerApi.Value`, `passertSorted` has been deprecated in favor
+  of `ppromoteToSortedValue`.
+* `PSortedMap` and all sorted Value types now disallow duplicate keys.
 
 ### Removed
 

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/AssocMap.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/AssocMap.hs
@@ -24,6 +24,7 @@ module Plutarch.LedgerApi.AssocMap (
 
   -- ** Transformation
   passertSorted,
+  ppromoteToSortedMap,
   pforgetSorted,
   pmap,
   pmapData,
@@ -267,7 +268,7 @@ instance
   where
   ptryFrom' opq = runTermCont $ do
     (opq', _) <- tcont $ ptryFrom @(PAsData (PUnsortedMap k v)) opq
-    unwrapped <- tcont $ plet . papp passertSorted . pfromData $ opq'
+    unwrapped <- tcont $ plet . papp ppromoteToSortedMap . pfromData $ opq'
     pure (pdata unwrapped, ())
 
 {- | Checks that we have a valid 'PSortedMap' with keys sorted in ascending
@@ -280,7 +281,7 @@ instance (PValidateData k, PValidateData v, POrd k, PIsData k) => PValidateData 
     -- the PUnsortedMap validation should run before the sortedness check
     pwithValidated @(PUnsortedMap k v) opq $
       plet
-        (passertSorted #$ pfromData $ punsafeCoerce @(PAsData (PUnsortedMap k v)) opq)
+        (ppromoteToSortedMap #$ pfromData $ punsafeCoerce @(PAsData (PUnsortedMap k v)) opq)
         (const x)
 
 ----------------------------------------------------------------------
@@ -382,14 +383,13 @@ psortedMapFromFoldable = foldl' go pempty
 ----------------------------------------------------------------------
 -- Transformation
 
--- TODO: Rename this, because the name is confusing.
-
 {- | Attempt to promote `PUnsortedMap` to `PSortedMap`. This function checks
-that the keys in the input map are in ascending order and fails with an error if
-they are not.
+that the keys in the input map are in strictly ascending order and fails with
+an error if they are not. Duplicate keys are not allowed.
 
 @since 2.0.0
 -}
+{-# DEPRECATED passertSorted "Use ppromoteToSortedMap instead" #-}
 passertSorted ::
   forall (k :: S -> Type) (v :: S -> Type) (s :: S).
   ( POrd k
@@ -408,13 +408,27 @@ passertSorted =
                       pif
                         (badKey # k)
                         (ptraceInfoError "unsorted map")
-                        (self # xs # plam (#< k))
+                        (self # xs # plam (#<= k))
             )
             -- this is actually the empty map so we can
             -- safely assume that it is sorted
             (const . plam . const . punsafeDowncast $ pto m)
             # pto (pto m)
             # plam (const $ pcon PFalse)
+
+{- | Attempt to promote `PUnsortedMap` to `PSortedMap`. This function checks
+that the keys in the input map are in strictly ascending order and fails with
+an error if they are not. Duplicate keys are not allowed.
+
+@since wip
+-}
+ppromoteToSortedMap ::
+  forall (k :: S -> Type) (v :: S -> Type) (s :: S).
+  ( POrd k
+  , PIsData k
+  ) =>
+  Term s (PUnsortedMap k v :--> PSortedMap k v)
+ppromoteToSortedMap = passertSorted
 
 {- | Forget the knowledge that keys were sorted.
 

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/MintValue.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/MintValue.hs
@@ -26,6 +26,9 @@ import PlutusTx.Prelude qualified as PlutusTx
 {- | Represents sorted, well-formed Values with a mandatory /zero/ Ada entry,
 while all other token quantities must be non-zero.
 
+Duplicate currency symbols or duplicate token names within the same
+token map are not allowed (since wip).
+
 @since 3.5.0
 -}
 newtype PMintValue (s :: S) = PMintValue (Term s PSortedValue)

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/MintValue.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V3/MintValue.hs
@@ -25,6 +25,9 @@ import PlutusTx.Prelude qualified as PlutusTx
 {- | Represents sorted, well-formed Values without an Ada entry, while all
 non-Ada token quantities must be non-zero.
 
+Duplicate currency symbols or duplicate token names within the same
+token map are not allowed (since wip).
+
 @since 3.5.0
 -}
 newtype PMintValue (s :: S) = PMintValue (Term s PSortedValue)

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Value.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Value.hs
@@ -36,6 +36,7 @@ module Plutarch.LedgerApi.Value (
 
   -- ** Transformation
   passertSorted,
+  ppromoteToSortedValue,
   pforgetSorted,
   ptoLedgerValue,
 
@@ -82,8 +83,8 @@ import PlutusTx.Prelude qualified as PlutusTx
 
 {- | Represents Values without any guarantees.
 
-Values of this type may be unsorted, contain empty token maps, and include
-entries with zero token quantities.
+Values of this type may be unsorted, have duplicate keys, contain empty token
+maps, and include entries with zero token quantities.
 
 @since 3.5.0
 -}
@@ -128,6 +129,9 @@ deriving via
 -- PSortedValue
 
 {- | Represents sorted, well-formed Values without empty token maps.
+
+Duplicate currency symbols or duplicate token names within the same
+token map are not allowed (since wip).
 
 Compared to 'PRawValue', this type provides stronger guarantees, though
 'PSortedValue's may still contain entries with zero token quantities.
@@ -192,7 +196,7 @@ instance PlutusTx.Group (Term s PSortedValue) where
 instance PTryFrom PData (PAsData PSortedValue) where
   ptryFrom' opq = runTermCont $ do
     (opq', _) <- tcont $ ptryFrom @(PAsData PRawValue) opq
-    unwrapped <- tcont . plet . papp passertSorted . pfromData $ opq'
+    unwrapped <- tcont . plet . papp ppromoteToSortedValue . pfromData $ opq'
     pure (pdata unwrapped, ())
 
 {- | Checks that we have a valid 'PSortedValue'. The underlying map must be
@@ -203,13 +207,16 @@ sorted and contain no empty token maps.
 instance PValidateData PSortedValue where
   pwithValidated opq x =
     plet
-      (passertSorted #$ pfromData $ pparseData @PRawValue opq)
+      (ppromoteToSortedValue #$ pfromData $ pparseData @PRawValue opq)
       (const x)
 
 ----------------------------------------------------------------------
 -- PLedgerValue
 
 {- | Represents sorted, well-formed Values with a mandatory Ada entry.
+
+Duplicate currency symbols or duplicate token names within the same
+token map are not allowed (since wip).
 
 Like 'PSortedValue', but requires the presence of an Ada entry, which may have a
 zero quantity. Values of this type may still contain entries with zero token
@@ -436,6 +443,7 @@ contain empty token maps. Otherwise, the function fails with an error.
 
 @since 2.1.1
 -}
+{-# DEPRECATED passertSorted "Use ppromoteToSortedValue instead" #-}
 passertSorted :: forall (s :: S). Term s (PRawValue :--> PSortedValue)
 passertSorted = phoistAcyclic $
   plam $ \value ->
@@ -444,15 +452,25 @@ passertSorted = phoistAcyclic $
           # plam
             ( \submap ->
                 AssocMap.pnull
-                  # AssocMap.pforgetSorted (AssocMap.passertSorted # submap)
+                  # AssocMap.pforgetSorted (AssocMap.ppromoteToSortedMap # submap)
             )
           # pto value
       )
       (ptraceInfoError "Abnormal Value")
       ( punsafeDowncast
           -- punsafeCoerce since we know that the token maps are sorted at this point
-          (AssocMap.passertSorted #$ punsafeCoerce $ pto value)
+          (AssocMap.ppromoteToSortedMap #$ punsafeCoerce $ pto value)
       )
+
+{- | Attempt to promote a 'PRawValue' to 'PSortedValue'.
+
+The conversion succeeds only if the input Value is already sorted and does not
+contain empty token maps. Otherwise, the function fails with an error.
+
+@since wip
+-}
+ppromoteToSortedValue :: forall (s :: S). Term s (PRawValue :--> PSortedValue)
+ppromoteToSortedValue = passertSorted
 
 {- | Safely demote a 'PSortedValue' to a 'PRawValue'.
 
@@ -659,7 +677,7 @@ phasZeroTokenQuantities =
       # plam (AssocMap.pany # plam (0 #==) #)
       # pto value
 
-{- | Check if the given 'PSortedValue' contains a valid ADA entry.
+{- | Check if the given 'PSortedValue' contains an ADA entry (can be zero).
 
 @since wip
 -}
@@ -670,17 +688,8 @@ phasAdaEntry =
       pmatch (pto $ pto $ pto value) $ \case
         PNil -> pcon PFalse
         PCons x _ ->
-          pmatch x $ \(PBuiltinPair cs tokenMap) ->
-            -- TODO: Should we allow duplicates in the token map?
-            (cs #== padaSymbolData)
-              #&& ( pall
-                      # plam
-                        ( \p ->
-                            pmatch p $ \(PBuiltinPair token _) ->
-                              token #== pdata padaToken
-                        )
-                      # pto (pto $ pfromData tokenMap)
-                  )
+          pmatch x $ \(PBuiltinPair cs _) ->
+            cs #== padaSymbolData
 
 {- | Check if the given 'PSortedValue' has a zero ADA entry.
 

--- a/plutarch-testlib/goldens/assoc-map-validate-data.bench.golden
+++ b/plutarch-testlib/goldens/assoc-map-validate-data.bench.golden
@@ -1,1 +1,1 @@
-PSortedMap {"exBudgetCPU":10582062,"exBudgetMemory":58016,"scriptSizeBytes":480}
+PSortedMap {"exBudgetCPU":10580609,"exBudgetMemory":58016,"scriptSizeBytes":480}

--- a/plutarch-testlib/goldens/assoc-map-validate-data.uplc.golden
+++ b/plutarch-testlib/goldens/assoc-map-validate-data.uplc.golden
@@ -85,7 +85,7 @@ PSortedMap program
                                                     [ !8
                                                     , !5
                                                     , (\!0 ->
-                                                         lessThanInteger
+                                                         lessThanEqualsInteger
                                                            !1
                                                            !3) ])
                                                  [!8])

--- a/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/AssocMap.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/AssocMap.hs
@@ -211,11 +211,11 @@ tests =
             (pconstant @PBool True)
         ]
     , propEval "Ledger AssocMap is sorted (sanity check for punsafeCoerce below)" $
-        \(m :: PlutusMap.Map Integer Integer) -> AssocMap.passertSorted # pconstant @(PUnsortedMap PInteger PInteger) m
+        \(m :: PlutusMap.Map Integer Integer) -> AssocMap.ppromoteToSortedMap # pconstant @(PUnsortedMap PInteger PInteger) m
     , adjustOption (fewerTests 4) $
-        propEval "passertSorted . psortedMapFromFoldable" $
+        propEval "ppromoteToSortedMap . psortedMapFromFoldable" $
           \(m :: UnsortedAssocMap Integer Integer) ->
-            papp AssocMap.passertSorted . AssocMap.pforgetSorted $
+            papp AssocMap.ppromoteToSortedMap . AssocMap.pforgetSorted $
               AssocMap.psortedMapFromFoldable @PInteger @PInteger
                 (map (bimap pconstant pconstant) $ PlutusMap.toList $ getUnsortedAssocMap m)
     , testProperty "null = pnull" $ checkHaskellUnsortedPMapEquivalent PlutusMap.null AssocMap.pnull
@@ -249,7 +249,7 @@ tests =
                 ( AssocMap.pfoldlWithKey
                     # plam (\acc k v -> acc + k + v)
                     # pconstant a
-                    # (AssocMap.passertSorted # pconstant @(PUnsortedMap PInteger PInteger) m)
+                    # (AssocMap.ppromoteToSortedMap # pconstant @(PUnsortedMap PInteger PInteger) m)
                 )
     , testProperty "all = pall" $
         checkHaskellUnsortedPMapEquivalent (PlutusMap.all even) (AssocMap.pall # peven)

--- a/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/Parse.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/Parse.hs
@@ -113,6 +113,12 @@ tests =
             , testEvalFail
                 "fails if Value is unsorted"
                 (pparseData @PSortedValue $ pforgetData $ pdata unsortedValueFixture)
+            , testEvalFail
+                "fails if Value contains duplicate currency symbols"
+                (pparseData @PSortedValue $ pforgetData $ pdata valueWithDuplicatePolicies)
+            , testEvalFail
+                "fails if Value contains duplicate token names within the same token map"
+                (pparseData @PSortedValue $ pforgetData $ pdata valueWithDuplicateTokens)
             ]
         , testGroup
             "PLedgerValue"
@@ -239,3 +245,21 @@ unsortedValueFixture =
       [ (Value.padaSymbol, AssocMap.psingleton # Value.padaToken # 1)
       , (csFixture, AssocMap.psingleton # tnFixture # 1)
       ]
+
+valueWithDuplicatePolicies :: forall (s :: S). Term s PRawValue
+valueWithDuplicatePolicies =
+  punsafeDowncast $
+    AssocMap.punsortedMapFromFoldable @PCurrencySymbol @(PUnsortedMap PTokenName PInteger) @[]
+      [ (csFixture, AssocMap.psingleton # tnFixture # 1)
+      , (csFixture, AssocMap.psingleton # tnFixture # 1)
+      ]
+
+valueWithDuplicateTokens :: forall (s :: S). Term s PRawValue
+valueWithDuplicateTokens =
+  punsafeDowncast $
+    AssocMap.psingleton
+      # csFixture
+      # AssocMap.punsortedMapFromFoldable @PTokenName @PInteger @[]
+        [ (tnFixture, 1)
+        , (tnFixture, 1)
+        ]

--- a/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1/Value.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1/Value.hs
@@ -20,7 +20,7 @@ tests =
     , testGroup
         "Generators sanity tests"
         [ propEval "UtxoValue is sorted" $ \val ->
-            precompileTerm PValue.passertSorted
+            precompileTerm PValue.ppromoteToSortedValue
               # pconstant (getUtxoValue val)
               -- FIXME: remove this test case or re-add passertPositive
               -- , propEval "UtxoValue is positive" $ \val ->


### PR DESCRIPTION
Closes https://github.com/Plutonomicon/plutarch-plutus/issues/910
Closes https://github.com/Plutonomicon/plutarch-plutus/issues/914

The changes in this PR are motivated by the definition of a Map, which requires unique keys, as well as by this comment in cardano-ledger: https://github.com/IntersectMBO/cardano-ledger/issues/4335#issuecomment-2121639540.

Initially, I wanted to disallow duplicate keys for all `PAssocMap`-based types, but checking for duplicates in unsorted maps is computationally expensive, so I decided to move forward with the current solution as it looks like a reasonable compromise between performance and user experience imo.