### PR TITLE
Curry up RawTerm lambdas and applications, remove Liftability

### DIFF
--- a/Plutarch/Backend/ANF.hs
+++ b/Plutarch/Backend/ANF.hs
@@ -49,7 +49,6 @@ import Plutarch.Backend.AST (
     ASTLeaf
   ),
   Hash,
-  Liftability,
   Multiplicity,
  )
 import Plutarch.Backend.AST qualified as AST
@@ -113,8 +112,8 @@ data ANFBind (ann :: Type)
   = ANFLeaf (Leaf ann)
   | ANFForce ann Ref
   | ANFDelay ann Ref
-  | ANFLam ann (NonEmptyVector (Maybe Multiplicity)) Liftability Ref
-  | ANFFix ann Multiplicity Liftability Ref
+  | ANFLam ann (NonEmptyVector (Maybe Multiplicity)) Ref
+  | ANFFix ann Multiplicity Ref
   | ANFApply ann Ref (NonEmptyVector Ref)
   | ANFConstr ann Word64 (Vector Ref)
   | ANFCase ann Ref (NonEmptyVector Ref)
@@ -156,12 +155,12 @@ fromHashedAST ast = case runState (go ast) (Bimap.empty, IntMap.empty) of
       ASTDelay h body -> withLookup h $ do
         bodyRef <- go body
         newBind h (ANFDelay () bodyRef)
-      ASTLam h mults liftability body -> withLookup h $ do
+      ASTLam h mults body -> withLookup h $ do
         bodyRef <- go body
-        newBind h (ANFLam () mults liftability bodyRef)
-      ASTFix h mult liftability body -> withLookup h $ do
+        newBind h (ANFLam () mults bodyRef)
+      ASTFix h mult body -> withLookup h $ do
         bodyRef <- go body
-        newBind h (ANFFix () mult liftability bodyRef)
+        newBind h (ANFFix () mult bodyRef)
       ASTApply h f xs -> withLookup h $ do
         fRef <- go f
         xsRefs <- traverse go xs

