### PR TITLE
Fix typoes in PInterval fields

### DIFF
--- a/plutarch-ledger-api/CHANGELOG.md
+++ b/plutarch-ledger-api/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   functions now accept `PUnsortedMap` instead of `PSortedMap`, making them more
   generic.
 * In `Plutarch.LedgerApi.Interval`, renamed `palways` to `punbounded`. 
+* Fields for `PInterval` have been renamed to remove a typo.
 
 ### Removed
 

--- a/plutarch-ledger-api/plutarch-ledger-api.cabal
+++ b/plutarch-ledger-api/plutarch-ledger-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          plutarch-ledger-api
-version:       3.5.0
+version:       3.6.0
 
 common common-lang
   default-language:   Haskell2010

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Interval.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Interval.hs
@@ -41,8 +41,10 @@ import PlutusLedgerApi.V3 qualified as Plutus
 
 -- | @since 2.0.0
 data PInterval (a :: S -> Type) (s :: S) = PInterval
-  { pinteral'from :: Term s (PLowerBound a)
-  , pinteral'to :: Term s (PUpperBound a)
+  { pinterval'from :: Term s (PLowerBound a)
+  -- ^ @since 3.6.0
+  , pinterval'to :: Term s (PUpperBound a)
+  -- ^ @since 3.6.0
   }
   deriving stock
     ( -- | @since 2.0.0

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Interval.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Interval.hs
@@ -42,9 +42,9 @@ import PlutusLedgerApi.V3 qualified as Plutus
 -- | @since 2.0.0
 data PInterval (a :: S -> Type) (s :: S) = PInterval
   { pinterval'from :: Term s (PLowerBound a)
-  -- ^ @since 3.6.0
+  -- ^ @since wip
   , pinterval'to :: Term s (PUpperBound a)
-  -- ^ @since 3.6.0
+  -- ^ @since wip
   }
   deriving stock
     ( -- | @since 2.0.0


### PR DESCRIPTION
This fixes the (rather embarrassing) typoes in the field names for `PInterval`.