### PR TITLE
PShow instance for PNatural, expose PShow method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   and tail are needed
 * `punsafeCase`, to give access to the UPLC `Case` construct more conveniently
 * `prfoldArray`, which folds a pull array from highest-to-lowest indexes
+* `PShow` instance for `PNatural`
 
 ## Changed
 
@@ -24,6 +25,7 @@
 * `Plutarch.Internal.Parse` definitions are now re-exported from
   `Plutarch.Prelude`. 
 * `pfoldlArray` renamed to `pfoldArray`.
+* `PShow`'s `pshow'` method is now available from the Prelude.
 
 ## Removed
 

--- a/Plutarch/Internal/Show.hs
+++ b/Plutarch/Internal/Show.hs
@@ -72,7 +72,7 @@ import Plutarch.Internal.ListLike (
   pmap,
   precList,
  )
-import Plutarch.Internal.Numeric (PPositive, pquot, prem)
+import Plutarch.Internal.Numeric (PNatural, PPositive, pquot, prem)
 import Plutarch.Internal.Ord (POrd ((#<)))
 import Plutarch.Internal.PLam (PLamN (plam))
 import Plutarch.Internal.PlutusType (PlutusType, pmatch)
@@ -92,11 +92,27 @@ import Plutarch.Maybe (PMaybe)
 
 import PlutusCore qualified as PLC
 
-class PShow t where
-  {- | Return the string representation of a Plutarch value
+{- | Allows a debugging representation of the datatype as a 'PString'.
 
-  If the wrap argument is True, optionally wrap the output in `(..)` if it
+= Important note
+
+Use of 'PShow' in production scripts is not a good idea, as it requires
+considerable script budget, especially for larger or more complex values. In
+general, this type class is provided to assist with testing or debugging: be
+very careful when using it for anything else, lest it impact your
+performance.
+
+Writing manual instances of this type class is also discouraged, as it is not
+intended to be a pretty printer. In most situations, the 'Generic'-based
+derivation of instances for this type class is what you want.
+-}
+class PShow t where
+  {- | Return the 'PString' representation of a Plutarch value.
+
+  If the argument is True, wrap the output in `(..)` if it
   represents multiple parameters.
+
+  @since wip
   -}
   pshow' :: Bool -> Term s t -> Term s PString
   default pshow' :: (PGeneric t, PlutusType t, All2 PShow (PCode t)) => Bool -> Term s t -> Term s PString
@@ -354,3 +370,6 @@ instance PShow PPositive
 
 -- | @since 1.10.0
 instance PShow a => PShow (PMaybe a)
+
+-- | @since wip
+instance PShow PNatural

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -201,7 +201,7 @@ module Plutarch.Prelude (
   PForall (..),
 
   -- * Show
-  PShow,
+  PShow (pshow'),
   pshow,
 
   -- * Term and related functionality


### PR DESCRIPTION
This adds an instance of `PShow` for `PNatural`, which for some reason didn't have one before. We also expose the `pshow'` method of `PShow` from the Plutarch prelude.