### PR TITLE
PBuiltinValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # UNRELEASED
 
+## Added
+
+* `PBuiltinValue`, and bindings to primitive functions for this
+
 # 1.13.0 -- 04-03-2026
 
 ## Added

--- a/Plutarch/Builtin/Value.hs
+++ b/Plutarch/Builtin/Value.hs
@@ -1,7 +1,7 @@
 -- | @since wip
 module Plutarch.Builtin.Value (
   -- * Type
-  PBuiltinValue,
+  PBuiltinValue (..),
 
   -- * Functions
   pinsertCoin,

--- a/Plutarch/Builtin/Value.hs
+++ b/Plutarch/Builtin/Value.hs
@@ -1,0 +1,167 @@
+-- | @since wip
+module Plutarch.Builtin.Value (
+  -- * Type
+  PBuiltinValue,
+
+  -- * Functions
+  pinsertCoin,
+  plookupCoin,
+  punionValue,
+  pvalueContains,
+  pvalueData,
+  punValueData,
+  pscaleValue,
+) where
+
+import GHC.Generics (Generic)
+import Generics.SOP qualified as SOP
+import Plutarch.Builtin.Bool (PBool)
+import Plutarch.Builtin.ByteString (PByteString)
+import Plutarch.Builtin.Data (PData)
+import Plutarch.Builtin.Integer (PInteger)
+import Plutarch.Builtin.Opaque (POpaque)
+import Plutarch.Internal.Term (S, Term, punsafeBuiltin, (:-->))
+import PlutusCore qualified as PLC
+
+{- | A builtin Plutus @Value@.
+
+@since wip
+-}
+newtype PBuiltinValue (s :: S) = PBuiltinValue (Term s POpaque)
+  deriving stock
+    ( -- | @since wip
+      Generic
+    )
+  deriving anyclass
+    ( -- | @since wip
+      SOP.Generic
+    )
+
+{- | Given a currency, a token name, an amount, an an existing 'PBuiltinValue',
+produce a new 'PBuiltinValue', identical to the argument 'PBuiltinValue',
+except as follows:
+
+* If the amount is @0@, the new 'PBuiltinValue' will have the given
+  currency-token name entry deleted;
+* If the argument 'PBuiltinValue' is empty, the new 'PBuiltinValue' will be a
+  singleton containing the given currency-token name entry with the given
+  (nonzero) amount.
+* If the argument 'PBuiltinValue' already contains the given currency-token
+  name entry, the new 'PBuiltinValue' will have that currency-token name
+  entry modified by the amount by the given (nonzero) amount.
+* Otherwise, the new 'PBuiltinValue' will contain a new currency-token name
+  entry, with the given (nonzero) amount.
+
+= Important note
+
+If given a currency name, or a token name, that isn't valid, this will error.
+
+@since wip
+-}
+pinsertCoin ::
+  forall (s :: S).
+  Term
+    s
+    ( PByteString
+        :--> PByteString
+        :--> PInteger
+        :--> PBuiltinValue
+        :--> PBuiltinValue
+    )
+pinsertCoin = punsafeBuiltin PLC.InsertCoin
+
+{- | Given a currency, a token name, and a 'PBuiltinValue', return the amount
+associated with the given currency-token name entry. If there is no such
+entry, the result is @0@.
+
+= Important note
+
+If given a currency name, or token name, that isn't valid, this will produce
+@0@.
+
+@since wip
+-}
+plookupCoin ::
+  forall (s :: S).
+  Term
+    s
+    ( PByteString
+        :--> PByteString
+        :--> PBuiltinValue
+        :--> PInteger
+    )
+plookupCoin = punsafeBuiltin PLC.LookupCoin
+
+{- | Given two 'PBuiltinValue's, constructs their union. More specifically, for
+every currency-token name entry in either argument, the result will contain a
+currency-token name entry as well. If the entry is in one argument, it will
+be copied as-is; otherwise, the amounts will be combined from both maps using
+addition.
+
+= Important note
+
+'PBuiltinValue's cannot store amounts outside of the range of a 128-bit
+signed integer. If any amount produced by this operation would fall outside
+of this range, this function will error.
+
+@since wip
+-}
+punionValue ::
+  forall (s :: S).
+  Term
+    s
+    ( PBuiltinValue
+        :--> PBuiltinValue
+        :--> PBuiltinValue
+    )
+punionValue = punsafeBuiltin PLC.UnionValue
+
+{- | @'pvalueContains' x y@ is true when, for any currency-token name entry in
+@y@, the amount associated with that entry in @x@ is not smaller.
+
+= Important note
+
+Neither argument can contain any negative entries. If either argument has a
+negative entry, this will error.
+
+@since wip
+-}
+pvalueContains ::
+  forall (s :: S).
+  Term
+    s
+    ( PBuiltinValue
+        :--> PBuiltinValue
+        :--> PBool
+    )
+pvalueContains = punsafeBuiltin PLC.ValueContains
+
+{- | Converts a 'PBuiltinValue' into its @Data@ encoding.
+
+@since wip
+-}
+pvalueData ::
+  forall (s :: S).
+  Term s (PBuiltinValue :--> PData)
+pvalueData = punsafeBuiltin PLC.ValueData
+
+{- | Converts a valid @Data@ encoding of a 'PBuiltinValue' into the
+'PBuiltinValue' it represents, and errors otherwise.
+
+@since wip
+-}
+punValueData ::
+  forall (s :: S).
+  Term s (PData :--> PBuiltinValue)
+punValueData = punsafeBuiltin PLC.UnValueData
+
+{- | Given a 'PBuiltinValue' and a scalar, produce a new 'PBuiltinValue' with
+all amounts multiplied by that scalar. Note that if the scalar is @0@, then
+the result will be an empty 'PBuiltinValue'.
+
+@since wip
+-}
+pscaleValue ::
+  forall (s :: S).
+  Term s (PInteger :--> PBuiltinValue :--> PBuiltinValue)
+pscaleValue = punsafeBuiltin PLC.ScaleValue

--- a/Plutarch/Internal/IsData.hs
+++ b/Plutarch/Internal/IsData.hs
@@ -30,6 +30,11 @@ import Plutarch.Builtin.Data (
  )
 import Plutarch.Builtin.Integer (PInteger, pconstantInteger)
 import Plutarch.Builtin.Unit (PUnit, punit)
+import Plutarch.Builtin.Value (
+  PBuiltinValue,
+  punValueData,
+  pvalueData,
+ )
 import Plutarch.Internal.Eq (PEq ((#==)))
 import Plutarch.Internal.ListLike (
   PListLike (pcons, phead, pnil, ptail),
@@ -178,3 +183,8 @@ instance
   where
   pfromDataImpl x = punsafeCoerce $ pasList # pforgetData x
   pdataImpl x = plistData # punsafeCoerce x
+
+-- | @since wip
+instance PIsData PBuiltinValue where
+  pfromDataImpl d = punValueData # pforgetData d
+  pdataImpl x = pvalueData # x

--- a/Plutarch/Internal/Lift.hs
+++ b/Plutarch/Internal/Lift.hs
@@ -69,6 +69,7 @@ import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.Builtin.Opaque (POpaque, popaque)
 import Plutarch.Builtin.String (PString)
 import Plutarch.Builtin.Unit (PUnit)
+import Plutarch.Builtin.Value (PBuiltinValue)
 import Plutarch.Internal.Evaluate (evalScriptHuge)
 import {-# SOURCE #-} Plutarch.Internal.IsData (PIsData)
 import Plutarch.Internal.PlutusType (DeriveFakePlutusType (DeriveFakePlutusType), PlutusType (PInner))
@@ -93,6 +94,7 @@ import PlutusCore.Builtin (
 import PlutusCore.Crypto.BLS12_381.G1 qualified as BLS12_381.G1
 import PlutusCore.Crypto.BLS12_381.G2 qualified as BLS12_381.G2
 import PlutusCore.Crypto.BLS12_381.Pairing qualified as BLS12_381.Pairing
+import PlutusCore.Value as PlutusCore
 import PlutusTx qualified as PTx
 import Universe (Includes)
 import UntypedPlutusCore qualified as UPLC
@@ -598,3 +600,9 @@ instance
   reprToPlut = reprToPlutUni
   {-# INLINEABLE plutToRepr #-}
   plutToRepr = plutToReprUni
+
+-- | @since wip
+deriving via
+  (DeriveBuiltinPLiftable PBuiltinValue PlutusCore.Value)
+  instance
+    PLiftable PBuiltinValue

--- a/Plutarch/Internal/PlutusType.hs
+++ b/Plutarch/Internal/PlutusType.hs
@@ -46,6 +46,7 @@ import Plutarch.Builtin.Integer (PInteger)
 import Plutarch.Builtin.Opaque (POpaque (POpaque), popaque)
 import Plutarch.Builtin.String (PString, ptraceInfo)
 import Plutarch.Builtin.Unit (PUnit (PUnit), punit)
+import Plutarch.Builtin.Value (PBuiltinValue (PBuiltinValue))
 import Plutarch.Internal.Case (punsafeCase)
 import Plutarch.Internal.PLam (plam)
 
@@ -315,3 +316,9 @@ instance PlutusType (PArray a) where
   type PInner (PArray a) = PArray a
   pcon' (PArray t) = t
   pmatch' x f = f (PArray x)
+
+-- | @since wip
+instance PlutusType PBuiltinValue where
+  type PInner PBuiltinValue = PBuiltinValue
+  pcon' (PBuiltinValue t) = punsafeCoerce t
+  pmatch' x f = f (PBuiltinValue (punsafeCoerce x))

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -86,6 +86,7 @@ library
     Plutarch.Builtin.Opaque
     Plutarch.Builtin.String
     Plutarch.Builtin.Unit
+    Plutarch.Builtin.Value
     Plutarch.DataRepr
     Plutarch.DataRepr.Internal
     Plutarch.DataRepr.Internal.Field


### PR DESCRIPTION
Closes #943 . Unfortunately, due to the somewhat odd set of primitive operations, only `PlutusType`, `PLiftable` and `PIsData` instances made sense.