### PR TITLE
Always inline builtins

### DIFF
--- a/Plutarch/Backend/ANF.hs
+++ b/Plutarch/Backend/ANF.hs
@@ -241,12 +241,12 @@ data Demand
     @since wip
     -}
     Demanded Id Word64
-  | {- | Some constants should never be @let@-bound. This means their demand
+  | {- | Some things should never be @let@-bound. This means their demand
     analysis is trivial.
 
     @since wip
     -}
-    TrivialConstant
+    Trivial
   deriving stock
     ( -- | @since wip
       Eq
@@ -260,8 +260,8 @@ instance Semigroup Demand where
   x <> NeverDemanded = x
   Demanded (Id i) count1 <> Demanded (Id j) count2 =
     Demanded (Id $ max i j) (count1 + count2)
-  TrivialConstant <> _ = TrivialConstant
-  _ <> TrivialConstant = TrivialConstant
+  Trivial <> _ = Trivial
+  _ <> Trivial = Trivial
 
 -- | @since wip
 instance Monoid Demand where
@@ -277,9 +277,9 @@ analyzeDemand (ANF bm binds) = runST $ do
     ANFLeaf ell -> MVector.write mv i . ANFLeaf $ case ell of
       LConstant _ c ->
         if smallEnoughToInline c
-          then LConstant TrivialConstant c
+          then LConstant Trivial c
           else LConstant NeverDemanded c
-      LBuiltin _ f -> LBuiltin NeverDemanded f
+      LBuiltin _ f -> LBuiltin Trivial f
       LCompiled _ code -> LCompiled NeverDemanded code
       LError _ -> LError NeverDemanded
     ANFForce _ r -> do

--- a/Plutarch/Backend/Compile.hs
+++ b/Plutarch/Backend/Compile.hs
@@ -45,7 +45,7 @@ import Plutarch.Backend.ANF (
     ANFLam,
     ANFLeaf
   ),
-  Demand (Demanded, NeverDemanded, TrivialConstant),
+  Demand (Demanded, NeverDemanded, Trivial),
   Id (Id),
   Leaf (
     LBuiltin,
@@ -170,8 +170,8 @@ compileWithCache cache i (bindName, bind) = do
   let (firstDemanded, mName) = case getANFBindAnn bind of
         -- Top-level node, nothing to do.
         NeverDemanded -> (-1, Nothing)
-        -- A constant we should always inline.
-        TrivialConstant -> (-1, Nothing)
+        -- Something we should always inline.
+        Trivial -> (-1, Nothing)
         -- Check use count: if it's greater than 1, we have to let-bind;
         -- otherwise, we inline.
         Demanded (Id j) useCount ->

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -29,7 +29,11 @@ import Plutarch.Backend.Term (
 import Plutarch.Backend.UPLC (UPLCTerm (UPLCTerm))
 import Plutarch.Backend.VarMap (VarMap, vmEmpty)
 import Plutarch.Primitive.Bool (PBool, pnot, por)
-import Plutarch.Primitive.Integer (PInteger, paddInteger)
+import Plutarch.Primitive.Integer (
+  PInteger,
+  paddInteger,
+  pmultiplyInteger,
+ )
 import PlutusCore.Pretty (prettyPlcReadable)
 import Prettyprinter (defaultLayoutOptions, layoutSmart)
 import Prettyprinter.Render.String (renderString)
@@ -135,6 +139,24 @@ main =
             let (UPLCTerm t) = toUPLCTerm anf'
             step $ "UPLC:\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
             pure ()
+    , testCaseSteps "Case 5" $ \step -> do
+        step "Case: \\x y -> paddInteger (pmultiplyInteger x x) (pmultiplyInteger y y)"
+        step "1. Does Case 5 compile?"
+        let compiled = compileTerm case5
+        case compiled of
+          Left err -> assertFailure $ "Compile error: " <> show err
+          Right (_, t) -> do
+            step "Successfully compiled!"
+            let asAST = fromRawTerm t
+            let anf@(ANF bm binds) = fromHashedAST asAST
+            step $ "ANF bimap:\n" <> ppShow bm
+            step $ "ANF binds:\n" <> ppShow binds
+            let anf'@(ANF bm' binds') = analyzeDemand anf
+            step $ "ANF bimap:\n" <> ppShow bm'
+            step $ "ANF binds:\n" <> ppShow binds'
+            let (UPLCTerm t) = toUPLCTerm anf'
+            step $ "UPLC:\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
+            pure ()
     ]
 
 -- Cases
@@ -154,6 +176,11 @@ case3 = plam' $ \x -> plam' $ \y -> por (pnot x) y
 -- Case 4: \x y -> addInteger x y
 case4 :: forall (s :: S). Term s (PInteger :--> PInteger :--> PInteger)
 case4 = plam' $ \x -> plam' $ papp (papp paddInteger x)
+
+-- Case 5: \x y -> addInteger (multiplyInteger x x) (multiplyInteger y y)
+case5 :: forall (s :: S). Term s (PInteger :--> PInteger :--> PInteger)
+case5 = plam' $ \x -> plam' $ \y ->
+  papp (papp paddInteger (papp (papp pmultiplyInteger x) x)) (papp (papp pmultiplyInteger y) y)
 
 -- Helpers
 


### PR DESCRIPTION
Closes #994. In the end, changing `ANF` to remove builtin nodes entirely proved awkward, as then, when asked to compile (the eta-reduction to) a single builtin, the compilation pipeline explodes. While we could modify `ANF` to deal with this eventuality, it's both annoying enough and rare enough to not really be worth it.