--- a/Plutarch/Backend/AST.hs
+++ b/Plutarch/Backend/AST.hs
@@ -23,7 +23,6 @@ module Plutarch.Backend.AST (
   -- * Common
   Hash (..),
   Multiplicity (..),
-  Liftability (..),
 
   -- * AST
   Leaf (..),
@@ -52,7 +51,7 @@ import Data.Vector.NonEmpty qualified as NEVector
 import Data.Word (Word64)
 import Plutarch.Backend.PosTree (
   PosTree (
-    PApplyCase,
+    PCase,
     PHere,
     PMany,
     POne,
@@ -115,18 +114,6 @@ data Multiplicity
       Show
     )
 
-{- | A marker whether a lambda has any free (relative the lambda's body)
-variable occurrences or not. If the lambda has no free variables in its body,
-it is trivially liftable; otherwise, its lifting is not trivial.
-
-@since wip
--}
-data Liftability = Trivial | NonTrivial
-  deriving stock
-    ( -- | @since wip
-      Show
-    )
-
 {- | A leaf computation (namely, one that cannot have dependencies).
 
 @since wip
@@ -151,6 +138,7 @@ and thus be easier to prettyprint and generate.
 More precisely, this closely follows 'RawTerm', except that:
 
 - 'RLet' nodes have been removed
+- Lambdas and applications have been uncurried
 - Position trees have been replaced by 'Multiplicity', whose hashes are
   hashes of the corresponding position tree
 - Lambdas and fixpoints have been annotated with their 'Liftability'
@@ -161,8 +149,8 @@ data AST (ann :: Type)
   = ASTLeaf (Leaf ann)
   | ASTForce ann (AST ann)
   | ASTDelay ann (AST ann)
-  | ASTLam ann (NonEmptyVector (Maybe Multiplicity)) Liftability (AST ann)
-  | ASTFix ann Multiplicity Liftability (AST ann)
+  | ASTLam ann (NonEmptyVector (Maybe Multiplicity)) (AST ann)
+  | ASTFix ann Multiplicity (AST ann)
   | ASTApply ann (AST ann) (NonEmptyVector (AST ann))
   | ASTConstr ann Word64 (Vector (AST ann))
   | ASTCase ann (AST ann) (NonEmptyVector (AST ann))
@@ -218,16 +206,15 @@ fromRawTerm t = snd . fst . evalRWS (go t) vmEmpty $ 0
         let mult = case fromJust . findVarUsage fresh (Just pt) $ body of
               (h, False) -> MultiplicityOne h
               (h, True) -> MultiplicityMany h
-        liftability <- asks (bool NonTrivial Trivial . (vmEmpty ==))
         (structuralHashBody, body') <- local (vmExtend fresh pt . vmMap stepDownOne) (go body)
         let structuralHash = hash (7 :: Int, structuralHashBody)
-        mkHashed structuralHash (\h -> ASTFix h mult liftability body')
+        mkHashed structuralHash (\h -> ASTFix h mult body')
       RLet _ mpt v f -> do
-        let node = RApply () (RLamAbs () (NEVector.singleton mpt) f) . NEVector.singleton $ v
+        let node = RApply () (RLamAbs () mpt f) v
         (vmv, vmf) <- asks (vmFold separateTwo (vmEmpty, vmEmpty))
         let vmf' = vmMap POne vmf
-        let extendedVMV = vmMap (PApplyCase Nothing . NEVector.singleton . Just) vmv
-        let extendedVMF = vmMap (\pt -> PApplyCase (Just pt) (NEVector.singleton Nothing)) vmf'
+        let extendedVMV = vmMap (PTwo . That) vmv
+        let extendedVMF = vmMap (PTwo . This) vmf'
         let vm' = vmMerge mergeLet extendedVMF extendedVMV
         local (const vm') (go node)
       RConstr _ tag fields -> do
@@ -239,35 +226,48 @@ fromRawTerm t = snd . fst . evalRWS (go t) vmEmpty $ 0
         mkHashed structuralHash (\h -> ASTConstr h tag fields')
       RCase _ scrut handlers -> do
         let len = NEVector.length handlers
-        (scrutVM, handlerVMs) <- asks (vmFold separateApplyCase (vmEmpty, NEVector.replicate1 len vmEmpty))
+        (scrutVM, handlerVMs) <- asks (vmFold separateCase (vmEmpty, NEVector.replicate1 len vmEmpty))
         (structuralHashScrut, scrut') <- local (const scrutVM) (go scrut)
         let descendCase i rt = local (const (handlerVMs NEVector.! i)) (go rt)
         (structuralHashesHandlers, handlers') <- NEVector.unzip <$> NEVector.imapM descendCase handlers
         let structuralHash = hash (9 :: Int, structuralHashScrut, NEVector.toVector structuralHashesHandlers)
         mkHashed structuralHash (\h -> ASTCase h scrut' handlers')
-      RApply _ f xs -> do
-        let len = NEVector.length xs
-        (fVM, xsVMs) <- asks (vmFold separateApplyCase (vmEmpty, NEVector.replicate1 len vmEmpty))
+      RApply _ f x -> do
+        (fVM, xVM) <- asks (vmFold separateTwo (vmEmpty, vmEmpty))
         (structuralHashF, f') <- local (const fVM) (go f)
-        let descendApply i rt = local (const (xsVMs NEVector.! i)) (go rt)
-        (structuralHashesXs, xs') <- NEVector.unzip <$> NEVector.imapM descendApply xs
-        let structuralHash = hash (10 :: Int, structuralHashF, NEVector.toVector structuralHashesXs)
-        mkHashed structuralHash (\h -> ASTApply h f' xs')
-      RLamAbs _ mpts body -> do
-        let len = NEVector.length mpts
-        withFreshes <- NEVector.zip <$> NEVector.replicate1M len getFresh <*> pure mpts
-        let multiplicities = fmap (\(name, mpt) -> (\(h, b) -> bool MultiplicityOne MultiplicityMany b h) <$> findVarUsage name mpt body) withFreshes
-        liftability <- asks (bool NonTrivial Trivial . (vmEmpty ==))
+        (structuralHashX, x') <- local (const xVM) (go x)
+        case f' of
+          -- We're part of a curried apply. We need to add one more argument.
+          ASTApply _ g ys -> do
+            let structuralHash = hash (structuralHashF, structuralHashX)
+            mkHashed structuralHash (\h -> ASTApply h g . NEVector.snoc ys $ x')
+          _ -> do
+            let structuralHash = hash (10 :: Int, structuralHashF, structuralHashX)
+            mkHashed structuralHash (\h -> ASTApply h f' . NEVector.singleton $ x')
+      RLamAbs _ mpt body -> do
+        fresh <- getFresh
+        let multiplicity = case findVarUsage fresh mpt body of
+              Nothing -> Nothing
+              Just (h, b) -> Just . bool MultiplicityOne MultiplicityMany b $ h
         vm' <- asks (vmMap stepDownOne)
-        let bodyVM = NEVector.foldl' (\acc (k, mv) -> case mv of Nothing -> acc; Just v -> vmExtend k v acc) vm' withFreshes
-        (structuralHashBody, body') <- local (const bodyVM) (go body)
-        let structuralHash = hash (11 :: Int, NEVector.toVector mpts, structuralHashBody)
-        mkHashed structuralHash (\h -> ASTLam h multiplicities liftability body')
+        let extendedVM = case mpt of
+              Nothing -> vm'
+              Just pt -> vmExtend fresh pt vm'
+        (structuralHashBody, body') <- local (const extendedVM) (go body)
+        case body' of
+          -- We're part of a curried lambda. We need to add one more
+          -- multiplicity.
+          ASTLam _ mults body'' -> do
+            let structuralHash = hash (structuralHashBody, mpt)
+            mkHashed structuralHash (\h -> ASTLam h (NEVector.cons multiplicity mults) body'')
+          _ -> do
+            let structuralHash = hash (11 :: Int, mpt, structuralHashBody)
+            mkHashed structuralHash (\h -> ASTLam h (NEVector.singleton multiplicity) body')
 
 -- Helpers
 
 mergeLet :: PosTree -> PosTree -> PosTree
-mergeLet (PApplyCase f1 xs1) (PApplyCase f2 xs2) = PApplyCase (f1 <|> f2) (NEVector.zipWith (<|>) xs1 xs2)
+mergeLet (PCase f1 xs1) (PCase f2 xs2) = PCase (f1 <|> f2) (NEVector.zipWith (<|>) xs1 xs2)
 mergeLet x _ = x -- impossible
 
 mkHashed ::
@@ -302,9 +302,9 @@ separateConstr acc k = \case
       Nothing -> vm
       Just t -> vmExtend k t vm
 
-separateApplyCase :: (VarMap, NonEmptyVector VarMap) -> Word64 -> PosTree -> (VarMap, NonEmptyVector VarMap)
-separateApplyCase acc@(scrutVM, handlerVMs) k = \case
-  PApplyCase mpt mpts -> case mpt of
+separateCase :: (VarMap, NonEmptyVector VarMap) -> Word64 -> PosTree -> (VarMap, NonEmptyVector VarMap)
+separateCase acc@(scrutVM, handlerVMs) k = \case
+  PCase mpt mpts -> case mpt of
     Nothing -> (scrutVM, NEVector.zipWith go handlerVMs mpts)
     Just pt -> (vmExtend k pt scrutVM, NEVector.zipWith go handlerVMs mpts)
   _ -> acc
@@ -343,22 +343,23 @@ findVarUsage name mpt t = case mpt of
     RLet _ _ v f -> case pts of
       This pt -> findVarUsage name (Just pt) v
       That pt -> findVarUsage name (Just pt) f
+      -- Bind is likely to be smaller, so we'll search there.
       These ptv _ -> (\(h, _) -> (h, True)) <$> findVarUsage name (Just ptv) v
+    RApply _ f x -> case pts of
+      This pt -> findVarUsage name (Just pt) f
+      That pt -> findVarUsage name (Just pt) x
+      -- Argument is likely to be smaller, so we'll search there.
+      These _ ptv -> (\(h, _) -> (h, True)) <$> findVarUsage name (Just ptv) x
     _ -> Nothing
   Just (PMany pts) -> case t of
     RConstr _ _ fields -> Vector.foldl' go Nothing . Vector.zip pts $ fields
     _ -> Nothing
-  Just (PApplyCase pt pts) -> case t of
+  Just (PCase pt pts) -> case t of
     RCase _ scrut handlers ->
       let resScrut = findVarUsage name pt scrut
        in case resScrut of
             Just (_, True) -> resScrut
             _ -> NEVector.foldl' go resScrut . NEVector.zip pts $ handlers
-    RApply _ f xs ->
-      let resF = findVarUsage name pt f
-       in case resF of
-            Just (_, True) -> resF
-            _ -> NEVector.foldl' go resF . NEVector.zip pts $ xs
     _ -> Nothing
   where
     go :: Maybe (Hash, Bool) -> (Maybe PosTree, RawTerm ()) -> Maybe (Hash, Bool)

--- a/Plutarch/Backend/Compile.hs
+++ b/Plutarch/Backend/Compile.hs
@@ -118,8 +118,8 @@ toUPLCTerm (ANF _ binds) =
       ANFLeaf _ -> acc
       ANFForce _ r -> addVar acc r
       ANFDelay _ r -> addVar acc r
-      ANFLam _ _ _ r -> addVar acc r
-      ANFFix _ _ _ r -> addVar acc r
+      ANFLam _ _ r -> addVar acc r
+      ANFFix _ _ r -> addVar acc r
       ANFApply _ fR xsRs -> addVar (NEVector.foldl' addVar acc xsRs) fR
       ANFConstr _ _ fieldsRs -> Vector.foldl' addVar acc fieldsRs
       ANFCase _ scrutR handlersRs -> addVar (NEVector.foldl' addVar acc handlersRs) scrutR
@@ -183,7 +183,7 @@ compile = do
               let delayBody = uplcDelay . uplcVar $ nameBody
               let delayBinds = [(nameBody, codeBody) | firstDemandedBody == i]
               pure (delayBinds, delayBody)
-        ANFFix _ _ _ body -> do
+        ANFFix _ _ body -> do
           (firstDemandedBody, mNameBody, codeBody) <- checkCache compiled body
           -- For fixed points, given the body `F`, we want to produce `M
           -- (\r -> F (r r))`. To enable this, we've set aside two
@@ -244,7 +244,7 @@ compile = do
               let constrCall = uplcConstr 0 . NEVector.toVector $ xsArgs
               let soleHandler = NEVector.singleton fArg
               pure (applyBinds, uplcCase constrCall soleHandler)
-        ANFLam _ params _ body -> do
+        ANFLam _ params body -> do
           (firstDemandedBody, mNameBody, codeBody) <- checkCache compiled body
           asParamNames <- NEVector.mapM multToName params
           case mNameBody of
@@ -370,8 +370,8 @@ doDemandAnalysis binds = runST $ do
     ANFLeaf _ -> pure ()
     ANFForce _ r -> updateWithRef mv i r
     ANFDelay _ r -> updateWithRef mv i r
-    ANFLam _ _ _ r -> updateWithRef mv i r
-    ANFFix _ _ _ r -> updateWithRef mv i r
+    ANFLam _ _ r -> updateWithRef mv i r
+    ANFFix _ _ r -> updateWithRef mv i r
     ANFApply _ f xs -> do
       updateWithRef mv i f
       traverse_ (updateWithRef mv i) xs

--- a/Plutarch/Backend/PosTree.hs
+++ b/Plutarch/Backend/PosTree.hs
@@ -59,16 +59,16 @@ data PosTree
     @since wip
     -}
     PMany (Vector (Maybe PosTree))
-  | {- | The variable of interest occurs in an application or @case@,
-    in either the function (scrutinee) subtree, one or more of the argument
-    (handler) subtrees, or both.
+  | {- | The variable of interest occurs in a @case@,
+    in either the scrutinee subtree, one or more of the handler subtrees, or
+    both.
 
     = Note
 
     This structure must maintain the implicit invariant that at least one of
     the following always holds:
 
-    - The function (scrutinee) 'PosTree' is not 'Nothing'; or
+    - The scrutinee 'PosTree' is not 'Nothing'; or
     - At least one of the 'NonEmptyVector' entries is not 'Nothing'.
 
     All operations we provide over 'PosTree' maintain this invariant, but if
@@ -76,7 +76,7 @@ data PosTree
 
     @since wip
     -}
-    PApplyCase (Maybe PosTree) (NonEmptyVector (Maybe PosTree))
+    PCase (Maybe PosTree) (NonEmptyVector (Maybe PosTree))
   deriving stock
     ( -- | @since wip
       Show
@@ -94,7 +94,7 @@ instance Hashable PosTree where
     POne t -> hash (1 :: Int, t)
     PTwo ts -> hash (2 :: Int, ts)
     PMany ts -> hash (3 :: Int, Vector.toList ts)
-    PApplyCase t ts -> hash (4 :: Int, t, NEVector.toList ts)
+    PCase t ts -> hash (4 :: Int, t, NEVector.toList ts)
 
 {- | Checks if a 'PosTree' corresponds to a non-branching path. In the context
 of variables, checks whether the variable's use is linear (no more than
@@ -115,7 +115,7 @@ isLinear = \case
     Just (x, xs) -> case Vector.foldl' go (fmap isLinear x) xs of
       Nothing -> False -- impossible
       Just linearity -> linearity
-  PApplyCase t ts -> case fmap isLinear t of
+  PCase t ts -> case fmap isLinear t of
     Nothing -> case NEVector.uncons ts of
       (x, xs) -> case Vector.foldl' go (fmap isLinear x) xs of
         Nothing -> False -- impossible

--- a/Plutarch/Backend/RawTerm.hs
+++ b/Plutarch/Backend/RawTerm.hs
@@ -75,16 +75,16 @@ data RawTerm (ann :: Type)
     @since wip
     -}
     RVar ann VarTag
-  | {- | A lambda, which has a known arity (not curried).
+  | {- | A (possibly curried) lambda.
 
     @since
     -}
-    RLamAbs ann (NonEmptyVector (Maybe PosTree)) (RawTerm ann)
-  | {- | An application of known arity.
+    RLamAbs ann (Maybe PosTree) (RawTerm ann)
+  | {- | An (possibly curried) application.
 
     @since wip
     -}
-    RApply ann (RawTerm ann) (NonEmptyVector (RawTerm ann))
+    RApply ann (RawTerm ann) (RawTerm ann)
   | {- | A UPLC @force@.
 
     @since wip

--- a/Plutarch/Backend/Term.hs
+++ b/Plutarch/Backend/Term.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE RoleAnnotations #-}
 {-# LANGUAGE TypeData #-}
+{-# LANGUAGE NoPartialTypeSignatures #-}
 
 {- | The full definition of Plutarch 'Term's, as well as eDSL primitives which
 everything else is built from.
@@ -69,7 +70,7 @@ import Data.Word (Word64)
 import GHC.Stack (CallStack, HasCallStack, callStack)
 import Plutarch.Backend.PosTree (
   PosTree (
-    PApplyCase,
+    PCase,
     PHere,
     PMany,
     POne,
@@ -151,14 +152,14 @@ data TermError
 
     @since wip
     -}
-    BadMergeApplyExtend Word64 PosTree PosTree
+    BadMergeApply Word64 PosTree PosTree
   | {- | An @apply@ or @case@ construction caused a bad position tree merge.
     This is something that should not happen normally, and is /definitely/
     a bug!
 
     @since wip
     -}
-    BadMergeApplyCase Word64 PosTree PosTree
+    BadMergeCase Word64 PosTree PosTree
   | {- | A @constr@ construction caused a bad position tree merge. This is
     something that should not happen normally, and is /definitely/ a bug!
 
@@ -219,14 +220,8 @@ plam' f = Term $ do
   fresh <- freshAndIncrement
   let varTerm = Term . pure $ (vmSingleton fresh PHere, RVar () Argument)
   (vm, t) <- asRawTerm (f varTerm)
-  case t of
-    RLamAbs () paramTrees body -> do
-      let vmPeeled = vmMap (\case POne t -> t; x -> x) vm
-      let (mpt, vm') = vmDelete fresh vmPeeled
-      pure (vmMap POne vm', RLamAbs () (NEVector.cons mpt paramTrees) body)
-    _ -> do
-      let (mpt, vm') = vmDelete fresh vm
-      pure (vmMap POne vm', RLamAbs () (NEVector.singleton mpt) t)
+  let (mpt, vm') = vmDelete fresh vm
+  pure (vmMap POne vm', RLamAbs () mpt t)
 
 {- | Given a piece of code and a code transformation, use this to build a
 @let@-binding.
@@ -251,7 +246,7 @@ plet v f = Term $ do
   let (fpt, fvm') = vmDelete fresh fvm
   let vvmExtended = vmMap (PTwo . This) vvm
   let fvmExtended = vmMap (PTwo . That) fvm'
-  vm <- vmMergeM mergeTwo vvmExtended fvmExtended
+  vm <- vmMergeM (mergeTwo BadMergeLet) vvmExtended fvmExtended
   pure (vm, RLet () fpt vt ft)
 
 {- | Given a code transformation that takes the code for a \'self\' argument and
@@ -293,15 +288,10 @@ papp ::
 papp f x = Term $ do
   (fvm, ft) <- asRawTerm f
   (xvm, xt) <- asRawTerm x
-  case ft of
-    RApply () func args -> do
-      merged <- vmMergeM mergeExtendApply fvm xvm
-      pure (merged, RApply () func . NEVector.snoc args $ xt)
-    _ -> do
-      let fvmExtended = vmMap (\pt -> PApplyCase (Just pt) (NEVector.singleton Nothing)) fvm
-      let xvmExtended = vmMap (PApplyCase Nothing . NEVector.singleton . Just) xvm
-      merged <- vmMergeM mergeApplyCase fvmExtended xvmExtended
-      pure (merged, RApply () ft . NEVector.singleton $ xt)
+  let fvmExtended = vmMap (PTwo . This) fvm
+  let xvmExtended = vmMap (PTwo . That) xvm
+  merged <- vmMergeM (mergeTwo BadMergeApply) fvmExtended xvmExtended
+  pure (merged, RApply () ft xt)
 
 {- | Given the code for @a@, construct code that delays its evaluation.
 
@@ -437,20 +427,20 @@ punsafeCase scrut handlers = Term $ do
   -- `asRawTerm` can't solve for the existential for some reason.
   handlers' <- traverse (\(Term t) -> t) handlers
   let len = NEVector.length handlers
-  let vmScrutExtended = vmMap (\pt -> PApplyCase (Just pt) . NEVector.replicate1 len $ Nothing) vmScrut
+  let vmScrutExtended = vmMap (\pt -> PCase (Just pt) . NEVector.replicate1 len $ Nothing) vmScrut
   vm <- NEVector.ifoldM (go len) vmScrutExtended . fmap fst $ handlers'
   pure (vm, RCase () tscrut . fmap snd $ handlers')
   where
     go ::
       forall (m :: Type -> Type).
       MonadError TermError m => Int -> VarMap -> Int -> VarMap -> m VarMap
-    go len acc ix = vmMergeM mergeApplyCase acc . vmMap (toCase len ix)
+    go len acc ix = vmMergeM mergeCase acc . vmMap (toCase len ix)
 
 -- Helpers
 
 -- Helper for extending position trees for `case`s
 toCase :: Int -> Int -> PosTree -> PosTree
-toCase len ix pt = PApplyCase Nothing . NEVector.generate1 len $ \ix' -> if ix == ix' then Just pt else Nothing
+toCase len ix pt = PCase Nothing . NEVector.generate1 len $ \ix' -> if ix == ix' then Just pt else Nothing
 
 -- Helper for extending position trees for `constr`s
 toConstr :: Int -> Int -> PosTree -> PosTree
@@ -473,37 +463,29 @@ mergeConstr = zipWithAMatched $ \k v1 v2 -> case v1 of
 mergeTwo ::
   forall (m :: Type -> Type).
   MonadError TermError m =>
+  (Word64 -> PosTree -> PosTree -> TermError) ->
   WhenMatched m Word64 PosTree PosTree PosTree
-mergeTwo = zipWithAMatched $ \k v1 v2 -> case v1 of
+mergeTwo mkErr = zipWithAMatched $ \k v1 v2 -> case v1 of
   PTwo (This t1) -> case v2 of
     PTwo (That t2) -> pure . PTwo . These t1 $ t2
-    _ -> throwError . BadMergeLet k v1 $ v2
-  _ -> throwError . BadMergeLet k v1 $ v2
+    _ -> throwError . mkErr k v1 $ v2
+  _ -> throwError . mkErr k v1 $ v2
 
--- Handler for combining position trees for applications and `case`s
-mergeApplyCase ::
+-- Handler for combining position trees for `case`s
+mergeCase ::
   forall (m :: Type -> Type).
   MonadError TermError m =>
   WhenMatched m Word64 PosTree PosTree PosTree
-mergeApplyCase = zipWithAMatched $ \k v1 v2 -> case v1 of
-  PApplyCase func1 args1 -> case v2 of
-    PApplyCase func2 args2 -> do
+mergeCase = zipWithAMatched $ \k v1 v2 -> case v1 of
+  PCase func1 args1 -> case v2 of
+    PCase func2 args2 -> do
       let funcs = maybeToCan func1 func2
       let args = NEVector.zipWith maybeToCan args1 args2
-      func <- mergeCanM (BadMergeApplyCase k v1 v2) funcs
-      args' <- traverse (mergeCanM (BadMergeApplyCase k v1 v2)) args
-      pure . PApplyCase func $ args'
-    _ -> throwError . BadMergeApplyCase k v1 $ v2
-  _ -> throwError . BadMergeApplyCase k v1 $ v2
-
--- Handler for combining position trees in applications
-mergeExtendApply ::
-  forall (m :: Type -> Type).
-  MonadError TermError m =>
-  WhenMatched m Word64 PosTree PosTree PosTree
-mergeExtendApply = zipWithAMatched $ \k v1 v2 -> case v1 of
-  PApplyCase func args -> pure . PApplyCase func . NEVector.snoc args . Just $ v2
-  _ -> throwError . BadMergeApplyExtend k v1 $ v2
+      func <- mergeCanM (BadMergeCase k v1 v2) funcs
+      args' <- traverse (mergeCanM (BadMergeCase k v1 v2)) args
+      pure . PCase func $ args'
+    _ -> throwError . BadMergeCase k v1 $ v2
+  _ -> throwError . BadMergeCase k v1 $ v2
 
 freshAndIncrement ::
   forall (m :: Type -> Type) (a :: Type).


### PR DESCRIPTION
Closes #978 . This also eliminates `Liftability` from `AST`. It ultimately isn't terribly useful, as the ANF already does as much lifting as we could want or need.