### PR TITLE
Trivial constant inlining

### DIFF
--- a/Plutarch/Backend/Compile.hs
+++ b/Plutarch/Backend/Compile.hs
@@ -8,7 +8,7 @@ module Plutarch.Backend.Compile (
   toUPLCTerm,
 ) where
 
-import Control.Monad (foldM, guard)
+import Control.Monad (foldM, guard, when)
 import Control.Monad.RWS.CPS (
   MonadState (get),
   RWS,
@@ -76,6 +76,7 @@ import Plutarch.Backend.UPLC (
   uplcMCombinator,
   uplcVar,
  )
+import PlutusCore (Some (Some), ValueOf (ValueOf))
 import PlutusCore qualified as PLC
 
 {- | Given an ANF, compile it into UPLC. This compilation also applies automatic
@@ -258,6 +259,7 @@ compile = do
       -- later. We can determine this from its use count alone.
       (firstDemanded, mName) <- case demand of
         NeverDemanded -> pure (-1, Nothing)
+        TrivialConstant -> pure (-1, Nothing)
         Demanded (Id j) useCount ->
           if useCount <= 1
             then pure (j, Nothing)
@@ -330,30 +332,25 @@ doFixpointAnalysis = NEVector.ifoldl' go Set.empty
       ANFFix {} -> Set.insert pos acc
       _ -> acc
 
--- Maybe (Int, Word64), but with more indicative names
---
--- Used for demand analysis. Specifically, it allows us, for each bind `b` in an
--- ANF, to check the following:
---
-
--- * The last ANF bind (thus, the first evaluation site) that requires `b` as a
-
--- direct dependency; and
-
--- * How many times _any_ ANF bind requires `b` as a direct dependency.
-
---
--- By using this pair of monoids, we can do this in a single pass, instead of
--- needing two.
+-- Used for demand analysis per bind.
 data Demand
-  = NeverDemanded
-  | Demanded Id Word64
+  = -- The 'default' starting point
+    NeverDemanded
+  | -- `Id` determines first evaluation site that requires us as a direct
+    -- dependency (which means we should `let`-bind there), `Word64` is how many
+    -- times anyone requires us as direct dependency
+    Demanded Id Word64
+  | -- Trivial constants should always be inlined. Thus, tracking their demand
+    -- analysis is pointless.
+    TrivialConstant
   deriving stock (Eq)
 
 instance Semigroup Demand where
   NeverDemanded <> x = x
   x <> NeverDemanded = x
   Demanded (Id i) count1 <> Demanded (Id j) count2 = Demanded (Id $ max i j) (count1 + count2)
+  TrivialConstant <> _ = TrivialConstant
+  _ <> TrivialConstant = TrivialConstant
 
 instance Monoid Demand where
   mempty = NeverDemanded
@@ -367,7 +364,9 @@ doDemandAnalysis binds = runST $ do
   -- here as currently, there is no way to 'freeze' a mutable non-empty vector.
   mv <- MVector.replicate len mempty
   for_ [0, 1 .. len - 1] $ \i -> case binds NEVector.! i of
-    ANFLeaf _ -> pure ()
+    ANFLeaf ell -> case ell of
+      LConstant _ c -> when (isTrivialConstant c) (MVector.write mv i TrivialConstant)
+      _ -> pure ()
     ANFForce _ r -> updateWithRef mv i r
     ANFDelay _ r -> updateWithRef mv i r
     ANFLam _ _ _ r -> updateWithRef mv i r
@@ -386,6 +385,12 @@ doDemandAnalysis binds = runST $ do
     updateWithRef mv i = \case
       AnId (Id j) -> MVector.modify mv (Demanded (Id i) 1 <>) j
       _ -> pure ()
+    isTrivialConstant :: Some (ValueOf PLC.DefaultUni) -> Bool
+    isTrivialConstant = \case
+      Some (ValueOf PLC.DefaultUniBool _) -> True
+      Some (ValueOf PLC.DefaultUniUnit _) -> True
+      Some (ValueOf PLC.DefaultUniInteger n) -> n < 256
+      _ -> False
 
 mkFixpointNames ::
   Map Int (PLC.Name, PLC.Name) ->

--- a/Plutarch/Backend/Term.hs
+++ b/Plutarch/Backend/Term.hs
@@ -41,7 +41,7 @@ module Plutarch.Backend.Term (
   pplaceholder,
   punsafeCoerce,
   punsafeBuiltin,
-  punsafeConstantInternal,
+  punsafeConstant,
   punsafeConstr,
   punsafeCase,
   pfix,
@@ -396,10 +396,10 @@ plan to use this directly.
 
 @since wip
 -}
-punsafeConstantInternal ::
+punsafeConstant ::
   forall (a :: S -> Type) (s :: S).
   Some (ValueOf PLC.DefaultUni) -> Term s a
-punsafeConstantInternal c = Term . pure $ (vmEmpty, RConstant () c)
+punsafeConstant c = Term . pure $ (vmEmpty, RConstant () c)
 
 {- | Given a tag, and an existentially-erased 'Vector' of fields, construct a
 @constr@ term producing an SOP with the given tag and the stated fields.

--- a/Plutarch/Backend/Term.hs
+++ b/Plutarch/Backend/Term.hs
@@ -25,6 +25,8 @@ which describes the \'@ST@ trick\'
 module Plutarch.Backend.Term (
   TermEnv (..),
   Term (..),
+  SomeTerm,
+  toSomeTerm,
   TermError (..),
   PDelayed,
   S,
@@ -182,6 +184,24 @@ newtype Term (s :: S) (a :: S -> Type)
   = Term {asRawTerm :: ExceptT TermError (RWS TermEnv () Word64) (VarMap, RawTerm ())}
 
 type role Term nominal nominal
+
+{- | A 'Term' whose result has been forgotten. Useful mainly together with
+'punsafeCase' and 'punsafeConstr', as it allows fields and handlers of
+heterogenous types to be used in both.
+
+@since wip
+-}
+data SomeTerm (s :: S) where
+  SomeTerm :: Term s a -> SomeTerm s
+
+{- | \'Forgets\' the result of a computation represented by a 'Term'.
+
+@since wip
+-}
+toSomeTerm ::
+  forall (a :: S -> Type) (s :: S).
+  Term s a -> SomeTerm s
+toSomeTerm = SomeTerm
 
 {- | The type of a Plutarch lambda. To be specific, @'Term' s (a :--> b)@
 corresponds to the code of a computation that, when run, will produce a UPLC
@@ -396,12 +416,12 @@ SOP you're trying to construct.
 punsafeConstr ::
   forall (a :: S -> Type) (s :: S).
   Word64 ->
-  Vector (forall (b :: S -> Type). Term s b) ->
+  Vector (SomeTerm s) ->
   Term s a
 punsafeConstr ix fields = Term $ do
   -- Note (Koz, 28/05/2026): We need to use the constructor explicitly here, as
   -- `asRawTerm` can't solve for the existential for some reason.
-  fields' <- traverse (\(Term t) -> t) fields
+  fields' <- traverse (\(SomeTerm (Term t)) -> t) fields
   let len = Vector.length fields
   vm <- Vector.ifoldM (go len) vmEmpty . fmap fst $ fields'
   pure (vm, RConstr () ix . fmap snd $ fields')
@@ -429,13 +449,13 @@ using.
 punsafeCase ::
   forall (a :: S -> Type) (b :: S -> Type) (s :: S).
   Term s a ->
-  NonEmptyVector (forall (c :: S -> Type). Term s c) ->
+  NonEmptyVector (SomeTerm s) ->
   Term s b
 punsafeCase scrut handlers = Term $ do
   (vmScrut, tscrut) <- asRawTerm scrut
   -- Note (Koz, 28/05/2026): We need to use the constructor explicitly here, as
   -- `asRawTerm` can't solve for the existential for some reason.
-  handlers' <- traverse (\(Term t) -> t) handlers
+  handlers' <- traverse (\(SomeTerm (Term t)) -> t) handlers
   let len = NEVector.length handlers
   let vmScrutExtended = vmMap (\pt -> PApplyCase (Just pt) . NEVector.replicate1 len $ Nothing) vmScrut
   vm <- NEVector.ifoldM (go len) vmScrutExtended . fmap fst $ handlers'

--- a/Plutarch/Primitive/Bool.hs
+++ b/Plutarch/Primitive/Bool.hs
@@ -1,0 +1,63 @@
+module Plutarch.Primitive.Bool (
+  PBool,
+  pfalse,
+  ptrue,
+  pif,
+  pand,
+  por,
+  pcond,
+) where
+
+import Data.Foldable (foldl')
+import Data.Kind (Type)
+import Data.Vector.NonEmpty qualified as NEVector
+import Plutarch.Backend.Term (
+  S,
+  Term,
+  punsafeCase,
+  punsafeConstant,
+  toSomeTerm,
+ )
+import PlutusCore qualified as PLC
+
+data PBool (s :: S)
+
+pfalse :: forall (s :: S). Term s PBool
+pfalse = punsafeConstant $ PLC.someValue False
+
+ptrue :: forall (s :: S). Term s PBool
+ptrue = punsafeConstant $ PLC.someValue True
+
+pif ::
+  forall (a :: S -> Type) (s :: S).
+  Term s PBool ->
+  Term s a ->
+  Term s a ->
+  Term s a
+pif cond ifT ifF =
+  let tAsSome = toSomeTerm ifT
+      fAsSome = toSomeTerm ifF
+      -- This is backwards in UPLC `case`s: false first.
+      handlers = NEVector.cons fAsSome $ NEVector.singleton tAsSome
+   in punsafeCase cond handlers
+
+pand ::
+  forall (s :: S).
+  Term s PBool ->
+  Term s PBool ->
+  Term s PBool
+pand x y = pif x y pfalse
+
+por ::
+  forall (s :: S).
+  Term s PBool ->
+  Term s PBool ->
+  Term s PBool
+por x = pif x ptrue
+
+pcond ::
+  forall (a :: S -> Type) (s :: S).
+  Term s a ->
+  [(Term s PBool, Term s a)] ->
+  Term s a
+pcond = foldl' (\acc (cond, res) -> pif cond res acc)

--- a/Plutarch/Primitive/Bool.hs
+++ b/Plutarch/Primitive/Bool.hs
@@ -3,6 +3,7 @@ module Plutarch.Primitive.Bool (
   pfalse,
   ptrue,
   pif,
+  pnot,
   pand,
   por,
   pcond,
@@ -40,6 +41,12 @@ pif cond ifT ifF =
       -- This is backwards in UPLC `case`s: false first.
       handlers = NEVector.cons fAsSome $ NEVector.singleton tAsSome
    in punsafeCase cond handlers
+
+pnot ::
+  forall (s :: S).
+  Term s PBool ->
+  Term s PBool
+pnot x = pif x pfalse ptrue
 
 pand ::
   forall (s :: S).

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -140,6 +140,7 @@ library
     Plutarch.Pretty.Internal.Name
     Plutarch.Pretty.Internal.TermUtils
     Plutarch.Pretty.Internal.Types
+    Plutarch.Primitive.Bool
     Plutarch.Rational
     Plutarch.Reducible
     Plutarch.Repr.Data

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -27,6 +27,7 @@ import Plutarch.Backend.Term (
  )
 import Plutarch.Backend.UPLC (UPLCTerm (UPLCTerm))
 import Plutarch.Backend.VarMap (VarMap, vmEmpty)
+import Plutarch.Primitive.Bool (PBool, pnot, por)
 import PlutusCore.Pretty (prettyPlcReadable)
 import Prettyprinter (defaultLayoutOptions, layoutSmart)
 import Prettyprinter.Render.String (renderString)
@@ -58,7 +59,7 @@ main =
                 step "Converting to ANF"
                 let anf@(ANF bm bindings) = fromHashedAST asAST
                 step $ "ANF bimap:\n" <> ppShow bm
-                step $ "ANF bindings:\n" <> ppShow bindings
+                step $ "ANF binds:\n" <> ppShow bindings
                 step "Converting to UPLC"
                 let (UPLCTerm t) = toUPLCTerm anf
                 step $ "UPLC:\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
@@ -76,7 +77,7 @@ main =
             step $ "AST: \n" <> ppShow asAST
             let ANF bm binds = fromHashedAST asAST
             step $ "ANF bimap:\n" <> ppShow bm
-            step $ "ANF bindings:\n" <> ppShow binds
+            step $ "ANF binds:\n" <> ppShow binds
             step "2. Is there one bind exactly?"
             assertBool "Too many binds" (NEVector.length binds == 1)
             step "Exactly one bind!"
@@ -85,6 +86,26 @@ main =
             case soleBind of
               ANFLam {} -> step "The bind is ANFLam!"
               _ -> assertFailure $ "Unexpected bind: " <> ppShow soleBind
+    , testCaseSteps "Case 3" $ \step -> do
+        step "Case: \\x y -> or (not x) y"
+        step "1. Does Case 3 compile?"
+        let compiled = compileTerm case3
+        case compiled of
+          Left err -> assertFailure $ "Compile error: " <> show err
+          Right (_, t) -> do
+            step "Successfully compiled!"
+            let asAST = fromRawTerm t
+            step $ "AST:\n" <> ppShow asAST
+            let anf@(ANF bm binds) = fromHashedAST asAST
+            step $ "ANF bimap:\n" <> ppShow bm
+            step $ "ANF binds:\n" <> ppShow binds
+            step "2. Are there 5 binds?"
+            let len = NEVector.length binds
+            assertBool ("Too many binds: " <> show len) (len == 5)
+            step "5 binds exactly!"
+            let (UPLCTerm t) = toUPLCTerm anf
+            step $ "UPLC:\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
+            pure ()
     ]
 
 -- Cases
@@ -93,9 +114,13 @@ main =
 case1 :: forall (a :: S -> Type) (s :: S). Term s (a :--> a)
 case1 = plam' $ \x -> papp (plam' id) (papp (plam' id) x)
 
--- Case2: \x -> force (delay x)
+-- Case 2: \x -> force (delay x)
 case2 :: forall (a :: S -> Type) (s :: S). Term s (a :--> a)
 case2 = plam' $ \x -> pforce (pdelay x)
+
+-- Case 3: \x y -> por (pnot x) y
+case3 :: forall (s :: S). Term s (PBool :--> PBool :--> PBool)
+case3 = plam' $ \x -> plam' $ \y -> por (pnot x) y
 
 -- Helpers
 


### PR DESCRIPTION
Closes #975. Also replaces the explicit existentials in `punsafeCase` and `punsafeConstr` with a wrapper `SomeTerm`, as this is easier to work with.