### PR TITLE
Subtyping relationships for `PNatural` and `PPositive`, defaults for `pzero` and `pone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@
   `Plutarch.Prelude`. 
 * `pfoldlArray` renamed to `pfoldArray`.
 * `PShow`'s `pshow'` method is now available from the Prelude.
+* `PInner PPositive` is now `PNatural`, which allows the use of `pupcast` for
+  easier conversions 'upward'.
 
 ## Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * `PShow`'s `pshow'` method is now available from the Prelude.
 * `PInner PPositive` is now `PNatural`, which allows the use of `pupcast` for
   easier conversions 'upward'.
+* `pzero` and `pone` now have defaults based on `PInner`, similar to `#+`.
 
 ## Removed
 

--- a/Plutarch/Enum.hs
+++ b/Plutarch/Enum.hs
@@ -11,8 +11,8 @@ import Plutarch.Internal.Eq ((#==))
 import Plutarch.Internal.Fix (pfix)
 import Plutarch.Internal.Numeric (PPositive, pone, (#+))
 import Plutarch.Internal.Ord (POrd)
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
+import Plutarch.Internal.Subtype (pupcast)
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -71,7 +71,7 @@ instance PCountable PInteger where
   {-# INLINEABLE psuccessor #-}
   psuccessor = phoistAcyclic $ plam (+ 1)
   {-# INLINEABLE psuccessorN #-}
-  psuccessorN = phoistAcyclic $ plam $ \p i -> pto p + i
+  psuccessorN = phoistAcyclic $ plam $ \p i -> pupcast p + i
 
 -- | @since 1.10.0
 instance PCountable PPositive where
@@ -129,4 +129,4 @@ instance PEnumerable PInteger where
   {-# INLINEABLE ppredecessor #-}
   ppredecessor = phoistAcyclic $ plam (- 1)
   {-# INLINEABLE ppredecessorN #-}
-  ppredecessorN = phoistAcyclic $ plam $ \p i -> i - pto p
+  ppredecessorN = phoistAcyclic $ plam $ \p i -> i - pupcast p

--- a/Plutarch/Internal/Numeric.hs
+++ b/Plutarch/Internal/Numeric.hs
@@ -265,17 +265,13 @@ infix 6 #+
 
 -- | @since 1.10.0
 instance PAdditiveSemigroup PPositive where
-  -- {-# INLINEABLE (#+) #-}
-  -- x #+ y = punsafeCoerce $ paddInteger # pto x # pto y
   {-# INLINEABLE pscalePositive #-}
   pscalePositive b e = b #* e
 
 -- | @since 1.10.0
 instance PAdditiveSemigroup PNatural where
-  -- {-# INLINEABLE (#+) #-}
-  -- x #+ y = pcon . PNatural $ paddInteger # pto x # pto y
   {-# INLINEABLE pscalePositive #-}
-  pscalePositive b e = b #* punsafeCoerce e
+  pscalePositive b e = b #* pupcast e
 
 -- | @since 1.10.0
 instance PAdditiveSemigroup PInteger where
@@ -318,6 +314,11 @@ The default implementation of 'pscaleNatural' ensures these laws hold.
 -}
 class PAdditiveSemigroup a => PAdditiveMonoid (a :: S -> Type) where
   pzero :: forall (s :: S). Term s a
+  default pzero ::
+    forall (s :: S).
+    PAdditiveMonoid (PInner a) =>
+    Term s a
+  pzero = punsafeDowncast pzero
   {-# INLINEABLE pscaleNatural #-}
   pscaleNatural ::
     forall (s :: S).
@@ -340,8 +341,6 @@ instance PAdditiveMonoid PInteger where
 
 -- | @since 1.10.0
 instance PAdditiveMonoid PNatural where
-  {-# INLINEABLE pzero #-}
-  pzero = pcon . PNatural . pconstantInteger $ 0
   {-# INLINEABLE pscaleNatural #-}
   pscaleNatural n1 n2 = n1 #* n2
 
@@ -488,14 +487,8 @@ infix 6 #*
 -- | @since 1.10.0
 instance PMultiplicativeSemigroup PPositive
 
--- {-# INLINEABLE (#*) #-}
--- x #* y = punsafeCoerce $ pmultiplyInteger # pto x # pto y
-
 -- | @since 1.10.0
 instance PMultiplicativeSemigroup PNatural
-
--- {-# INLINEABLE (#*) #-}
--- x #* y = pcon . PNatural $ pmultiplyInteger # pto x # pto y
 
 -- | @since 1.10.0
 instance PMultiplicativeSemigroup PInteger where
@@ -526,6 +519,11 @@ If you define 'ppowNatural', ensure the following as well:
 -}
 class PMultiplicativeSemigroup a => PMultiplicativeMonoid (a :: S -> Type) where
   pone :: forall (s :: S). Term s a
+  default pone ::
+    forall (s :: S).
+    PMultiplicativeMonoid (PInner a) =>
+    Term s a
+  pone = punsafeDowncast pone
   {-# INLINEABLE ppowNatural #-}
   ppowNatural ::
     forall (s :: S).
@@ -539,14 +537,10 @@ class PMultiplicativeSemigroup a => PMultiplicativeMonoid (a :: S -> Type) where
       (ppowPositive x (punsafeCoerce n'))
 
 -- | @since 1.10.0
-instance PMultiplicativeMonoid PPositive where
-  {-# INLINEABLE pone #-}
-  pone = punsafeCoerce $ pconstantInteger 1
+instance PMultiplicativeMonoid PPositive
 
 -- | @since 1.10.0
-instance PMultiplicativeMonoid PNatural where
-  {-# INLINEABLE pone #-}
-  pone = pcon . PNatural $ pconstantInteger 1
+instance PMultiplicativeMonoid PNatural
 
 -- | @since 1.10.0
 instance PMultiplicativeMonoid PInteger where

--- a/Plutarch/Internal/Numeric.hs
+++ b/Plutarch/Internal/Numeric.hs
@@ -88,6 +88,7 @@ import Plutarch.Internal.PlutusType (
   PlutusType (PInner),
   pcon,
  )
+import Plutarch.Internal.Subtype (pupcast)
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -112,9 +113,10 @@ import Test.QuickCheck (
   functionMap,
  )
 import Test.QuickCheck qualified as QuickCheck
+import Test.QuickCheck.Instances ()
 
 -- | @since 1.10.0
-newtype PPositive (s :: S) = PPositive (Term s PInteger)
+newtype PPositive (s :: S) = PPositive (Term s PNatural)
   deriving stock
     ( -- | @since 1.10.0
       Generic
@@ -142,7 +144,7 @@ deriving via
     PLiftable PPositive
 
 -- | @since 1.10.0
-newtype Positive = UnsafeMkPositive {getPositive :: Integer}
+newtype Positive = UnsafeMkPositive {getPositive :: Natural}
   deriving stock
     ( -- | @since 1.10.0
       Show
@@ -154,20 +156,17 @@ newtype Positive = UnsafeMkPositive {getPositive :: Integer}
   deriving
     ( -- | @since 1.10.0
       Arbitrary
-    )
-    via QuickCheck.Positive Integer
-  deriving
-    ( -- | @since 1.10.0
+    , -- | @since 1.10.0
       CoArbitrary
     , -- | @since 1.10.0
       Pretty
     )
-    via Integer
+    via Natural
 
 -- | @since 1.10.0
 instance Function Positive where
   {-# INLINEABLE function #-}
-  function = functionMap @Integer coerce coerce
+  function = functionMap @Natural coerce coerce
 
 {- | Converts negative 'Integer's into their absolute values, positive
 'Integer's into their 'Positive' equivalents. Errors on 0.
@@ -176,13 +175,13 @@ instance Function Positive where
 -}
 toPositiveAbs :: Integer -> Positive
 toPositiveAbs i = UnsafeMkPositive $ case signum i of
-  (-1) -> abs i
+  (-1) -> fromIntegral $ abs i
   0 -> error "toPositiveAbs: called with zero"
-  _ -> i
+  _ -> fromIntegral i
 
 -- | @since 1.10.0
 positiveToInteger :: Positive -> Integer
-positiveToInteger = getPositive
+positiveToInteger = fromIntegral . getPositive
 
 -- | @since 1.10.0
 newtype PNatural (s :: S) = PNatural (Term s PInteger)
@@ -266,15 +265,15 @@ infix 6 #+
 
 -- | @since 1.10.0
 instance PAdditiveSemigroup PPositive where
-  {-# INLINEABLE (#+) #-}
-  x #+ y = punsafeCoerce $ paddInteger # pto x # pto y
+  -- {-# INLINEABLE (#+) #-}
+  -- x #+ y = punsafeCoerce $ paddInteger # pto x # pto y
   {-# INLINEABLE pscalePositive #-}
   pscalePositive b e = b #* e
 
 -- | @since 1.10.0
 instance PAdditiveSemigroup PNatural where
-  {-# INLINEABLE (#+) #-}
-  x #+ y = pcon . PNatural $ paddInteger # pto x # pto y
+  -- {-# INLINEABLE (#+) #-}
+  -- x #+ y = pcon . PNatural $ paddInteger # pto x # pto y
   {-# INLINEABLE pscalePositive #-}
   pscalePositive b e = b #* punsafeCoerce e
 
@@ -283,21 +282,21 @@ instance PAdditiveSemigroup PInteger where
   {-# INLINEABLE (#+) #-}
   x #+ y = paddInteger # x # y
   {-# INLINEABLE pscalePositive #-}
-  pscalePositive b e = b #* pto e
+  pscalePositive b e = b #* pupcast e
 
 -- | @since 1.10.0
 instance PAdditiveSemigroup PBuiltinBLS12_381_G1_Element where
   {-# INLINEABLE (#+) #-}
   x #+ y = pbls12_381_G1_add # x # y
   {-# INLINEABLE pscalePositive #-}
-  pscalePositive x p = pbls12_381_G1_scalarMul # pto p # x
+  pscalePositive x p = pbls12_381_G1_scalarMul # pupcast p # x
 
 -- | @since 1.10.0
 instance PAdditiveSemigroup PBuiltinBLS12_381_G2_Element where
   {-# INLINEABLE (#+) #-}
   x #+ y = pbls12_381_G2_add # x # y
   {-# INLINEABLE pscalePositive #-}
-  pscalePositive x p = pbls12_381_G2_scalarMul # pto p # x
+  pscalePositive x p = pbls12_381_G2_scalarMul # pupcast p # x
 
 {- | The notion of zero, as well as a way to scale by naturals.
 
@@ -413,8 +412,8 @@ class PAdditiveMonoid a => PAdditiveGroup (a :: S -> Type) where
         pzero
         ( pif
             (e' #<= pzero)
-            (pnegate # pscalePositive b (punsafeDowncast (pnegate # e')))
-            (pscalePositive b (punsafeDowncast e'))
+            (pnegate # pscalePositive b (punsafeCoerce $ pnegate # e'))
+            (pscalePositive b (punsafeCoerce e'))
         )
 
 -- | @since 1.10.0
@@ -487,14 +486,16 @@ class PMultiplicativeSemigroup (a :: S -> Type) where
 infix 6 #*
 
 -- | @since 1.10.0
-instance PMultiplicativeSemigroup PPositive where
-  {-# INLINEABLE (#*) #-}
-  x #* y = punsafeCoerce $ pmultiplyInteger # pto x # pto y
+instance PMultiplicativeSemigroup PPositive
+
+-- {-# INLINEABLE (#*) #-}
+-- x #* y = punsafeCoerce $ pmultiplyInteger # pto x # pto y
 
 -- | @since 1.10.0
-instance PMultiplicativeSemigroup PNatural where
-  {-# INLINEABLE (#*) #-}
-  x #* y = pcon . PNatural $ pmultiplyInteger # pto x # pto y
+instance PMultiplicativeSemigroup PNatural
+
+-- {-# INLINEABLE (#*) #-}
+-- x #* y = pcon . PNatural $ pmultiplyInteger # pto x # pto y
 
 -- | @since 1.10.0
 instance PMultiplicativeSemigroup PInteger where
@@ -535,7 +536,7 @@ class PMultiplicativeSemigroup a => PMultiplicativeMonoid (a :: S -> Type) where
     pif
       (n' #== pzero)
       pone
-      (ppowPositive x (pcon (PPositive $ pto n')))
+      (ppowPositive x (punsafeCoerce n'))
 
 -- | @since 1.10.0
 instance PMultiplicativeMonoid PPositive where
@@ -571,8 +572,7 @@ ppositive = phoistAcyclic $
     pif
       (i #<= pconstantInteger 0)
       (pcon PNothing)
-      $ pcon . PJust . pcon
-      $ PPositive i
+      (pcon . PJust . punsafeCoerce $ i)
 
 {- | A default implementation of exponentiation-by-squaring with a
 strictly-positive exponent.
@@ -594,12 +594,12 @@ pbySquaringDefault f b e = go # b # e
     go :: forall (s'' :: S). Term s'' (a :--> PPositive :--> a)
     go = phoistAcyclic $ pfix $ \self -> plam $ \b e -> plet e $ \e' ->
       pif
-        (pto e' #== pconstantInteger 1)
+        (pto e' #== pone)
         b
-        ( plet (self # b #$ punsafeDowncast (pquotientInteger # pto e' # pconstantInteger 2)) $ \below ->
+        ( plet (self # b #$ punsafeDowncast (punsafeDowncast (pquotientInteger # pupcast e' # pconstantInteger 2))) $ \below ->
             plet (f below below) $ \res ->
               pif
-                ((premainderInteger # pto e' # pconstantInteger 2) #== pconstantInteger 1)
+                ((premainderInteger # pupcast e' # pconstantInteger 2) #== pconstantInteger 1)
                 (f b res)
                 res
         )

--- a/Plutarch/Internal/Semigroup.hs
+++ b/Plutarch/Internal/Semigroup.hs
@@ -66,6 +66,7 @@ import Plutarch.Internal.PlutusType (
   PlutusType (PInner),
   pcon,
  )
+import Plutarch.Internal.Subtype (PSubtype, pupcast)
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -130,7 +131,7 @@ instance PSemigroup PByteString where
   pstimes p bs = plet bs $ \bs' ->
     pif
       (plengthBS # bs' #== 1)
-      (preplicateBS # pto p #$ pindexBS # bs' # 0)
+      (preplicateBS # pupcast p #$ pindexBS # bs' # 0)
       (pbySquaringDefault (#<>) bs' p)
 
 {- | BLS points form a group technically, but a @PGroup@ notion would be too
@@ -413,12 +414,12 @@ instance PMonoid (PXor PByteString) where
 
 pxortimes ::
   forall (a :: S -> Type) (b :: S -> Type) (s :: S).
-  PInner a ~ PInteger =>
+  PSubtype PInteger a =>
   Term s b ->
   Term s a ->
   Term s (PXor b) ->
   Term s (PXor b)
 pxortimes def x =
   pif
-    ((pdiv # pto x # 2) #== 0)
+    ((pdiv # pupcast x # 2) #== 0)
     (pcon . PXor $ def)

--- a/Plutarch/Rational.hs
+++ b/Plutarch/Rational.hs
@@ -60,6 +60,7 @@ import Plutarch.Internal.Other (Flip, pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (PlutusType, pcon, pmatch)
 import Plutarch.Internal.Show (PShow, pshow, pshow')
+import Plutarch.Internal.Subtype (pupcast)
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -162,13 +163,13 @@ instance PAdditiveSemigroup PRational where
           PRational yn yd' <- tcont $ pmatch y
           xd <- tcont $ plet xd'
           yd <- tcont $ plet yd'
-          pure $ preduce' # (xn * pto yd + yn * pto xd) # pto (xd #* yd)
+          pure $ preduce' # (xn * pupcast yd + yn * pupcast xd) # pupcast (xd #* yd)
       )
       # x'
       # y'
   {-# INLINEABLE pscalePositive #-}
   pscalePositive x p = pmatch x $ \(PRational xn xd) ->
-    preduce' # (xn #* pto p) # pto xd
+    preduce' # (xn #* pupcast p) # pupcast xd
 
 -- | @since 1.10.0
 instance PAdditiveMonoid PRational where
@@ -176,7 +177,7 @@ instance PAdditiveMonoid PRational where
   pzero = pcon . PRational pzero $ pone
   {-# INLINEABLE pscaleNatural #-}
   pscaleNatural x n = pmatch x $ \(PRational xn xd) ->
-    preduce' # (xn #* pto n) # pto xd
+    preduce' # (xn #* pto n) # pupcast xd
 
 -- | @since 1.10.0
 instance PAdditiveGroup PRational where
@@ -194,13 +195,13 @@ instance PAdditiveGroup PRational where
           PRational yn yd' <- tcont $ pmatch y
           xd <- tcont $ plet xd'
           yd <- tcont $ plet yd'
-          pure $ preduce' # (xn * pto yd - yn * pto xd) # pto (xd #* yd)
+          pure $ preduce' # (xn * pupcast yd - yn * pupcast xd) # pupcast (xd #* yd)
       )
       # x'
       # y'
   {-# INLINEABLE pscaleInteger #-}
   pscaleInteger x e = pmatch x $ \(PRational xn xd) ->
-    preduce' # (xn #* e) # pto xd
+    preduce' # (xn #* e) # pupcast xd
 
 -- | @since 1.10.0
 instance PMultiplicativeSemigroup PRational where
@@ -210,7 +211,7 @@ instance PMultiplicativeSemigroup PRational where
       ( plam $ \x y -> unTermCont $ do
           PRational xn xd <- tcont $ pmatch x
           PRational yn yd <- tcont $ pmatch y
-          pure $ preduce' # (xn * yn) # pto (xd #* yd)
+          pure $ preduce' # (xn * yn) # pupcast (xd #* yd)
       )
       # x'
       # y'
@@ -255,11 +256,11 @@ instance Fractional (Term s PRational) where
       inner :: forall (s :: S). Term s (PRational :--> PRational :--> PRational)
       inner = phoistAcyclic $ plam $ \x y -> pmatch x $ \(PRational xn xd) ->
         pmatch y $ \(PRational yn yd) ->
-          plet (pto xd * yn) $ \denm ->
+          plet (pupcast xd * yn) $ \denm ->
             pif
               (denm #== 0)
               (ptraceInfoError "Cannot divide by zero")
-              (preduce' # (xn * pto yd) # denm)
+              (preduce' # (xn * pupcast yd) # denm)
   {-# INLINEABLE recip #-}
   recip x = inner # x
     where
@@ -267,9 +268,9 @@ instance Fractional (Term s PRational) where
       inner = phoistAcyclic $ plam $ \x -> pmatch x $ \(PRational xn xd) ->
         pcond
           [ (xn #== 0, ptraceInfoError "attempted to construct the reciprocal of zero")
-          , (xn #<= 0, pcon $ PRational (pnegate #$ pto xd) (punsafeCoerce $ pnegate # xn))
+          , (xn #<= 0, pcon $ PRational (pnegate #$ pupcast xd) (punsafeCoerce $ pnegate # xn))
           ]
-          (pcon $ PRational (pto xd) (punsafeCoerce xn))
+          (pcon $ PRational (pupcast xd) (punsafeCoerce xn))
   {-# INLINEABLE fromRational #-}
   fromRational = pconstant . PlutusTx.fromGHC
 
@@ -279,7 +280,7 @@ instance PShow PRational where
     where
       pshowRat = phoistAcyclic $
         plam $ \n -> pmatch n $ \(PRational x y) ->
-          pshow x <> "/" <> pshow (pto y)
+          pshow x <> "/" <> pshow (pupcast @PInteger y)
 
 -- | NOTE: This instance produces a verified 'PPositive' as the excess output.
 instance PTryFrom PData (PAsData PRational) where
@@ -294,7 +295,7 @@ instance PTryFrom PData (PAsData PRational) where
 
 preduce :: Term s (PRational :--> PRational)
 preduce = phoistAcyclic $ plam $ \x ->
-  pmatch x $ \(PRational n d) -> preduce' # n # pto d
+  pmatch x $ \(PRational n d) -> preduce' # n # pupcast d
 
 pgcd :: Term s (PInteger :--> PInteger :--> PInteger)
 pgcd = phoistAcyclic $
@@ -332,13 +333,13 @@ pround = phoistAcyclic $
     PRational a' b' <- tcont $ pmatch x
     a <- tcont $ plet a'
     b <- tcont $ plet b'
-    base <- tcont . plet $ pdiv # a # pto b
-    rem <- tcont . plet $ pmod # a # pto b
+    base <- tcont . plet $ pdiv # a # pupcast b
+    rem <- tcont . plet $ pmod # a # pupcast b
     let result =
           pcond
-            [ (pmod # pto b # 2 #== 1, pif (pdiv # pto b # 2 #< rem) 1 0)
-            , (pdiv # pto b # 2 #== rem, pmod # base # 2)
-            , (rem #< pdiv # pto b # 2, 0)
+            [ (pmod # pupcast b # 2 #== 1, pif (pdiv # pupcast b # 2 #< rem) 1 0)
+            , (pdiv # pupcast b # 2 #== rem, pmod # base # 2)
+            , (rem #< pdiv # pupcast b # 2, 0)
             ]
             1
     pure $ base + result
@@ -347,7 +348,7 @@ ptruncate :: Term s (PRational :--> PInteger)
 ptruncate = phoistAcyclic $
   plam $ \x ->
     pmatch x $ \(PRational a b) ->
-      pquot # a # pto b
+      pquot # a # pupcast b
 
 pproperFraction :: Term s (PRational :--> PPair PInteger PRational)
 pproperFraction = phoistAcyclic $
@@ -363,7 +364,7 @@ cmpHelper ::
 cmpHelper = phoistAcyclic $ plam $ \f l r ->
   pmatch l $ \(PRational ln ld) ->
     pmatch r $ \(PRational rn rd) ->
-      f # (pto rd * ln) # (rn * pto ld)
+      f # (pupcast rd * ln) # (rn * pupcast ld)
 
 -- Assumes d is not zero
 preduce' :: forall (s :: S). Term s (PInteger :--> PInteger :--> PRational)
@@ -372,5 +373,5 @@ preduce' = phoistAcyclic $ plam $ \n d' ->
     plet (pgcd # n # d) $ \r ->
       pif
         (d #<= 0)
-        (pcon $ PRational (pnegate # (pdiv # n # r)) $ punsafeDowncast (pnegate # (pdiv # d # r)))
-        (pcon $ PRational (pdiv # n # r) $ punsafeDowncast (pdiv # d # r))
+        (pcon $ PRational (pnegate # (pdiv # n # r)) $ punsafeDowncast (punsafeDowncast (pnegate # (pdiv # d # r))))
+        (pcon $ PRational (pdiv # n # r) $ punsafeDowncast (punsafeDowncast (pdiv # d # r)))

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/Utils.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/Utils.hs
@@ -434,4 +434,4 @@ liftCompareOp f x y = phoistAcyclic (plam go) # x # y
     go l r = unTermCont $ do
       PRationalData ln ld <- pmatchC l
       PRationalData rn rd <- pmatchC r
-      pure $ f (pfromData ln * pto (pfromData rd)) (pfromData rn * pto (pfromData ld))
+      pure $ f (pfromData ln * pupcast (pfromData rd)) (pfromData rn * pupcast (pfromData ld))

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
@@ -50,7 +50,7 @@ instance PCountable PPosixTime where
   psuccessor = phoistAcyclic $ plam (\x -> x #+ pposixTime pone)
   {-# INLINEABLE psuccessorN #-}
   psuccessorN = phoistAcyclic $ plam $ \p t ->
-    let p' = pcon . PPosixTime . pto $ p
+    let p' = pcon . PPosixTime . pupcast $ p
      in p' #+ t
 
 -- | @since 3.3.0
@@ -59,7 +59,7 @@ instance PEnumerable PPosixTime where
   ppredecessor = phoistAcyclic $ plam (\x -> x #- pposixTime pone)
   {-# INLINEABLE ppredecessorN #-}
   ppredecessorN = phoistAcyclic $ plam $ \p t ->
-    let p' = pcon . PPosixTime . pto $ p
+    let p' = pcon . PPosixTime . pupcast $ p
      in t #- p'
 
 -- | @since 3.3.0
@@ -67,7 +67,7 @@ instance PAdditiveSemigroup PPosixTime where
   {-# INLINEABLE (#+) #-}
   t1 #+ t2 = pposixTime (unPPosixTime t1 #+ unPPosixTime t2)
   {-# INLINEABLE pscalePositive #-}
-  pscalePositive t p = pposixTime (unPPosixTime t #* pto p)
+  pscalePositive t p = pposixTime (unPPosixTime t #* pupcast p)
 
 -- | @since 3.3.0
 instance PAdditiveMonoid PPosixTime where

--- a/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
+++ b/plutarch-ledger-api/src/Plutarch/LedgerApi/V1/Time.hs
@@ -64,15 +64,10 @@ instance PEnumerable PPosixTime where
 
 -- | @since 3.3.0
 instance PAdditiveSemigroup PPosixTime where
-  {-# INLINEABLE (#+) #-}
-  t1 #+ t2 = pposixTime (unPPosixTime t1 #+ unPPosixTime t2)
-  {-# INLINEABLE pscalePositive #-}
   pscalePositive t p = pposixTime (unPPosixTime t #* pupcast p)
 
 -- | @since 3.3.0
 instance PAdditiveMonoid PPosixTime where
-  {-# INLINEABLE pzero #-}
-  pzero = pposixTime pzero
   {-# INLINEABLE pscaleNatural #-}
   pscaleNatural t n = pposixTime (unPPosixTime t #* pto n)
 

--- a/plutarch-testlib/Plutarch/Test/Methods.hs
+++ b/plutarch-testlib/Plutarch/Test/Methods.hs
@@ -358,8 +358,8 @@ instance IsTest DefaultBetter where
             pzero
             ( pif
                 (e' #<= pzero)
-                (pnegate # pscalePositive b (punsafeDowncast (pnegate # e')))
-                (pscalePositive b (punsafeDowncast e'))
+                (pnegate # pscalePositive b (punsafeDowncast (punsafeDowncast (pnegate # e'))))
+                (pscalePositive b (punsafeDowncast (punsafeDowncast e')))
             )
       ppowNaturalDefault ::
         forall (a :: S -> Type) (s :: S).

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -163,6 +163,7 @@ library
     , plutus-tx
     , prettyprinter
     , QuickCheck
+    , quickcheck-instances
     , random
     , semialign
     , sop-core


### PR DESCRIPTION
This PR solves two minor, but still annoying, problems:

* Previously, `PInner PNatural = PInner PPositive = PInteger`. This is a bit annoying, because converting from `PPositive` to `PNatural` requires either checked ops (which are inefficient) or `punsafeCoerce` (which is dangerous). Now, we have `PInner PPositive = PNatural`, which allows the use of `pto`, which is both efficient and safe.
* `pzero` and `pone` had no default implementations, unlike `#+` and `#*`. Not only is this weirdly asymmetrical, it's also quite strange, and if we can default addition and multiplication from `PInner`, defaulting identities for both should also be possible. This is now done.