### PR TITLE
Perf tests for optional methods

### DIFF
--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -66,7 +66,7 @@ import Plutarch.Internal.Lift (
   pliftedToClosed,
  )
 import Plutarch.Internal.ListLike (pcons, phead, pnil)
-import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=)))
+import Plutarch.Internal.Ord (POrd (pmin, (#<), (#<=)))
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -204,14 +204,6 @@ instance
     PDRight t1' -> pmatch t2 $ \case
       PDLeft _ -> pcon PFalse
       PDRight t2' -> pfromData t1' #< pfromData t2'
-  {-# INLINEABLE pmax #-}
-  pmax t1 t2 = pmatch t1 $ \case
-    PDLeft t1' -> pmatch t2 $ \case
-      PDLeft t2' -> pif (pfromData t1' #< pfromData t2') t2 t1
-      PDRight _ -> t2
-    PDRight t1' -> pmatch t2 $ \case
-      PDLeft _ -> t1
-      PDRight t2' -> pif (pfromData t1' #< pfromData t2') t2 t1
   {-# INLINEABLE pmin #-}
   pmin t1 t2 = pmatch t1 $ \case
     PDLeft t1' -> pmatch t2 $ \case

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -204,14 +204,6 @@ instance
     PDRight t1' -> pmatch t2 $ \case
       PDLeft _ -> pcon PFalse
       PDRight t2' -> pfromData t1' #< pfromData t2'
-  {-# INLINEABLE pmin #-}
-  pmin t1 t2 = pmatch t1 $ \case
-    PDLeft t1' -> pmatch t2 $ \case
-      PDLeft t2' -> pif (pfromData t1' #< pfromData t2') t1 t2
-      PDRight _ -> t1
-    PDRight t1' -> pmatch t2 $ \case
-      PDLeft _ -> t2
-      PDRight t2' -> pif (pfromData t1' #< pfromData t2') t1 t2
 
 -- | @since 1.10.0
 instance PlutusType (PEitherData a b) where

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -44,7 +44,9 @@ import Plutarch.Builtin.Data (
   pasConstr,
   pconstrBuiltin,
  )
-import Plutarch.Internal.Eq (PEq ((#==)))
+import Plutarch.Builtin.Opaque (popaque)
+import Plutarch.Internal.Case (punsafeCase)
+import Plutarch.Internal.Eq (PEq)
 import Plutarch.Internal.IsData (PIsData (pdataImpl, pfromDataImpl), pdata, pforgetData, pfromData)
 import Plutarch.Internal.Lift (
   DeriveDataPLiftable,
@@ -66,7 +68,7 @@ import Plutarch.Internal.Lift (
   pliftedToClosed,
  )
 import Plutarch.Internal.ListLike (pcons, phead, pnil)
-import Plutarch.Internal.Ord (POrd (pmin, (#<), (#<=)))
+import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=)))
 import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
@@ -204,6 +206,22 @@ instance
     PDRight t1' -> pmatch t2 $ \case
       PDLeft _ -> pcon PFalse
       PDRight t2' -> pfromData t1' #< pfromData t2'
+  {-# INLINEABLE pmax #-}
+  pmax t1 t2 = pmatch t1 $ \case
+    PDLeft t1' -> pmatch t2 $ \case
+      PDLeft t2' -> pif (pfromData t1' #<= pfromData t2') t2 t1
+      PDRight _ -> t2
+    PDRight t1' -> pmatch t2 $ \case
+      PDLeft _ -> t1
+      PDRight t2' -> pif (pfromData t1' #<= pfromData t2') t2 t1
+  {-# INLINEABLE pmin #-}
+  pmin t1 t2 = pmatch t1 $ \case
+    PDLeft t1' -> pmatch t2 $ \case
+      PDLeft t2' -> pif (pfromData t1' #<= pfromData t2') t1 t2
+      PDRight _ -> t1
+    PDRight t1' -> pmatch t2 $ \case
+      PDLeft _ -> t2
+      PDRight t2' -> pif (pfromData t1' #<= pfromData t2') t1 t2
 
 -- | @since 1.10.0
 instance PlutusType (PEitherData a b) where
@@ -217,11 +235,11 @@ instance PlutusType (PEitherData a b) where
   {-# INLINEABLE pmatch' #-}
   pmatch' t f = plet (pasConstr # t) $ \asConstr ->
     pmatch asConstr $ \(PBuiltinPair tag dat) ->
-      plet (phead # dat) $ \arg ->
-        pif
-          (tag #== 0)
-          (f . PDLeft . punsafeCoerce $ arg)
-          (f . PDRight . punsafeCoerce $ arg)
+      punsafeCase
+        tag
+        [ popaque . f . PDLeft . punsafeCoerce $ phead # dat
+        , popaque . f . PDRight . punsafeCoerce $ phead # dat
+        ]
 
 -- | @since 1.10.0
 deriving via

--- a/Plutarch/Rational.hs
+++ b/Plutarch/Rational.hs
@@ -42,7 +42,7 @@ import Plutarch.Internal.Numeric (
   PAdditiveMonoid (pscaleNatural, pzero),
   PAdditiveSemigroup (pscalePositive, (#+)),
   PIntegralDomain (pabs, psignum),
-  PMultiplicativeMonoid (pone, ppowNatural),
+  PMultiplicativeMonoid (pone),
   PMultiplicativeSemigroup (ppowPositive, (#*)),
   PPositive,
   PRing (pfromInteger),
@@ -224,10 +224,6 @@ instance PMultiplicativeSemigroup PRational where
 instance PMultiplicativeMonoid PRational where
   {-# INLINEABLE pone #-}
   pone = pcon . PRational pone $ pone
-  {-# INLINEABLE ppowNatural #-}
-  ppowNatural x n = plet n $ \n' ->
-    pmatch x $ \(PRational xn xd) ->
-      pcon . PRational (ppowNatural xn n') $ ppowNatural xd n'
 
 -- | @since 1.10.0
 instance PRing PRational where

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
@@ -82,6 +82,8 @@ instance PAdditiveGroup PPosixTime where
   pnegate = phoistAcyclic $ plam $ \t -> pposixTime (pnegate # unPPosixTime t)
   {-# INLINEABLE (#-) #-}
   t1 #- t2 = pposixTime (unPPosixTime t1 #- unPPosixTime t2)
+  {-# INLINEABLE pscaleInteger #-}
+  pscaleInteger t i = pposixTime (unPPosixTime t #* i)
 
 -- | @since 3.3.0
 deriving via

--- a/plutarch-testlib/CHANGELOG.md
+++ b/plutarch-testlib/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 * Unit tests for `PValidateData` instances of plutarch-ledger-api types.
 * `goldenEvalWithConfig`, which allows choosing compilation configuration for a
   golden test
+* `Plutarch.Test.Methods` for checking if implementing an optional method of a
+  Plutarch type class has a performance benefit or not
 
 ## 1.0.2
 

--- a/plutarch-testlib/Plutarch/Test/Methods.hs
+++ b/plutarch-testlib/Plutarch/Test/Methods.hs
@@ -4,7 +4,12 @@ module Plutarch.Test.Methods (
   -- * POrd
   pmaxDefaultBetter,
   pminDefaultBetter,
+
+  -- * PCountable
   psuccessorNBetter,
+
+  -- * PEnumerable
+  ppredecessorNBetter,
 ) where
 
 import Data.Bifunctor (first)
@@ -18,6 +23,7 @@ import Plutarch.Evaluate (evalScriptUnlimited)
 import Plutarch.Internal.Term (compileOptimized)
 import Plutarch.Prelude (
   PCountable (psuccessor, psuccessorN),
+  PEnumerable (ppredecessor, ppredecessorN),
   POrd (pmax, pmin, (#<=)),
   PPositive,
   S,
@@ -39,6 +45,7 @@ import PlutusLedgerApi.Common (serialiseUPLC)
 import Test.Tasty (TestTree)
 import Test.Tasty.Providers (
   IsTest (run, testOptions),
+  Result,
   singleTest,
   testFailed,
   testPassed,
@@ -105,6 +112,26 @@ psuccessorNBetter arg1 arg2 = singleTest testName $ PSuccessorN arg1 arg2
     testName :: String
     testName = "psuccessorN versus default for " <> typeName @(S -> Type) @a
 
+{- | Given two arguments to test with, compares the default implementation of
+'ppredecessorN' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+ppredecessorNBetter ::
+  forall (a :: S -> Type).
+  (PEnumerable a, Typeable a) =>
+  (forall (s :: S). Term s PPositive) ->
+  (forall (s :: S). Term s a) ->
+  TestTree
+ppredecessorNBetter arg1 arg2 = singleTest testName $ PPredecessorN arg1 arg2
+  where
+    testName :: String
+    testName = "ppredecessorN versus default for " <> typeName @(S -> Type) @a
+
 -- Helpers
 
 data DefaultBetter where
@@ -126,28 +153,28 @@ data DefaultBetter where
     (forall (s :: S). Term s PPositive) ->
     (forall (s :: S). Term s a) ->
     DefaultBetter
+  PPredecessorN ::
+    forall (a :: S -> Type).
+    PEnumerable a =>
+    (forall (s :: S). Term s PPositive) ->
+    (forall (s :: S). Term s a) ->
+    DefaultBetter
 
 instance IsTest DefaultBetter where
   testOptions = Tagged []
   run _ t _ = pure $ case t of
     PMax x y -> case tryAndApply "pmax" pmaxDefault (plam $ \x' y' -> pmax x' y') x y of
       Left failText -> testFailed failText
-      Right deltas@(sizeDelta, exUnitDelta, memDelta) ->
-        if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
-          then testPassed . formatDelta $ deltas
-          else testFailed . formatDelta $ deltas
+      Right deltas -> handleDeltas deltas
     PMin x y -> case tryAndApply "pmin" pminDefault (plam $ \x' y' -> pmin x' y') x y of
       Left failText -> testFailed failText
-      Right deltas@(sizeDelta, exUnitDelta, memDelta) ->
-        if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
-          then testPassed . formatDelta $ deltas
-          else testFailed . formatDelta $ deltas
+      Right deltas -> handleDeltas deltas
     PSuccessorN p x -> case tryAndApply "psuccessorN" psuccessorNDefault psuccessorN p x of
       Left failText -> testFailed failText
-      Right deltas@(sizeDelta, exUnitDelta, memDelta) ->
-        if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
-          then testPassed . formatDelta $ deltas
-          else testFailed . formatDelta $ deltas
+      Right deltas -> handleDeltas deltas
+    PPredecessorN p x -> case tryAndApply "ppredecessorN" ppredecessorNDefault ppredecessorN p x of
+      Left failText -> testFailed failText
+      Right deltas -> handleDeltas deltas
     where
       pmaxDefault :: forall (a :: S -> Type) (s :: S). POrd a => Term s (a :--> a :--> a)
       pmaxDefault = plam $ \x y -> pif (x #<= y) y x
@@ -162,6 +189,15 @@ instance IsTest DefaultBetter where
         PCountable a => Term s PPositive -> Term s (a :--> PPositive :--> a)
       goSucc limit = pfix $ \self -> plam $ \acc count ->
         pif (count #== limit) acc (self # (psuccessor # acc) # (count #+ pone))
+      ppredecessorNDefault ::
+        forall (a :: S -> Type) (s :: S).
+        PEnumerable a => Term s (PPositive :--> a :--> a)
+      ppredecessorNDefault = plam $ \n x -> goPred n # (ppredecessor # x) # pone
+      goPred ::
+        forall (a :: S -> Type) (s :: S).
+        PEnumerable a => Term s PPositive -> Term s (a :--> PPositive :--> a)
+      goPred limit = pfix $ \self -> plam $ \acc count ->
+        pif (count #== limit) acc (self # (ppredecessor # acc) # (count #+ pone))
 
 scriptSize :: Script -> Integer
 scriptSize = fromIntegral . Short.length . serialiseUPLC . unScript
@@ -196,6 +232,13 @@ tryAndApply op defaultImpl definedImpl x y = do
     tryEval which s = case evalScriptUnlimited s of
       (Left err, _, _) -> Left $ which <> " implementation of " <> op <> " did not evaluate: " <> show err
       (Right _, ExBudget (ExCPU cpu) (ExMemory mem), _) -> pure (fromSatInt @Integer cpu, fromSatInt @Integer mem)
+
+handleDeltas :: (Integer, Integer, Integer) -> Result
+handleDeltas deltas@(sizeDelta, exUnitDelta, memDelta) =
+  let formatted = formatDelta deltas
+   in if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
+        then testPassed formatted
+        else testFailed formatted
 
 formatDelta :: (Integer, Integer, Integer) -> String
 formatDelta (sizeDelta, exUnitDelta, memDelta) =

--- a/plutarch-testlib/Plutarch/Test/Methods.hs
+++ b/plutarch-testlib/Plutarch/Test/Methods.hs
@@ -1,20 +1,28 @@
+{-# LANGUAGE NoPartialTypeSignatures #-}
+
 module Plutarch.Test.Methods (
   -- * POrd
   pmaxDefaultBetter,
+  pminDefaultBetter,
 ) where
 
+import Data.Bifunctor (first)
 import Data.ByteString.Short qualified as Short
 import Data.Kind (Type)
 import Data.SatInt (fromSatInt)
 import Data.Tagged (Tagged (Tagged))
+import Data.Text (Text)
 import Data.Text qualified as Text
 import Plutarch.Evaluate (evalScriptUnlimited)
 import Plutarch.Internal.Term (compileOptimized)
 import Plutarch.Prelude (
-  POrd (pmax, (#<=)),
+  POrd (pmax, pmin, (#<=)),
   S,
   Term,
   pif,
+  plam,
+  (#),
+  (:-->),
  )
 import Plutarch.Script (Script (unScript))
 import Plutarch.Test.Utils (typeName)
@@ -50,6 +58,26 @@ pmaxDefaultBetter arg1 arg2 = singleTest testName $ PMax arg1 arg2
     testName :: String
     testName = "pmax versus default for " <> typeName @(S -> Type) @a
 
+{- | Given two arguments to test with, compares the default implementation of
+'pmin' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+pminDefaultBetter ::
+  forall (a :: S -> Type).
+  (POrd a, Typeable a) =>
+  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s a) ->
+  TestTree
+pminDefaultBetter arg1 arg2 = singleTest testName $ PMin arg1 arg2
+  where
+    testName :: String
+    testName = "pmin versus default for " <> typeName @(S -> Type) @a
+
 -- Helpers
 
 data DefaultBetter where
@@ -59,61 +87,82 @@ data DefaultBetter where
     (forall (s :: S). Term s a) ->
     (forall (s :: S). Term s a) ->
     DefaultBetter
+  PMin ::
+    forall (a :: S -> Type).
+    POrd a =>
+    (forall (s :: S). Term s a) ->
+    (forall (s :: S). Term s a) ->
+    DefaultBetter
 
 instance IsTest DefaultBetter where
   testOptions = Tagged []
-  run _ t _ = case t of
-    PMax x y -> pure $ case compileOptimized (pif (x #<= y) y x) of
-      Left err -> testFailed $ "Failed to compile default implementation of pmax: " <> Text.unpack err
-      Right usingDefault -> case compileOptimized (pmax x y) of
-        Left err -> testFailed $ "Failed to compile defined implementation of pmax: " <> Text.unpack err
-        Right usingImpl -> case evalScriptUnlimited usingDefault of
-          (Left err, _, _) -> testFailed $ "Default implementation of pmax did not evaluate: " <> show err
-          (Right _, ExBudget (ExCPU cpuDefault) (ExMemory memDefault), _) -> case evalScriptUnlimited usingImpl of
-            (Left err, _, _) -> testFailed $ "Defined implementation of pmax did not evaluate: " <> show err
-            (Right _, ExBudget (ExCPU cpuImpl) (ExMemory memImpl), _) ->
-              let sizeOfDefault = scriptSize usingDefault
-                  sizeOfImpl = scriptSize usingImpl
-                  exUnitsDefault = fromSatInt @Integer cpuDefault
-                  exUnitsImpl = fromSatInt cpuImpl
-                  memUnitsDefault = fromSatInt @Integer memDefault
-                  memUnitsImpl = fromSatInt memImpl
-                  sizeDiff = sizeOfImpl - sizeOfDefault
-                  exUnitsDiff = exUnitsImpl - exUnitsDefault
-                  memDiff = memUnitsImpl - memUnitsDefault
-               in if
-                    | sizeDiff < 0 ->
-                        testFailed $
-                          "Implementation is larger than the default by "
-                            <> show (abs sizeDiff)
-                            <> " bytes.\nOther diffs (negative means worse implementation):\nExunits: "
-                            <> show exUnitsDiff
-                            <> "\n"
-                            <> "Memory: "
-                            <> show memDiff
-                            <> "\n"
-                    | exUnitsDiff < 0 ->
-                        testFailed $
-                          "Implementation uses "
-                            <> show (abs exUnitsDiff)
-                            <> " more exunits than default"
-                    | memDiff < 0 ->
-                        testFailed $
-                          "Implementation uses "
-                            <> show (abs memDiff)
-                            <> " more memory units than default"
-                    | otherwise ->
-                        testPassed $
-                          "Differences from pmax default:\n"
-                            <> "Size: "
-                            <> show sizeDiff
-                            <> "\n"
-                            <> "Exunits: "
-                            <> show exUnitsDiff
-                            <> "\n"
-                            <> "Memory: "
-                            <> show memDiff
-                            <> "\n"
+  run _ t _ = pure $ case t of
+    PMax x y -> case tryAndApply
+      "pmax"
+      (plam $ \x' y' -> pif (x' #<= y') y x)
+      (plam $ \x' y' -> pmax x' y')
+      x
+      y of
+      Left failText -> testFailed failText
+      Right deltas@(sizeDelta, exUnitDelta, memDelta) ->
+        if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
+          then testPassed . formatDelta $ deltas
+          else testFailed . formatDelta $ deltas
+    PMin x y -> case tryAndApply
+      "pmin"
+      (plam $ \x' y' -> pif (x' #<= y') x' y')
+      (plam $ \x' y' -> pmin x' y')
+      x
+      y of
+      Left failText -> testFailed failText
+      Right deltas@(sizeDelta, exUnitDelta, memDelta) ->
+        if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
+          then testPassed . formatDelta $ deltas
+          else testFailed . formatDelta $ deltas
 
 scriptSize :: Script -> Integer
 scriptSize = fromIntegral . Short.length . serialiseUPLC . unScript
+
+tryAndApply ::
+  forall (a :: S -> Type).
+  String ->
+  (forall (s :: S). Term s (a :--> a :--> a)) ->
+  (forall (s :: S). Term s (a :--> a :--> a)) ->
+  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s a) ->
+  Either String (Integer, Integer, Integer)
+tryAndApply op defaultImpl definedImpl x y = do
+  usingDefault <- first (formatCompileErr "default") . compileOptimized $ defaultImpl # x # y
+  usingImpl <- first (formatCompileErr "defined") . compileOptimized $ definedImpl # x # y
+  (cpuDefault, memDefault) <- tryEval "Default" usingDefault
+  (cpuImpl, memImpl) <- tryEval "Defined" usingImpl
+  let sizeDelta = scriptSize usingImpl - scriptSize usingDefault
+  let exunitDelta = cpuImpl - cpuDefault
+  let memDelta = memImpl - memDefault
+  pure (sizeDelta, exunitDelta, memDelta)
+  where
+    formatCompileErr :: String -> Text -> String
+    formatCompileErr which err =
+      "Failed to compile "
+        <> which
+        <> "implementation of "
+        <> op
+        <> ": "
+        <> Text.unpack err
+    tryEval :: String -> Script -> Either String (Integer, Integer)
+    tryEval which s = case evalScriptUnlimited s of
+      (Left err, _, _) -> Left $ which <> " implementation of " <> op <> " did not evaluate: " <> show err
+      (Right _, ExBudget (ExCPU cpu) (ExMemory mem), _) -> pure (fromSatInt @Integer cpu, fromSatInt @Integer mem)
+
+formatDelta :: (Integer, Integer, Integer) -> String
+formatDelta (sizeDelta, exUnitDelta, memDelta) =
+  "Difference from default implementation (negative means worse):\n"
+    <> "Script size: "
+    <> show sizeDelta
+    <> "\n"
+    <> "Exunits: "
+    <> show exUnitDelta
+    <> "\n"
+    <> "Memory: "
+    <> show memDelta
+    <> "\n"

--- a/plutarch-testlib/Plutarch/Test/Methods.hs
+++ b/plutarch-testlib/Plutarch/Test/Methods.hs
@@ -1,0 +1,119 @@
+module Plutarch.Test.Methods (
+  -- * POrd
+  pmaxDefaultBetter,
+) where
+
+import Data.ByteString.Short qualified as Short
+import Data.Kind (Type)
+import Data.SatInt (fromSatInt)
+import Data.Tagged (Tagged (Tagged))
+import Data.Text qualified as Text
+import Plutarch.Evaluate (evalScriptUnlimited)
+import Plutarch.Internal.Term (compileOptimized)
+import Plutarch.Prelude (
+  POrd (pmax, (#<=)),
+  S,
+  Term,
+  pif,
+ )
+import Plutarch.Script (Script (unScript))
+import Plutarch.Test.Utils (typeName)
+import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (ExBudget))
+import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (ExCPU), ExMemory (ExMemory))
+import PlutusLedgerApi.Common (serialiseUPLC)
+import Test.Tasty (TestTree)
+import Test.Tasty.Providers (
+  IsTest (run, testOptions),
+  singleTest,
+  testFailed,
+  testPassed,
+ )
+import Type.Reflection (Typeable)
+
+{- | Given two arguments to test with, compares the default implementation of
+'pmax' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+pmaxDefaultBetter ::
+  forall (a :: S -> Type).
+  (POrd a, Typeable a) =>
+  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s a) ->
+  TestTree
+pmaxDefaultBetter arg1 arg2 = singleTest testName $ PMax arg1 arg2
+  where
+    testName :: String
+    testName = "pmax versus default for " <> typeName @(S -> Type) @a
+
+-- Helpers
+
+data DefaultBetter where
+  PMax ::
+    forall (a :: S -> Type).
+    POrd a =>
+    (forall (s :: S). Term s a) ->
+    (forall (s :: S). Term s a) ->
+    DefaultBetter
+
+instance IsTest DefaultBetter where
+  testOptions = Tagged []
+  run _ t _ = case t of
+    PMax x y -> pure $ case compileOptimized (pif (x #<= y) y x) of
+      Left err -> testFailed $ "Failed to compile default implementation of pmax: " <> Text.unpack err
+      Right usingDefault -> case compileOptimized (pmax x y) of
+        Left err -> testFailed $ "Failed to compile defined implementation of pmax: " <> Text.unpack err
+        Right usingImpl -> case evalScriptUnlimited usingDefault of
+          (Left err, _, _) -> testFailed $ "Default implementation of pmax did not evaluate: " <> show err
+          (Right _, ExBudget (ExCPU cpuDefault) (ExMemory memDefault), _) -> case evalScriptUnlimited usingImpl of
+            (Left err, _, _) -> testFailed $ "Defined implementation of pmax did not evaluate: " <> show err
+            (Right _, ExBudget (ExCPU cpuImpl) (ExMemory memImpl), _) ->
+              let sizeOfDefault = scriptSize usingDefault
+                  sizeOfImpl = scriptSize usingImpl
+                  exUnitsDefault = fromSatInt @Integer cpuDefault
+                  exUnitsImpl = fromSatInt cpuImpl
+                  memUnitsDefault = fromSatInt @Integer memDefault
+                  memUnitsImpl = fromSatInt memImpl
+                  sizeDiff = sizeOfImpl - sizeOfDefault
+                  exUnitsDiff = exUnitsImpl - exUnitsDefault
+                  memDiff = memUnitsImpl - memUnitsDefault
+               in if
+                    | sizeDiff < 0 ->
+                        testFailed $
+                          "Implementation is larger than the default by "
+                            <> show (abs sizeDiff)
+                            <> " bytes.\nOther diffs (negative means worse implementation):\nExunits: "
+                            <> show exUnitsDiff
+                            <> "\n"
+                            <> "Memory: "
+                            <> show memDiff
+                            <> "\n"
+                    | exUnitsDiff < 0 ->
+                        testFailed $
+                          "Implementation uses "
+                            <> show (abs exUnitsDiff)
+                            <> " more exunits than default"
+                    | memDiff < 0 ->
+                        testFailed $
+                          "Implementation uses "
+                            <> show (abs memDiff)
+                            <> " more memory units than default"
+                    | otherwise ->
+                        testPassed $
+                          "Differences from pmax default:\n"
+                            <> "Size: "
+                            <> show sizeDiff
+                            <> "\n"
+                            <> "Exunits: "
+                            <> show exUnitsDiff
+                            <> "\n"
+                            <> "Memory: "
+                            <> show memDiff
+                            <> "\n"
+
+scriptSize :: Script -> Integer
+scriptSize = fromIntegral . Short.length . serialiseUPLC . unScript

--- a/plutarch-testlib/Plutarch/Test/Methods.hs
+++ b/plutarch-testlib/Plutarch/Test/Methods.hs
@@ -4,6 +4,7 @@ module Plutarch.Test.Methods (
   -- * POrd
   pmaxDefaultBetter,
   pminDefaultBetter,
+  psuccessorNBetter,
 ) where
 
 import Data.Bifunctor (first)
@@ -16,12 +17,18 @@ import Data.Text qualified as Text
 import Plutarch.Evaluate (evalScriptUnlimited)
 import Plutarch.Internal.Term (compileOptimized)
 import Plutarch.Prelude (
+  PCountable (psuccessor, psuccessorN),
   POrd (pmax, pmin, (#<=)),
+  PPositive,
   S,
   Term,
+  pfix,
   pif,
   plam,
+  pone,
   (#),
+  (#+),
+  (#==),
   (:-->),
  )
 import Plutarch.Script (Script (unScript))
@@ -78,6 +85,26 @@ pminDefaultBetter arg1 arg2 = singleTest testName $ PMin arg1 arg2
     testName :: String
     testName = "pmin versus default for " <> typeName @(S -> Type) @a
 
+{- | Given two arguments to test with, compares the default implementation of
+'psuccessorN' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+psuccessorNBetter ::
+  forall (a :: S -> Type).
+  (PCountable a, Typeable a) =>
+  (forall (s :: S). Term s PPositive) ->
+  (forall (s :: S). Term s a) ->
+  TestTree
+psuccessorNBetter arg1 arg2 = singleTest testName $ PSuccessorN arg1 arg2
+  where
+    testName :: String
+    testName = "psuccessorN versus default for " <> typeName @(S -> Type) @a
+
 -- Helpers
 
 data DefaultBetter where
@@ -93,52 +120,68 @@ data DefaultBetter where
     (forall (s :: S). Term s a) ->
     (forall (s :: S). Term s a) ->
     DefaultBetter
+  PSuccessorN ::
+    forall (a :: S -> Type).
+    PCountable a =>
+    (forall (s :: S). Term s PPositive) ->
+    (forall (s :: S). Term s a) ->
+    DefaultBetter
 
 instance IsTest DefaultBetter where
   testOptions = Tagged []
   run _ t _ = pure $ case t of
-    PMax x y -> case tryAndApply
-      "pmax"
-      (plam $ \x' y' -> pif (x' #<= y') y x)
-      (plam $ \x' y' -> pmax x' y')
-      x
-      y of
+    PMax x y -> case tryAndApply "pmax" pmaxDefault (plam $ \x' y' -> pmax x' y') x y of
       Left failText -> testFailed failText
       Right deltas@(sizeDelta, exUnitDelta, memDelta) ->
         if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
           then testPassed . formatDelta $ deltas
           else testFailed . formatDelta $ deltas
-    PMin x y -> case tryAndApply
-      "pmin"
-      (plam $ \x' y' -> pif (x' #<= y') x' y')
-      (plam $ \x' y' -> pmin x' y')
-      x
-      y of
+    PMin x y -> case tryAndApply "pmin" pminDefault (plam $ \x' y' -> pmin x' y') x y of
       Left failText -> testFailed failText
       Right deltas@(sizeDelta, exUnitDelta, memDelta) ->
         if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
           then testPassed . formatDelta $ deltas
           else testFailed . formatDelta $ deltas
+    PSuccessorN p x -> case tryAndApply "psuccessorN" psuccessorNDefault psuccessorN p x of
+      Left failText -> testFailed failText
+      Right deltas@(sizeDelta, exUnitDelta, memDelta) ->
+        if (sizeDelta >= 0) && (exUnitDelta >= 0) && (memDelta >= 0)
+          then testPassed . formatDelta $ deltas
+          else testFailed . formatDelta $ deltas
+    where
+      pmaxDefault :: forall (a :: S -> Type) (s :: S). POrd a => Term s (a :--> a :--> a)
+      pmaxDefault = plam $ \x y -> pif (x #<= y) y x
+      pminDefault :: forall (a :: S -> Type) (s :: S). POrd a => Term s (a :--> a :--> a)
+      pminDefault = plam $ \x y -> pif (x #<= y) x y
+      psuccessorNDefault ::
+        forall (a :: S -> Type) (s :: S).
+        PCountable a => Term s (PPositive :--> a :--> a)
+      psuccessorNDefault = plam $ \p x -> goSucc p # (psuccessor # x) # pone
+      goSucc ::
+        forall (a :: S -> Type) (s :: S).
+        PCountable a => Term s PPositive -> Term s (a :--> PPositive :--> a)
+      goSucc limit = pfix $ \self -> plam $ \acc count ->
+        pif (count #== limit) acc (self # (psuccessor # acc) # (count #+ pone))
 
 scriptSize :: Script -> Integer
 scriptSize = fromIntegral . Short.length . serialiseUPLC . unScript
 
 tryAndApply ::
-  forall (a :: S -> Type).
+  forall (a :: S -> Type) (b :: S -> Type) (c :: S -> Type).
   String ->
-  (forall (s :: S). Term s (a :--> a :--> a)) ->
-  (forall (s :: S). Term s (a :--> a :--> a)) ->
+  (forall (s :: S). Term s (a :--> b :--> c)) ->
+  (forall (s :: S). Term s (a :--> b :--> c)) ->
   (forall (s :: S). Term s a) ->
-  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s b) ->
   Either String (Integer, Integer, Integer)
 tryAndApply op defaultImpl definedImpl x y = do
   usingDefault <- first (formatCompileErr "default") . compileOptimized $ defaultImpl # x # y
   usingImpl <- first (formatCompileErr "defined") . compileOptimized $ definedImpl # x # y
   (cpuDefault, memDefault) <- tryEval "Default" usingDefault
   (cpuImpl, memImpl) <- tryEval "Defined" usingImpl
-  let sizeDelta = scriptSize usingImpl - scriptSize usingDefault
-  let exunitDelta = cpuImpl - cpuDefault
-  let memDelta = memImpl - memDefault
+  let sizeDelta = scriptSize usingDefault - scriptSize usingImpl
+  let exunitDelta = cpuDefault - cpuImpl
+  let memDelta = memDefault - memImpl
   pure (sizeDelta, exunitDelta, memDelta)
   where
     formatCompileErr :: String -> Text -> String

--- a/plutarch-testlib/Plutarch/Test/Methods.hs
+++ b/plutarch-testlib/Plutarch/Test/Methods.hs
@@ -10,6 +10,11 @@ module Plutarch.Test.Methods (
 
   -- * PEnumerable
   ppredecessorNBetter,
+
+  -- * Additive
+  pscalePositiveBetter,
+  pscaleNaturalBetter,
+  pscaleIntegerBetter,
 ) where
 
 import Data.Bifunctor (first)
@@ -20,10 +25,16 @@ import Data.Tagged (Tagged (Tagged))
 import Data.Text (Text)
 import Data.Text qualified as Text
 import Plutarch.Evaluate (evalScriptUnlimited)
-import Plutarch.Internal.Term (compileOptimized)
+import Plutarch.Internal.Numeric (pbySquaringDefault)
+import Plutarch.Internal.Term (compileOptimized, punsafeCoerce)
 import Plutarch.Prelude (
+  PAdditiveGroup (pnegate, pscaleInteger),
+  PAdditiveMonoid (pscaleNatural, pzero),
+  PAdditiveSemigroup (pscalePositive, (#+)),
   PCountable (psuccessor, psuccessorN),
   PEnumerable (ppredecessor, ppredecessorN),
+  PInteger,
+  PNatural,
   POrd (pmax, pmin, (#<=)),
   PPositive,
   S,
@@ -31,14 +42,15 @@ import Plutarch.Prelude (
   pfix,
   pif,
   plam,
+  plet,
   pone,
   (#),
-  (#+),
   (#==),
   (:-->),
  )
 import Plutarch.Script (Script (unScript))
 import Plutarch.Test.Utils (typeName)
+import Plutarch.Unsafe (punsafeDowncast)
 import PlutusCore.Evaluation.Machine.ExBudget (ExBudget (ExBudget))
 import PlutusCore.Evaluation.Machine.ExMemory (ExCPU (ExCPU), ExMemory (ExMemory))
 import PlutusLedgerApi.Common (serialiseUPLC)
@@ -132,6 +144,66 @@ ppredecessorNBetter arg1 arg2 = singleTest testName $ PPredecessorN arg1 arg2
     testName :: String
     testName = "ppredecessorN versus default for " <> typeName @(S -> Type) @a
 
+{- | Given two arguments to test with, compares the default implementation of
+'pscalePositive' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+pscalePositiveBetter ::
+  forall (a :: S -> Type).
+  (PAdditiveSemigroup a, Typeable a) =>
+  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s PPositive) ->
+  TestTree
+pscalePositiveBetter arg1 arg2 = singleTest testName $ PScalePositive arg1 arg2
+  where
+    testName :: String
+    testName = "pscalePositive versus default for " <> typeName @(S -> Type) @a
+
+{- | Given two arguments to test with, compares the default implementation of
+'pscaleNatural' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+pscaleNaturalBetter ::
+  forall (a :: S -> Type).
+  (PAdditiveMonoid a, Typeable a) =>
+  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s PNatural) ->
+  TestTree
+pscaleNaturalBetter arg1 arg2 = singleTest testName $ PScaleNatural arg1 arg2
+  where
+    testName :: String
+    testName = "pscaleNatural versus default for " <> typeName @(S -> Type) @a
+
+{- | Given two arguments to test with, compares the default implementation of
+'pscaleInteger' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+pscaleIntegerBetter ::
+  forall (a :: S -> Type).
+  (PAdditiveGroup a, Typeable a) =>
+  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s PInteger) ->
+  TestTree
+pscaleIntegerBetter arg1 arg2 = singleTest testName $ PScaleInteger arg1 arg2
+  where
+    testName :: String
+    testName = "pscaleInteger versus default for " <> typeName @(S -> Type) @a
+
 -- Helpers
 
 data DefaultBetter where
@@ -159,6 +231,24 @@ data DefaultBetter where
     (forall (s :: S). Term s PPositive) ->
     (forall (s :: S). Term s a) ->
     DefaultBetter
+  PScalePositive ::
+    forall (a :: S -> Type).
+    PAdditiveSemigroup a =>
+    (forall (s :: S). Term s a) ->
+    (forall (s :: S). Term s PPositive) ->
+    DefaultBetter
+  PScaleNatural ::
+    forall (a :: S -> Type).
+    PAdditiveMonoid a =>
+    (forall (s :: S). Term s a) ->
+    (forall (s :: S). Term s PNatural) ->
+    DefaultBetter
+  PScaleInteger ::
+    forall (a :: S -> Type).
+    PAdditiveGroup a =>
+    (forall (s :: S). Term s a) ->
+    (forall (s :: S). Term s PInteger) ->
+    DefaultBetter
 
 instance IsTest DefaultBetter where
   testOptions = Tagged []
@@ -173,6 +263,15 @@ instance IsTest DefaultBetter where
       Left failText -> testFailed failText
       Right deltas -> handleDeltas deltas
     PPredecessorN p x -> case tryAndApply "ppredecessorN" ppredecessorNDefault ppredecessorN p x of
+      Left failText -> testFailed failText
+      Right deltas -> handleDeltas deltas
+    PScalePositive x p -> case tryAndApply "pscalePositive" (plam $ pbySquaringDefault (#+)) (plam pscalePositive) x p of
+      Left failText -> testFailed failText
+      Right deltas -> handleDeltas deltas
+    PScaleNatural x n -> case tryAndApply "pscaleNatural" pscaleNaturalDefault (plam pscaleNatural) x n of
+      Left failText -> testFailed failText
+      Right deltas -> handleDeltas deltas
+    PScaleInteger x i -> case tryAndApply "pscaleInteger" pscaleIntegerDefault (plam pscaleInteger) x i of
       Left failText -> testFailed failText
       Right deltas -> handleDeltas deltas
     where
@@ -198,6 +297,24 @@ instance IsTest DefaultBetter where
         PEnumerable a => Term s PPositive -> Term s (a :--> PPositive :--> a)
       goPred limit = pfix $ \self -> plam $ \acc count ->
         pif (count #== limit) acc (self # (ppredecessor # acc) # (count #+ pone))
+      pscaleNaturalDefault ::
+        forall (a :: S -> Type) (s :: S).
+        PAdditiveMonoid a => Term s (a :--> PNatural :--> a)
+      pscaleNaturalDefault = plam $ \x n -> plet n $ \n' ->
+        pif (n' #== pzero) pzero (pscalePositive x (punsafeCoerce n'))
+      pscaleIntegerDefault ::
+        forall (a :: S -> Type) (s :: S).
+        PAdditiveGroup a => Term s (a :--> PInteger :--> a)
+      pscaleIntegerDefault = plam $ \b e ->
+        plet e $ \e' ->
+          pif
+            (e' #== pzero)
+            pzero
+            ( pif
+                (e' #<= pzero)
+                (pnegate # pscalePositive b (punsafeDowncast (pnegate # e')))
+                (pscalePositive b (punsafeDowncast e'))
+            )
 
 scriptSize :: Script -> Integer
 scriptSize = fromIntegral . Short.length . serialiseUPLC . unScript

--- a/plutarch-testlib/Plutarch/Test/Methods.hs
+++ b/plutarch-testlib/Plutarch/Test/Methods.hs
@@ -15,6 +15,10 @@ module Plutarch.Test.Methods (
   pscalePositiveBetter,
   pscaleNaturalBetter,
   pscaleIntegerBetter,
+
+  -- * Multiplicative
+  ppowPositiveBetter,
+  ppowNaturalBetter,
 ) where
 
 import Data.Bifunctor (first)
@@ -34,6 +38,8 @@ import Plutarch.Prelude (
   PCountable (psuccessor, psuccessorN),
   PEnumerable (ppredecessor, ppredecessorN),
   PInteger,
+  PMultiplicativeMonoid (ppowNatural),
+  PMultiplicativeSemigroup (ppowPositive, (#*)),
   PNatural,
   POrd (pmax, pmin, (#<=)),
   PPositive,
@@ -204,6 +210,46 @@ pscaleIntegerBetter arg1 arg2 = singleTest testName $ PScaleInteger arg1 arg2
     testName :: String
     testName = "pscaleInteger versus default for " <> typeName @(S -> Type) @a
 
+{- | Given two arguments to test with, compares the default implementation of
+'ppowPositive' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+ppowPositiveBetter ::
+  forall (a :: S -> Type).
+  (PMultiplicativeSemigroup a, Typeable a) =>
+  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s PPositive) ->
+  TestTree
+ppowPositiveBetter arg1 arg2 = singleTest testName $ PPowPositive arg1 arg2
+  where
+    testName :: String
+    testName = "ppowPositive versus default for " <> typeName @(S -> Type) @a
+
+{- | Given two arguments to test with, compares the default implementation of
+'ppowNatural' to the one defined for the given type. If the defined implementation
+is worse than the default in any capacity, the test fails, indicating both
+what metric (out of exunits, memory use or script size) was worse, and by how
+much; otherwise, the test passes, indicating how much better (if at all) the
+defined implementation is compared to the default.
+
+@since wip
+-}
+ppowNaturalBetter ::
+  forall (a :: S -> Type).
+  (PMultiplicativeMonoid a, Typeable a) =>
+  (forall (s :: S). Term s a) ->
+  (forall (s :: S). Term s PNatural) ->
+  TestTree
+ppowNaturalBetter arg1 arg2 = singleTest testName $ PPowNatural arg1 arg2
+  where
+    testName :: String
+    testName = "ppowNatural versus default for " <> typeName @(S -> Type) @a
+
 -- Helpers
 
 data DefaultBetter where
@@ -249,31 +295,31 @@ data DefaultBetter where
     (forall (s :: S). Term s a) ->
     (forall (s :: S). Term s PInteger) ->
     DefaultBetter
+  PPowPositive ::
+    forall (a :: S -> Type).
+    PMultiplicativeSemigroup a =>
+    (forall (s :: S). Term s a) ->
+    (forall (s :: S). Term s PPositive) ->
+    DefaultBetter
+  PPowNatural ::
+    forall (a :: S -> Type).
+    PMultiplicativeMonoid a =>
+    (forall (s :: S). Term s a) ->
+    (forall (s :: S). Term s PNatural) ->
+    DefaultBetter
 
 instance IsTest DefaultBetter where
   testOptions = Tagged []
-  run _ t _ = pure $ case t of
-    PMax x y -> case tryAndApply "pmax" pmaxDefault (plam $ \x' y' -> pmax x' y') x y of
-      Left failText -> testFailed failText
-      Right deltas -> handleDeltas deltas
-    PMin x y -> case tryAndApply "pmin" pminDefault (plam $ \x' y' -> pmin x' y') x y of
-      Left failText -> testFailed failText
-      Right deltas -> handleDeltas deltas
-    PSuccessorN p x -> case tryAndApply "psuccessorN" psuccessorNDefault psuccessorN p x of
-      Left failText -> testFailed failText
-      Right deltas -> handleDeltas deltas
-    PPredecessorN p x -> case tryAndApply "ppredecessorN" ppredecessorNDefault ppredecessorN p x of
-      Left failText -> testFailed failText
-      Right deltas -> handleDeltas deltas
-    PScalePositive x p -> case tryAndApply "pscalePositive" (plam $ pbySquaringDefault (#+)) (plam pscalePositive) x p of
-      Left failText -> testFailed failText
-      Right deltas -> handleDeltas deltas
-    PScaleNatural x n -> case tryAndApply "pscaleNatural" pscaleNaturalDefault (plam pscaleNatural) x n of
-      Left failText -> testFailed failText
-      Right deltas -> handleDeltas deltas
-    PScaleInteger x i -> case tryAndApply "pscaleInteger" pscaleIntegerDefault (plam pscaleInteger) x i of
-      Left failText -> testFailed failText
-      Right deltas -> handleDeltas deltas
+  run _ t _ = pure . either testFailed handleDeltas $ case t of
+    PMax x y -> tryAndApply "pmax" pmaxDefault (plam $ \x' y' -> pmax x' y') x y
+    PMin x y -> tryAndApply "pmin" pminDefault (plam $ \x' y' -> pmin x' y') x y
+    PSuccessorN p x -> tryAndApply "psuccessorN" psuccessorNDefault psuccessorN p x
+    PPredecessorN p x -> tryAndApply "ppredecessorN" ppredecessorNDefault ppredecessorN p x
+    PScalePositive x p -> tryAndApply "pscalePositive" (plam $ pbySquaringDefault (#+)) (plam pscalePositive) x p
+    PScaleNatural x n -> tryAndApply "pscaleNatural" pscaleNaturalDefault (plam pscaleNatural) x n
+    PScaleInteger x i -> tryAndApply "pscaleInteger" pscaleIntegerDefault (plam pscaleInteger) x i
+    PPowPositive x p -> tryAndApply "ppowPositive" (plam $ pbySquaringDefault (#*)) (plam ppowPositive) x p
+    PPowNatural x n -> tryAndApply "ppowNatural" ppowNaturalDefault (plam ppowNatural) x n
     where
       pmaxDefault :: forall (a :: S -> Type) (s :: S). POrd a => Term s (a :--> a :--> a)
       pmaxDefault = plam $ \x y -> pif (x #<= y) y x
@@ -315,6 +361,14 @@ instance IsTest DefaultBetter where
                 (pnegate # pscalePositive b (punsafeDowncast (pnegate # e')))
                 (pscalePositive b (punsafeDowncast e'))
             )
+      ppowNaturalDefault ::
+        forall (a :: S -> Type) (s :: S).
+        PMultiplicativeMonoid a => Term s (a :--> PNatural :--> a)
+      ppowNaturalDefault = plam $ \x n -> plet n $ \n' ->
+        pif
+          (n' #== pzero)
+          pone
+          (ppowPositive x (punsafeCoerce n'))
 
 scriptSize :: Script -> Integer
 scriptSize = fromIntegral . Short.length . serialiseUPLC . unScript

--- a/plutarch-testlib/goldens/either-data.bench.golden
+++ b/plutarch-testlib/goldens/either-data.bench.golden
@@ -1,0 +1,4 @@
+lte {"exBudgetCPU":481276,"exBudgetMemory":2864,"scriptSizeBytes":95}
+lt {"exBudgetCPU":481276,"exBudgetMemory":2864,"scriptSizeBytes":95}
+pmax {"exBudgetCPU":481276,"exBudgetMemory":2864,"scriptSizeBytes":156}
+pmin {"exBudgetCPU":481276,"exBudgetMemory":2864,"scriptSizeBytes":156}

--- a/plutarch-testlib/goldens/either-data.uplc.eval.golden
+++ b/plutarch-testlib/goldens/either-data.uplc.eval.golden
@@ -1,0 +1,4 @@
+lte program 1.1.0 True
+lt program 1.1.0 True
+pmax program 1.1.0 (Constr 1 [B #666f6f])
+pmin program 1.1.0 (Constr 0 [I 10])

--- a/plutarch-testlib/goldens/either-data.uplc.golden
+++ b/plutarch-testlib/goldens/either-data.uplc.golden
@@ -1,0 +1,144 @@
+lte program
+  1.1.0
+  ((\!0 ->
+      (\!0 ->
+         case
+           !1
+           [ (\!0 !0 ->
+                case
+                  !2
+                  [ ((\!0 ->
+                        case
+                          !1
+                          [ (\!0 !0 ->
+                               case
+                                 !2
+                                 [ (lessThanEqualsInteger
+                                      (unIData (!7 !4))
+                                      (unIData (!7 !1)))
+                                 , True ]) ])
+                       (unConstrData (Constr 1 [B #666f6f])))
+                  , ((\!0 ->
+                        case
+                          !1
+                          [ (\!0 !0 ->
+                               case
+                                 !2
+                                 [ False
+                                 , (lessThanEqualsByteString
+                                      (unBData (!7 !4))
+                                      (unBData (!7 !1))) ]) ])
+                       (unConstrData (Constr 1 [B #666f6f]))) ]) ])
+        (unConstrData (Constr 0 [I 10])))
+     (force headList))
+lt program
+  1.1.0
+  ((\!0 ->
+      (\!0 ->
+         case
+           !1
+           [ (\!0 !0 ->
+                case
+                  !2
+                  [ ((\!0 ->
+                        case
+                          !1
+                          [ (\!0 !0 ->
+                               case
+                                 !2
+                                 [ (lessThanInteger
+                                      (unIData (!7 !4))
+                                      (unIData (!7 !1)))
+                                 , True ]) ])
+                       (unConstrData (Constr 1 [B #666f6f])))
+                  , ((\!0 ->
+                        case
+                          !1
+                          [ (\!0 !0 ->
+                               case
+                                 !2
+                                 [ False
+                                 , (lessThanByteString
+                                      (unBData (!7 !4))
+                                      (unBData (!7 !1))) ]) ])
+                       (unConstrData (Constr 1 [B #666f6f]))) ]) ])
+        (unConstrData (Constr 0 [I 10])))
+     (force headList))
+pmax program
+  1.1.0
+  ((\!0 ->
+      (\!0 ->
+         case
+           !1
+           [ (\!0 !0 ->
+                case
+                  !2
+                  [ ((\!0 ->
+                        case
+                          !1
+                          [ (\!0 !0 ->
+                               case
+                                 !2
+                                 [ (case
+                                      (lessThanEqualsInteger
+                                         (unIData (!7 !4))
+                                         (unIData (!7 !1)))
+                                      [ (Constr 0 [I 10])
+                                      , (Constr 1 [B #666f6f]) ])
+                                 , (Constr 1 [B #666f6f]) ]) ])
+                       (unConstrData (Constr 1 [B #666f6f])))
+                  , ((\!0 ->
+                        case
+                          !1
+                          [ (\!0 !0 ->
+                               case
+                                 !2
+                                 [ (Constr 0 [I 10])
+                                 , (case
+                                      (lessThanEqualsByteString
+                                         (unBData (!7 !4))
+                                         (unBData (!7 !1)))
+                                      [ (Constr 0 [I 10])
+                                      , (Constr 1 [B #666f6f]) ]) ]) ])
+                       (unConstrData (Constr 1 [B #666f6f]))) ]) ])
+        (unConstrData (Constr 0 [I 10])))
+     (force headList))
+pmin program
+  1.1.0
+  ((\!0 ->
+      (\!0 ->
+         case
+           !1
+           [ (\!0 !0 ->
+                case
+                  !2
+                  [ ((\!0 ->
+                        case
+                          !1
+                          [ (\!0 !0 ->
+                               case
+                                 !2
+                                 [ (case
+                                      (lessThanEqualsInteger
+                                         (unIData (!7 !4))
+                                         (unIData (!7 !1)))
+                                      [ (Constr 1 [B #666f6f])
+                                      , (Constr 0 [I 10]) ])
+                                 , (Constr 0 [I 10]) ]) ])
+                       (unConstrData (Constr 1 [B #666f6f])))
+                  , ((\!0 ->
+                        case
+                          !1
+                          [ (\!0 !0 ->
+                               case
+                                 !2
+                                 [ (Constr 1 [B #666f6f])
+                                 , (case
+                                      (lessThanEqualsByteString
+                                         (unBData (!7 !4))
+                                         (unBData (!7 !1)))
+                                      [ (Constr 1 [B #666f6f])
+                                      , (Constr 0 [I 10]) ]) ]) ])
+                       (unConstrData (Constr 1 [B #666f6f]))) ]) ])
+        (unConstrData (Constr 0 [I 10])))
+     (force headList))

--- a/plutarch-testlib/plutarch-testlib.cabal
+++ b/plutarch-testlib/plutarch-testlib.cabal
@@ -115,6 +115,7 @@ test-suite tests
     Plutarch.Test.Suite.Plutarch.List
     Plutarch.Test.Suite.Plutarch.Maybe
     Plutarch.Test.Suite.Plutarch.Monadic
+    Plutarch.Test.Suite.Plutarch.Numeric
     Plutarch.Test.Suite.Plutarch.Pair
     Plutarch.Test.Suite.Plutarch.Parse
     Plutarch.Test.Suite.Plutarch.PLam
@@ -159,6 +160,7 @@ test-suite tests
     , serialise
     , sop-core
     , tasty
+    , tasty-expected-failure
     , tasty-hunit
     , tasty-quickcheck
     , text

--- a/plutarch-testlib/plutarch-testlib.cabal
+++ b/plutarch-testlib/plutarch-testlib.cabal
@@ -92,6 +92,7 @@ library
     Plutarch.Test.Bench
     Plutarch.Test.Golden
     Plutarch.Test.Laws
+    Plutarch.Test.Methods
     Plutarch.Test.QuickCheck
     Plutarch.Test.SpecTypes
     Plutarch.Test.Unit

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Array.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Array.hs
@@ -24,8 +24,11 @@ import Plutarch.Array (
   ptakeArray,
   pzipWithArray,
  )
+import Plutarch.Evaluate (evalTerm')
+import Plutarch.Internal.Term (Config (NoTracing))
 import Plutarch.Prelude
 import Plutarch.Test.Golden (goldenEval, plutarchGolden)
+import Plutarch.Test.Methods (ppowPositiveBetter, pscalePositiveBetter)
 import Plutarch.Test.QuickCheck (propEvalEqual)
 import Plutarch.Unsafe (punsafeCoerce)
 import Test.QuickCheck.Instances ()
@@ -89,6 +92,11 @@ tests =
             "zipWith f (generate n g) (generate m h) = generate (min n m) (\\i -> f (g i) (h i))"
             (\(n, m) -> ppullArrayToList $ pzipWithArray (plam (#-)) (pgenerate (pconstant n) (plam (+ 1))) $ pgenerate (pconstant m) (plam (* 2)))
             (\(n, m) -> ppullArrayToList $ pgenerate (pmin (pconstant n) (pconstant m)) (plam $ \i -> (i + 1) #- (i * 2)))
+        ]
+    , testGroup
+        "Methods"
+        [ pscalePositiveBetter (evalTerm' NoTracing sample2) (punsafeCoerce @_ @PInteger 10)
+        , ppowPositiveBetter (evalTerm' NoTracing sample2) (punsafeCoerce @_ @PInteger 10)
         ]
     ]
 

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Either.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Either.hs
@@ -1,11 +1,15 @@
 module Plutarch.Test.Suite.Plutarch.Either (tests) where
 
-import Plutarch.Either (PEitherData)
+import Plutarch.Either (PEitherData (PDLeft, PDRight))
+import Plutarch.Evaluate (evalTerm')
+import Plutarch.Internal.Term (Config (NoTracing))
 import Plutarch.LedgerApi.V1 (PPosixTime)
 import Plutarch.Prelude
 import Plutarch.Test.Golden (goldenEval, goldenGroup, plutarchGolden)
 import Plutarch.Test.Laws (checkLedgerProperties)
+import Plutarch.Test.Methods (pmaxDefaultBetter, pminDefaultBetter)
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.ExpectedFailure (expectFailBecause)
 
 tests :: TestTree
 tests =
@@ -32,5 +36,20 @@ tests =
     , testGroup
         "PEitherData"
         [ checkLedgerProperties @(PEitherData PPosixTime PPosixTime)
+        , expectFailBecause "40 script bytes is worth the other benefits" $ pmaxDefaultBetter pdleft pdright
+        , expectFailBecause "40 script bytes is worth the other benefits" $ pminDefaultBetter pdleft pdright
+        , plutarchGolden
+            "Goldens"
+            "either-data"
+            [ goldenEval "lte" (pdleft #<= pdright)
+            , goldenEval "lt" (pdleft #< pdright)
+            , goldenEval "pmax" (pmax pdleft pdright)
+            , goldenEval "pmin" (pmin pdleft pdright)
+            ]
         ]
     ]
+  where
+    pdleft :: forall (s :: S). Term s (PEitherData PInteger PByteString)
+    pdleft = evalTerm' NoTracing $ pcon . PDLeft . pdata $ 10
+    pdright :: forall (s :: S). Term s (PEitherData PInteger PByteString)
+    pdright = evalTerm' NoTracing $ pcon . PDRight . pdata . pconstant $ "foo"

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Numeric.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Numeric.hs
@@ -1,0 +1,20 @@
+module Plutarch.Test.Suite.Plutarch.Numeric (tests) where
+
+import Plutarch.Prelude (PInteger, PPositive)
+import Plutarch.Test.Methods (psuccessorNBetter)
+import Plutarch.Unsafe (punsafeCoerce)
+import Test.Tasty (TestTree, testGroup)
+
+tests :: TestTree
+tests =
+  testGroup
+    "Numeric"
+    [ testGroup
+        "PPositive"
+        [ psuccessorNBetter (punsafeCoerce @PPositive @PInteger 20) (punsafeCoerce @PPositive @PInteger 10)
+        ]
+    , testGroup
+        "PInteger"
+        [ psuccessorNBetter @PInteger (punsafeCoerce @_ @PInteger 20) 10
+        ]
+    ]

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Numeric.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Numeric.hs
@@ -1,7 +1,13 @@
 module Plutarch.Test.Suite.Plutarch.Numeric (tests) where
 
-import Plutarch.Prelude (PInteger, PPositive)
-import Plutarch.Test.Methods (ppredecessorNBetter, psuccessorNBetter)
+import Plutarch.Prelude (PInteger, PNatural, PPositive)
+import Plutarch.Test.Methods (
+  ppredecessorNBetter,
+  pscaleIntegerBetter,
+  pscaleNaturalBetter,
+  pscalePositiveBetter,
+  psuccessorNBetter,
+ )
 import Plutarch.Unsafe (punsafeCoerce)
 import Test.Tasty (TestTree, testGroup)
 
@@ -12,10 +18,19 @@ tests =
     [ testGroup
         "PPositive"
         [ psuccessorNBetter (punsafeCoerce @PPositive @PInteger 20) (punsafeCoerce @PPositive @PInteger 10)
+        , pscalePositiveBetter (punsafeCoerce @PPositive @PInteger 20) (punsafeCoerce @PPositive @PInteger 10)
+        ]
+    , testGroup
+        "PNatural"
+        [ pscalePositiveBetter (punsafeCoerce @PNatural @PInteger 20) (punsafeCoerce @PPositive @PInteger 10)
+        , pscaleNaturalBetter (punsafeCoerce @PNatural @PInteger 20) (punsafeCoerce @PNatural @PInteger 10)
         ]
     , testGroup
         "PInteger"
         [ psuccessorNBetter @PInteger (punsafeCoerce @_ @PInteger 20) 10
         , ppredecessorNBetter @PInteger (punsafeCoerce @_ @PInteger 20) 10
+        , pscalePositiveBetter @PInteger 20 (punsafeCoerce @PPositive @PInteger 10)
+        , pscaleNaturalBetter @PInteger 20 (punsafeCoerce @PNatural @PInteger 10)
+        , pscaleIntegerBetter @PInteger 20 10
         ]
     ]

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Numeric.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Numeric.hs
@@ -1,7 +1,7 @@
 module Plutarch.Test.Suite.Plutarch.Numeric (tests) where
 
 import Plutarch.Prelude (PInteger, PPositive)
-import Plutarch.Test.Methods (psuccessorNBetter)
+import Plutarch.Test.Methods (ppredecessorNBetter, psuccessorNBetter)
 import Plutarch.Unsafe (punsafeCoerce)
 import Test.Tasty (TestTree, testGroup)
 
@@ -16,5 +16,6 @@ tests =
     , testGroup
         "PInteger"
         [ psuccessorNBetter @PInteger (punsafeCoerce @_ @PInteger 20) 10
+        , ppredecessorNBetter @PInteger (punsafeCoerce @_ @PInteger 20) 10
         ]
     ]

--- a/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Rational.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/Plutarch/Rational.hs
@@ -1,8 +1,17 @@
 module Plutarch.Test.Suite.Plutarch.Rational (tests) where
 
+import Plutarch.Evaluate (evalTerm')
+import Plutarch.Internal.Term (Config (NoTracing))
 import Plutarch.Prelude
-import Plutarch.Rational (pproperFraction, ptruncate)
+import Plutarch.Rational (pproperFraction, preduce, ptruncate)
 import Plutarch.Test.Golden (goldenEval, goldenEvalFail, goldenGroup, plutarchGolden)
+import Plutarch.Test.Methods (
+  ppowPositiveBetter,
+  pscaleIntegerBetter,
+  pscaleNaturalBetter,
+  pscalePositiveBetter,
+ )
+import Plutarch.Unsafe (punsafeCoerce)
 import Test.Tasty (TestTree, testGroup)
 
 tests :: TestTree
@@ -57,7 +66,17 @@ tests =
             , goldenEvalFail "1/(1-1)" ((1 :: Term s PRational) / (1 - 1))
             ]
         ]
+    , testGroup
+        "Methods"
+        [ pscalePositiveBetter sample (punsafeCoerce @_ @PInteger 10)
+        , pscaleNaturalBetter sample (punsafeCoerce @_ @PInteger 10)
+        , pscaleIntegerBetter sample 10
+        , ppowPositiveBetter sample (punsafeCoerce @_ @PInteger 10)
+        ]
     ]
 
 rat :: Term s PRational -> Term s PRational
 rat = id
+
+sample :: forall (s :: S). Term s PRational
+sample = evalTerm' NoTracing (preduce # pcon (PRational 15 (punsafeCoerce @_ @PInteger 17)))

--- a/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1.hs
@@ -1,6 +1,8 @@
 module Plutarch.Test.Suite.PlutarchLedgerApi.V1 (tests) where
 
 import Data.Kind (Type)
+import Plutarch.Evaluate (evalTerm')
+import Plutarch.Internal.Term (Config (NoTracing))
 import Plutarch.LedgerApi.V1 qualified as PLA
 import Plutarch.LedgerApi.Value qualified as Value
 import Plutarch.Prelude
@@ -13,10 +15,12 @@ import Plutarch.Test.Laws (
   checkPAdditiveMonoidLaws,
   checkPAdditiveSemigroupLaws,
  )
+import Plutarch.Test.Methods (psuccessorNBetter)
 import Plutarch.Test.QuickCheck (propPTryFromRoundrip)
 import Plutarch.Test.Suite.PlutarchLedgerApi.V1.Interval qualified as Interval
 import Plutarch.Test.Suite.PlutarchLedgerApi.V1.Value qualified as Value
 import Plutarch.Test.Utils (fewerTests, typeName)
+import Plutarch.Unsafe (punsafeCoerce)
 import PlutusLedgerApi.V1.Orphans ()
 import Test.Tasty (TestTree, adjustOption, testGroup)
 
@@ -75,6 +79,7 @@ tests =
         , checkPAdditiveMonoidLaws @PLA.PPosixTime
         , checkPAdditiveGroupLaws @PLA.PPosixTime
         , propPTryFromRoundrip @PLA.PPosixTime
+        , psuccessorNBetter (punsafeCoerce @_ @PInteger 10) (evalTerm' NoTracing $ PLA.pposixTime 2000)
         ]
     , -- We only care about intervals of PPosixTime, so we don't check anything else
       testGroup

--- a/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1.hs
@@ -15,7 +15,7 @@ import Plutarch.Test.Laws (
   checkPAdditiveMonoidLaws,
   checkPAdditiveSemigroupLaws,
  )
-import Plutarch.Test.Methods (psuccessorNBetter)
+import Plutarch.Test.Methods (ppredecessorNBetter, psuccessorNBetter)
 import Plutarch.Test.QuickCheck (propPTryFromRoundrip)
 import Plutarch.Test.Suite.PlutarchLedgerApi.V1.Interval qualified as Interval
 import Plutarch.Test.Suite.PlutarchLedgerApi.V1.Value qualified as Value
@@ -80,6 +80,7 @@ tests =
         , checkPAdditiveGroupLaws @PLA.PPosixTime
         , propPTryFromRoundrip @PLA.PPosixTime
         , psuccessorNBetter (punsafeCoerce @_ @PInteger 10) (evalTerm' NoTracing $ PLA.pposixTime 2000)
+        , ppredecessorNBetter (punsafeCoerce @_ @PInteger 10) (evalTerm' NoTracing $ PLA.pposixTime 2000)
         ]
     , -- We only care about intervals of PPosixTime, so we don't check anything else
       testGroup

--- a/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1.hs
+++ b/plutarch-testlib/test/Plutarch/Test/Suite/PlutarchLedgerApi/V1.hs
@@ -15,7 +15,13 @@ import Plutarch.Test.Laws (
   checkPAdditiveMonoidLaws,
   checkPAdditiveSemigroupLaws,
  )
-import Plutarch.Test.Methods (ppredecessorNBetter, psuccessorNBetter)
+import Plutarch.Test.Methods (
+  ppredecessorNBetter,
+  pscaleIntegerBetter,
+  pscaleNaturalBetter,
+  pscalePositiveBetter,
+  psuccessorNBetter,
+ )
 import Plutarch.Test.QuickCheck (propPTryFromRoundrip)
 import Plutarch.Test.Suite.PlutarchLedgerApi.V1.Interval qualified as Interval
 import Plutarch.Test.Suite.PlutarchLedgerApi.V1.Value qualified as Value
@@ -81,6 +87,9 @@ tests =
         , propPTryFromRoundrip @PLA.PPosixTime
         , psuccessorNBetter (punsafeCoerce @_ @PInteger 10) (evalTerm' NoTracing $ PLA.pposixTime 2000)
         , ppredecessorNBetter (punsafeCoerce @_ @PInteger 10) (evalTerm' NoTracing $ PLA.pposixTime 2000)
+        , pscalePositiveBetter (evalTerm' NoTracing $ PLA.pposixTime 2000) (punsafeCoerce @_ @PInteger 10)
+        , pscaleNaturalBetter (evalTerm' NoTracing $ PLA.pposixTime 2000) (punsafeCoerce @_ @PInteger 10)
+        , pscaleIntegerBetter (evalTerm' NoTracing $ PLA.pposixTime 2000) 10
         ]
     , -- We only care about intervals of PPosixTime, so we don't check anything else
       testGroup

--- a/plutarch-testlib/test/Test.hs
+++ b/plutarch-testlib/test/Test.hs
@@ -11,6 +11,7 @@ import Plutarch.Test.Suite.Plutarch.Integer qualified as Integer
 import Plutarch.Test.Suite.Plutarch.List qualified as List
 import Plutarch.Test.Suite.Plutarch.Maybe qualified as Maybe
 import Plutarch.Test.Suite.Plutarch.Monadic qualified as Monadic
+import Plutarch.Test.Suite.Plutarch.Numeric qualified as Numeric
 import Plutarch.Test.Suite.Plutarch.PLam qualified as PLam
 import Plutarch.Test.Suite.Plutarch.POrd qualified as POrd
 import Plutarch.Test.Suite.Plutarch.Pair qualified as Pair
@@ -54,6 +55,7 @@ main = do
         , List.tests
         , Maybe.tests
         , Monadic.tests
+        , Numeric.tests
         , PLam.tests
         , POrd.tests
         , Pair.tests


### PR DESCRIPTION
Closes #770. This covers the following type class optional methods:

* `POrd`
* `PAdditiveSemigroup`, `PAdditiveMonoid`, `PAdditiveGroup`
* `PMultiplicativeSemigroup`, `PMultiplicativeMonoid`
* `PCountable`, `PEnumerable`

Part of this also includes tests for existing implementations of optional methods for these type classes. The only exclusion are BLS points, as constructing constants of these is a bit tricky.