### PR TITLE
Reorganize PSubtype

### DIFF
--- a/Plutarch/BitString.hs
+++ b/Plutarch/BitString.hs
@@ -29,7 +29,6 @@ import Plutarch.Internal.Lift (
  )
 import Plutarch.Internal.Numeric (pzero)
 import Plutarch.Internal.Ord (POrd ((#<)))
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
   DeriveNewtypePlutusType (DeriveNewtypePlutusType),
@@ -37,6 +36,7 @@ import Plutarch.Internal.PlutusType (
   pcon,
  )
 import Plutarch.Internal.Semigroup (PMonoid, PSemigroup)
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   S,
   Term,

--- a/Plutarch/Builtin/Crypto.hs
+++ b/Plutarch/Builtin/Crypto.hs
@@ -15,8 +15,7 @@ module Plutarch.Builtin.Crypto (
 
 import Plutarch.Builtin.Bool (PBool)
 import Plutarch.Builtin.ByteString (PByteString)
-import Plutarch.Internal.Term (Term, (:-->))
-import Plutarch.Unsafe (punsafeBuiltin)
+import Plutarch.Internal.Term (Term, punsafeBuiltin, (:-->))
 import PlutusCore qualified as PLC
 
 -- | Hash a 'PByteString' using SHA-256.

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -87,7 +87,7 @@ import Plutarch.Internal.Lift (pconstant)
 import Plutarch.Internal.ListLike (PListLike (pnil), pcons, pdrop, phead, ptail, ptryIndex)
 import Plutarch.Internal.Newtype (PlutusTypeNewtype)
 import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=)))
-import Plutarch.Internal.Other (Flip, pto)
+import Plutarch.Internal.Other (Flip)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
   DerivePlutusType (DPTStrat),
@@ -101,6 +101,7 @@ import Plutarch.Internal.PlutusType (
   pmatch,
  )
 import Plutarch.Internal.Show (PShow (pshow'))
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   RawTerm,
   Term,

--- a/Plutarch/DataRepr/Internal.hs
+++ b/Plutarch/DataRepr/Internal.hs
@@ -110,6 +110,7 @@ import Plutarch.Internal.Term (
   pforce,
   phoistAcyclic,
   plet,
+  punsafeCoerce,
   (#),
   (#$),
   (:-->),
@@ -133,7 +134,6 @@ import Plutarch.Internal.TryFrom (
  )
 import Plutarch.Reducible (NoReduce, Reduce)
 import Plutarch.Trace (ptraceInfoError)
-import Plutarch.Unsafe (punsafeCoerce)
 
 {- | A "record" of `exists a. PAsData a`. The underlying representation is
  `PBuiltinList PData`.

--- a/Plutarch/DataRepr/Internal/Field.hs
+++ b/Plutarch/DataRepr/Internal/Field.hs
@@ -52,9 +52,9 @@ import Plutarch.DataRepr.Internal.HList (
   type IndexList,
  )
 import Plutarch.Internal.IsData (PIsData, pfromData)
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (PInner)
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (S, Term, plet, (#), (:-->))
 import Plutarch.Internal.TermCont (TermCont (TermCont), runTermCont)
 import Plutarch.Internal.Witness (witness)

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -82,6 +82,7 @@ import Plutarch.Internal.Term (
   Term,
   phoistAcyclic,
   plet,
+  punsafeCoerce,
   (#),
   (#$),
   (:-->),
@@ -89,7 +90,6 @@ import Plutarch.Internal.Term (
 import Plutarch.Internal.TryFrom (PTryFrom)
 import Plutarch.Repr.SOP (DeriveAsSOPStruct (DeriveAsSOPStruct))
 import Plutarch.Trace (ptraceInfoError)
-import Plutarch.Unsafe (punsafeCoerce)
 import PlutusLedgerApi.V3 qualified as Plutus
 
 {- | SOP-encoded 'Either'.

--- a/Plutarch/Either.hs
+++ b/Plutarch/Either.hs
@@ -69,7 +69,6 @@ import Plutarch.Internal.Lift (
  )
 import Plutarch.Internal.ListLike (pcons, phead, pnil)
 import Plutarch.Internal.Ord (POrd (pmax, pmin, (#<), (#<=)))
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
   PlutusType (PInner, pcon', pmatch'),
@@ -77,6 +76,7 @@ import Plutarch.Internal.PlutusType (
   pmatch,
  )
 import Plutarch.Internal.Show (PShow)
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   S,
   Term,

--- a/Plutarch/Enum.hs
+++ b/Plutarch/Enum.hs
@@ -11,8 +11,8 @@ import Plutarch.Internal.Eq ((#==))
 import Plutarch.Internal.Fix (pfix)
 import Plutarch.Internal.Numeric (PPositive, pone, (#+))
 import Plutarch.Internal.Ord (POrd)
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   S,
   Term,

--- a/Plutarch/Internal/IsData.hs
+++ b/Plutarch/Internal/IsData.hs
@@ -40,7 +40,12 @@ import Plutarch.Internal.PlutusType (
   PlutusType (PInner),
   pmatch,
  )
-import Plutarch.Internal.Subtype (PSubtype, pto, pupcast)
+import Plutarch.Internal.Subtype (
+  PSubtype,
+  pto,
+  punsafeDowncast,
+  pupcast,
+ )
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -52,7 +57,6 @@ import Plutarch.Internal.Term (
   (#),
   (#$),
  )
-import Plutarch.Unsafe (punsafeDowncast)
 import PlutusCore qualified as PLC
 import PlutusTx qualified as PTx
 

--- a/Plutarch/Internal/IsData.hs
+++ b/Plutarch/Internal/IsData.hs
@@ -34,14 +34,13 @@ import Plutarch.Internal.Eq (PEq ((#==)))
 import Plutarch.Internal.ListLike (
   PListLike (pcons, phead, pnil, ptail),
  )
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (PLamN (plam))
 import Plutarch.Internal.PlutusType (
   PInnermost,
   PlutusType (PInner),
   pmatch,
  )
-import Plutarch.Internal.Subtype (PSubtype, pupcast)
+import Plutarch.Internal.Subtype (PSubtype, pto, pupcast)
 import Plutarch.Internal.Term (
   S,
   Term,

--- a/Plutarch/Internal/Lift.hs
+++ b/Plutarch/Internal/Lift.hs
@@ -79,10 +79,10 @@ import Plutarch.Internal.Term (
   Term,
   TracingMode (DoTracing),
   compile,
+  punsafeCoerce,
   punsafeConstantInternal,
  )
 import Plutarch.Script (Script (Script))
-import Plutarch.Unsafe (punsafeCoerce)
 import PlutusCore qualified as PLC
 import PlutusCore.Builtin (BuiltinError, readKnownConstant)
 import PlutusCore.Crypto.BLS12_381.G1 qualified as BLS12_381.G1

--- a/Plutarch/Internal/Numeric.hs
+++ b/Plutarch/Internal/Numeric.hs
@@ -87,7 +87,7 @@ import Plutarch.Internal.PlutusType (
   PlutusType (PInner),
   pcon,
  )
-import Plutarch.Internal.Subtype (pto)
+import Plutarch.Internal.Subtype (pto, punsafeDowncast)
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -102,7 +102,6 @@ import Plutarch.Internal.Term (
  )
 import Plutarch.Internal.Trace (ptraceInfo)
 import Plutarch.Maybe (PMaybe (PJust, PNothing))
-import Plutarch.Unsafe (punsafeDowncast)
 import PlutusCore qualified as PLC
 import Prettyprinter (Pretty)
 import Test.QuickCheck (

--- a/Plutarch/Internal/Numeric.hs
+++ b/Plutarch/Internal/Numeric.hs
@@ -81,13 +81,13 @@ import Plutarch.Internal.Lift (
   punsafeCoercePLifted,
  )
 import Plutarch.Internal.Ord (POrd ((#<=)))
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
   DeriveNewtypePlutusType (DeriveNewtypePlutusType),
   PlutusType (PInner),
   pcon,
  )
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   S,
   Term,

--- a/Plutarch/Internal/Ord.hs
+++ b/Plutarch/Internal/Ord.hs
@@ -27,8 +27,8 @@ import Plutarch.Builtin.Integer (
 import Plutarch.Builtin.Unit (PUnit)
 import Plutarch.Internal.Eq (PEq)
 import Plutarch.Internal.Lift (pconstant)
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PlutusType (PInner)
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   S,
   Term,

--- a/Plutarch/Internal/Other.hs
+++ b/Plutarch/Internal/Other.hs
@@ -3,7 +3,6 @@
 module Plutarch.Internal.Other (
   printTerm,
   printScript,
-  pto,
   Flip,
 ) where
 
@@ -11,15 +10,11 @@ import Data.Kind (Type)
 import Data.Text qualified as T
 import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
-import Plutarch.Internal.PlutusType (
-  PInner,
- )
 import Plutarch.Internal.Term (
   Config,
   S,
   Term,
   compile,
-  punsafeCoerce,
  )
 import Plutarch.Script (Script (Script))
 import PlutusCore.Pretty (prettyPlcReadable)
@@ -39,14 +34,9 @@ printScript = show . prettyPlcReadable . (\(Script s) -> s)
 printTerm :: forall (a :: S -> Type). HasCallStack => Config -> (forall (s :: S). Term s a) -> String
 printTerm config term = printScript $ either (error . T.unpack) id $ compile config term
 
-{- |
-  Safely coerce from a Term to it's 'PInner' representation.
--}
-pto :: Term s a -> Term s (PInner a)
-pto = punsafeCoerce
-
 {- | Type level flip operation, reversing the order of arguments
 Commonly used in Plutarch to get the PTryFromExcess associated type of PTryFrom for a Plutarch type
+
 @since 1.12.0
 -}
 newtype Flip (f :: k1 -> k2 -> Type) (a :: k2) (b :: k1) = Flip (f b a)

--- a/Plutarch/Internal/Parse.hs
+++ b/Plutarch/Internal/Parse.hs
@@ -56,6 +56,7 @@ import Plutarch.Internal.Term (
   perror,
   phoistAcyclic,
   plet,
+  punsafeCoerce,
   (#),
   (:-->),
  )
@@ -66,7 +67,6 @@ import Plutarch.Repr.Data (
  )
 import Plutarch.Repr.Internal (UnTermRec, UnTermStruct)
 import Plutarch.Repr.Tag (DeriveAsTag)
-import Plutarch.Unsafe (punsafeCoerce)
 
 {- | Describes a @Data@ encoded Plutarch type that requires some additional
 validation to ensure its structure is indeed what we expect. This is

--- a/Plutarch/Internal/Semigroup.hs
+++ b/Plutarch/Internal/Semigroup.hs
@@ -60,12 +60,12 @@ import Plutarch.Internal.Numeric (
   (#+),
  )
 import Plutarch.Internal.Ord (POrd)
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PlutusType (
   DeriveNewtypePlutusType (DeriveNewtypePlutusType),
   PlutusType (PInner),
   pcon,
  )
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   S,
   Term,

--- a/Plutarch/Internal/Semigroup.hs
+++ b/Plutarch/Internal/Semigroup.hs
@@ -65,7 +65,7 @@ import Plutarch.Internal.PlutusType (
   PlutusType (PInner),
   pcon,
  )
-import Plutarch.Internal.Subtype (pto)
+import Plutarch.Internal.Subtype (pto, punsafeDowncast)
 import Plutarch.Internal.Term (
   S,
   Term,
@@ -75,7 +75,6 @@ import Plutarch.Internal.Term (
   (#),
   (#$),
  )
-import Plutarch.Unsafe (punsafeDowncast)
 import PlutusCore qualified as PLC
 import Universe (Includes)
 

--- a/Plutarch/Internal/Subtype.hs
+++ b/Plutarch/Internal/Subtype.hs
@@ -5,6 +5,7 @@ module Plutarch.Internal.Subtype (
   PSubtype,
   PSubtype',
   pupcast,
+  pto,
 ) where
 
 import Data.Kind (Constraint, Type)
@@ -61,3 +62,9 @@ type family PSubtype (a :: S -> Type) (b :: S -> Type) :: Constraint where
 
 pupcast :: forall a b s. PSubtype a b => Term s b -> Term s a
 pupcast = let _ = witness (Proxy @(PSubtype a b)) in punsafeCoerce
+
+{- |
+  Safely coerce from a Term to it's 'PInner' representation.
+-}
+pto :: forall (a :: S -> Type) (s :: S). Term s a -> Term s (PInner a)
+pto = punsafeCoerce

--- a/Plutarch/Internal/Subtype.hs
+++ b/Plutarch/Internal/Subtype.hs
@@ -6,6 +6,7 @@ module Plutarch.Internal.Subtype (
   PSubtype',
   pupcast,
   pto,
+  punsafeDowncast,
 ) where
 
 import Data.Kind (Constraint, Type)
@@ -68,3 +69,10 @@ pupcast = let _ = witness (Proxy @(PSubtype a b)) in punsafeCoerce
 -}
 pto :: forall (a :: S -> Type) (s :: S). Term s a -> Term s (PInner a)
 pto = punsafeCoerce
+
+{- |
+  Unsafely coerce from the 'PInner' representation of a Term,
+  assuming that the value is a safe construction of the Term.
+-}
+punsafeDowncast :: Term s (PInner a) -> Term s a
+punsafeDowncast = punsafeCoerce

--- a/Plutarch/Prelude.hs
+++ b/Plutarch/Prelude.hs
@@ -195,7 +195,6 @@ module Plutarch.Prelude (
   ppositiveToNatural,
 
   -- * Other
-  pto,
   pinl,
   plam,
   PForall (..),
@@ -224,6 +223,7 @@ module Plutarch.Prelude (
   PTryFrom (..),
   ptryFrom,
   pupcast,
+  pto,
 
   -- * Maybe
   PMaybe (..),
@@ -301,7 +301,6 @@ import Plutarch.Internal.ListLike
 import Plutarch.Internal.Newtype
 import Plutarch.Internal.Numeric
 import Plutarch.Internal.Ord
-import Plutarch.Internal.Other
 import Plutarch.Internal.PLam
 import Plutarch.Internal.Parse
 import Plutarch.Internal.PlutusType
@@ -309,6 +308,7 @@ import Plutarch.Internal.Quantification
 import Plutarch.Internal.ScottEncoding
 import Plutarch.Internal.Semigroup
 import Plutarch.Internal.Show
+import Plutarch.Internal.Subtype
 import Plutarch.Internal.Term
 import Plutarch.Internal.TryFrom
 import Plutarch.List

--- a/Plutarch/Rational.hs
+++ b/Plutarch/Rational.hs
@@ -60,13 +60,14 @@ import Plutarch.Internal.Other (Flip)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (PlutusType, pcon, pmatch)
 import Plutarch.Internal.Show (PShow, pshow, pshow')
-import Plutarch.Internal.Subtype (pto)
+import Plutarch.Internal.Subtype (pto, punsafeDowncast)
 import Plutarch.Internal.Term (
   S,
   Term,
   phoistAcyclic,
   plet,
   punsafeBuiltin,
+  punsafeCoerce,
   (#),
   (#$),
   (:-->),
@@ -80,7 +81,6 @@ import Plutarch.Internal.TryFrom (PTryFrom (PTryFromExcess, ptryFrom'), ptryFrom
 import Plutarch.Pair (PPair (PPair))
 import Plutarch.Repr.SOP (DeriveAsSOPRec (DeriveAsSOPRec))
 import Plutarch.Trace (ptraceInfoError)
-import Plutarch.Unsafe (punsafeCoerce, punsafeDowncast)
 import PlutusCore qualified as PLC
 import PlutusTx.Ratio qualified as PlutusTx
 

--- a/Plutarch/Rational.hs
+++ b/Plutarch/Rational.hs
@@ -56,10 +56,11 @@ import Plutarch.Internal.Numeric (
 import Plutarch.Internal.Ord (
   POrd ((#<), (#<=)),
  )
-import Plutarch.Internal.Other (Flip, pto)
+import Plutarch.Internal.Other (Flip)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (PlutusType, pcon, pmatch)
 import Plutarch.Internal.Show (PShow, pshow, pshow')
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   S,
   Term,

--- a/Plutarch/Repr/Data.hs
+++ b/Plutarch/Repr/Data.hs
@@ -51,7 +51,6 @@ import Plutarch.Internal.Lift (
   punsafeCoercePLifted,
  )
 import Plutarch.Internal.ListLike (phead, ptail)
-import Plutarch.Internal.Other (pto)
 import Plutarch.Internal.PLam (plam)
 import Plutarch.Internal.PlutusType (
   PInner,
@@ -61,6 +60,7 @@ import Plutarch.Internal.PlutusType (
   pmatch,
   pmatch',
  )
+import Plutarch.Internal.Subtype (pto)
 import Plutarch.Internal.Term (
   InternalConfig (..),
   S,

--- a/Plutarch/Unsafe.hs
+++ b/Plutarch/Unsafe.hs
@@ -1,16 +1,8 @@
 module Plutarch.Unsafe (
-  PI.punsafeBuiltin,
-  PI.punsafeCoerce,
+  punsafeBuiltin,
+  punsafeCoerce,
   punsafeDowncast,
 ) where
 
-import Plutarch.Internal.PlutusType (PInner)
-import Plutarch.Internal.Term (Term)
-import Plutarch.Internal.Term qualified as PI
-
-{- |
-  Unsafely coerce from the 'PInner' representation of a Term,
-  assuming that the value is a safe construction of the Term.
--}
-punsafeDowncast :: Term s (PInner a) -> Term s a
-punsafeDowncast = PI.punsafeCoerce
+import Plutarch.Internal.Subtype (punsafeDowncast)
+import Plutarch.Internal.Term (punsafeBuiltin, punsafeCoerce)


### PR DESCRIPTION
This PR moves `punsafeDowncast` and `pto` to `Plutarch.Internal.Subtype`, which is arguably where they should have been from the beginning. As part of this change, I've also removed any use of `Plutarch.Unsafe` in internal modules. The whole point of `Plutarch.Unsafe` is to provide a stable API over these operations for users of Plutarch: we ourselves can just import them from `Internal`. This reduces the soup of dependencies in the repo.