### PR TITLE
Koz/999

### DIFF
--- a/Plutarch/Backend/ANF.hs
+++ b/Plutarch/Backend/ANF.hs
@@ -48,6 +48,7 @@ import Plutarch.Backend.AST (
   AST (
     ASTApply,
     ASTCase,
+    ASTCompose,
     ASTConstr,
     ASTDelay,
     ASTFix,
@@ -77,6 +78,8 @@ data Leaf (ann :: Type)
       Functor
     , -- | @since wip
       Show
+    , -- | @since wip
+      Eq
     )
 
 {- | As ANF \'inlines\' variables, subcomputations are either variables
@@ -91,6 +94,8 @@ data Ref
   deriving stock
     ( -- | @since wip
       Show
+    , -- | @since wip
+      Eq
     )
 
 {- | An identifier for an ANF bind.
@@ -124,11 +129,14 @@ data ANFBind (ann :: Type)
   | ANFApply ann Ref (NonEmptyVector Ref)
   | ANFConstr ann Word64 (Vector Ref)
   | ANFCase ann Ref (NonEmptyVector Ref)
+  | ANFCompose ann (NonEmptyVector Ref)
   deriving stock
     ( -- | @since wip
       Show
     , -- | @since wip
       Functor
+    , -- | @since wip
+      Eq
     )
 
 -- | @since wip
@@ -146,6 +154,7 @@ getANFBindAnn = \case
   ANFApply x _ _ -> x
   ANFConstr x _ _ -> x
   ANFCase x _ _ -> x
+  ANFCompose x _ -> x
 
 {- | A combination of a (nonempty) vector of binds, together with a unique
 mapping between identifiers and hashes of unique subcomputations.
@@ -197,6 +206,9 @@ fromHashedAST ast = case runState (go ast) (Bimap.empty, IntMap.empty) of
         scrutRef <- go scrut
         handlersRefs <- traverse go handlers
         newBind h (ANFCase () scrutRef handlersRefs)
+      ASTCompose h components -> withLookup h $ do
+        componentsRefs <- traverse go components
+        newBind h (ANFCompose () componentsRefs)
     doLeaf :: AST.Leaf Hash -> State (Bimap Id Hash, IntMap (ANFBind ())) Ref
     doLeaf = \case
       AST.LVar _ h -> pure . AVar $ h
@@ -278,33 +290,36 @@ analyzeDemand (ANF bm binds) = runST $ do
       LConstant _ c ->
         if smallEnoughToInline c
           then LConstant Trivial c
-          else LConstant NeverDemanded c
+          else LConstant mempty c
       LBuiltin _ f -> LBuiltin Trivial f
-      LCompiled _ code -> LCompiled NeverDemanded code
+      LCompiled _ code -> LCompiled mempty code
       LError _ -> LError Trivial
     ANFForce _ r -> do
       updateDemandAt mv i r
-      MVector.write mv i . ANFForce NeverDemanded $ r
+      MVector.write mv i . ANFForce mempty $ r
     ANFDelay _ r -> do
       updateDemandAt mv i r
-      MVector.write mv i . ANFDelay NeverDemanded $ r
+      MVector.write mv i . ANFDelay mempty $ r
     ANFLam _ mults r -> do
       updateDemandAt mv i r
-      MVector.write mv i . ANFLam NeverDemanded mults $ r
+      MVector.write mv i . ANFLam mempty mults $ r
     ANFFix _ mult r -> do
       updateDemandAt mv i r
-      MVector.write mv i . ANFFix NeverDemanded mult $ r
+      MVector.write mv i . ANFFix mempty mult $ r
     ANFApply _ f xs -> do
       updateDemandAt mv i f
       traverse_ (updateDemandAt mv i) xs
-      MVector.write mv i . ANFApply NeverDemanded f $ xs
+      MVector.write mv i . ANFApply mempty f $ xs
     ANFConstr _ tag fields -> do
       traverse_ (updateDemandAt mv i) fields
-      MVector.write mv i . ANFConstr NeverDemanded tag $ fields
+      MVector.write mv i . ANFConstr mempty tag $ fields
     ANFCase _ scrut handlers -> do
       updateDemandAt mv i scrut
       traverse_ (updateDemandAt mv i) handlers
-      MVector.write mv i . ANFCase NeverDemanded scrut $ handlers
+      MVector.write mv i . ANFCase mempty scrut $ handlers
+    ANFCompose _ components -> do
+      traverse_ (updateDemandAt mv i) components
+      MVector.write mv i . ANFCompose mempty $ components
   v <- Vector.unsafeFreeze mv
   pure . ANF bm . NEVector.unsafeFromVector $ v
   where

--- a/Plutarch/Backend/AST.hs
+++ b/Plutarch/Backend/AST.hs
@@ -53,6 +53,7 @@ import Data.Word (Word64)
 import Plutarch.Backend.PosTree (
   PosTree (
     PCase,
+    PCompose,
     PHere,
     PMany,
     POne,
@@ -65,6 +66,7 @@ import Plutarch.Backend.RawTerm (
     RBuiltin,
     RCase,
     RCompiled,
+    RCompose,
     RConstant,
     RConstr,
     RDelay,
@@ -113,6 +115,8 @@ data Multiplicity
   deriving stock
     ( -- | @since wip
       Show
+    , -- | @since wip
+      Eq
     )
 
 {- | A leaf computation (namely, one that cannot have dependencies).
@@ -130,6 +134,8 @@ data Leaf (ann :: Type)
       Functor
     , -- | @since wip
       Show
+    , -- | @since wip
+      Eq
     )
 
 {- | A compilation-friendly abstract syntax tree. This is in contrast to
@@ -162,11 +168,14 @@ data AST (ann :: Type)
   | ASTApply ann (AST ann) (NonEmptyVector (AST ann))
   | ASTConstr ann Word64 (Vector (AST ann))
   | ASTCase ann (AST ann) (NonEmptyVector (AST ann))
+  | ASTCompose ann (NonEmptyVector (AST ann))
   deriving stock
     ( -- | @since wip
       Functor
     , -- | @since wip
       Show
+    , -- | @since wip
+      Eq
     )
 
 {- | Given a 'RawTerm', construct its AST, using hashing to mark
@@ -305,6 +314,13 @@ fromRawTerm t = snd . fst . evalRWS (go t) vmEmpty $ 0
               -- empty variable map.
               Just structure -> local (const vmEmpty) (go structure)
           _ -> mkHashed structuralHashAll (\h -> ASTLam h fullMults fullBody)
+      RCompose _ components -> do
+        let len = NEVector.length components
+        fieldVMs <- asks (vmFold separateCompose (NEVector.replicate1 len vmEmpty))
+        let descendCompose i rt = local (const (fieldVMs NEVector.! i)) (go rt)
+        (structuralHashesComponents, components') <- NEVector.unzip <$> NEVector.imapM descendCompose components
+        let structuralHash = hash (12 :: Int, NEVector.toVector structuralHashesComponents)
+        mkHashed structuralHash (`ASTCompose` components')
 
 -- Helpers
 
@@ -392,6 +408,16 @@ separateConstr acc k = \case
       Nothing -> vm
       Just t -> vmExtend k t vm
 
+separateCompose :: NonEmptyVector VarMap -> Word64 -> PosTree -> NonEmptyVector VarMap
+separateCompose acc k = \case
+  PCompose ts -> NEVector.zipWith go acc ts
+  _ -> acc
+  where
+    go :: VarMap -> Maybe PosTree -> VarMap
+    go vm = \case
+      Nothing -> vm
+      Just t -> vmExtend k t vm
+
 separateCase :: (VarMap, NonEmptyVector VarMap) -> Word64 -> PosTree -> (VarMap, NonEmptyVector VarMap)
 separateCase acc@(scrutVM, handlerVMs) k = \case
   PCase mpt mpts -> case mpt of
@@ -450,6 +476,9 @@ findVarUsage name mpt t = case mpt of
        in case resScrut of
             Just (_, True) -> resScrut
             _ -> NEVector.foldl' go resScrut . NEVector.zip pts $ handlers
+    _ -> Nothing
+  Just (PCompose pts) -> case t of
+    RCompose _ components -> NEVector.foldl' go Nothing . NEVector.zip pts $ components
     _ -> Nothing
   where
     go :: Maybe (Hash, Bool) -> (Maybe PosTree, RawTerm ()) -> Maybe (Hash, Bool)

--- a/Plutarch/Backend/Compile.hs
+++ b/Plutarch/Backend/Compile.hs
@@ -39,6 +39,7 @@ import Plutarch.Backend.ANF (
   ANFBind (
     ANFApply,
     ANFCase,
+    ANFCompose,
     ANFConstr,
     ANFDelay,
     ANFFix,
@@ -108,14 +109,20 @@ toUPLCTerm (ANF _ binds) =
       -- - The argument to its copy of M; and
       -- - The variable name `r` for the transformed functional.
       (fixpointNameMap, lastFresh, _) = runRWS (foldM mkFixpointNames Map.empty . Set.toList $ fixpoints) usedNames 0
+      -- Check how many compositions we have and where they are.
+      compositions = doCompositionAnalysis rewrittenBinds
+      -- To compile a composition of the form `[f_1, f_2, ... , f_k]`, we want
+      -- to produce `\z -> f_1 (f_2 (... (f_k z) ...)`. For this, we need a
+      -- unique name for `z`.
+      (compositionNameMap, lastFresh', _) = runRWS (foldM mkCompositionName Map.empty . Set.toList $ compositions) usedNames lastFresh
       -- Make a unique name for any unused arguments. As lambdas in UPLC are all
       -- arity 1, and we will never use an unused argument, we can generate just
       -- a single name. It's cheaper to do this speculatively.
-      (unusedParamName, lastFresh', _) = runRWS mkUnusedName usedNames lastFresh
+      (unusedParamName, lastFresh'', _) = runRWS mkUnusedName usedNames lastFresh'
       -- Name every bind, avoiding any names of existing variables.
-      namedBinds = fst . evalRWS (NEVector.mapM nameBind rewrittenBinds) usedNames $ lastFresh'
+      namedBinds = fst . evalRWS (NEVector.mapM nameBind rewrittenBinds) usedNames $ lastFresh''
       -- Set up our compilation environment with everything we just put together
-      compileEnv = CompileEnv namedBinds fixpointNameMap unusedParamName mIdentity
+      compileEnv = CompileEnv namedBinds fixpointNameMap compositionNameMap unusedParamName mIdentity
    in -- Use our demand analysis to compile everything.
       runST $ runReaderT compile compileEnv
   where
@@ -129,6 +136,7 @@ toUPLCTerm (ANF _ binds) =
       ANFApply _ fR xsRs -> addVar (NEVector.foldl' addVar acc xsRs) fR
       ANFConstr _ _ fieldsRs -> Vector.foldl' addVar acc fieldsRs
       ANFCase _ scrutR handlersRs -> addVar (NEVector.foldl' addVar acc handlersRs) scrutR
+      ANFCompose _ componentRs -> NEVector.foldl' addVar acc componentRs
     addVar :: Set Int -> Ref -> Set Int
     addVar ess = \case
       AVar (Hash h) -> Set.insert h ess
@@ -328,7 +336,17 @@ compileBind cache i = \case
       Just nameBody -> do
         let lamBinds = [(nameBody, codeBody) | firstDemandedBody == i]
         pure (lamBinds, uplcLam asParamNames . uplcVar $ nameBody)
-
+  ANFCompose _ components -> do
+    components' <- traverse (checkCache cache) components
+    let componentBinds = Vector.toList . NEVector.mapMaybe (toBind i) $ components'
+    let componentArgs = NEVector.map (\(_, mName, code) -> maybe code uplcVar mName) components'
+    -- For compositions, given components `[f_1, f_2, .. , f_k]`, we want to
+    -- generate `\z -> f_1 (f_2 ( ... (f_k z) ... )`. We have a name set aside
+    -- for `z` to ensure it's unique.
+    compArgName <- asks (fromJust . Map.lookup i . ceCompNameMap)
+    let len = NEVector.length components'
+    let body = foldl' (\acc i -> uplcApply1 (componentArgs NEVector.! i) acc) (uplcVar compArgName) [len - 1, len - 2 .. 0]
+    pure (componentBinds, uplcLam1 compArgName body)
 multToName ::
   forall (m :: Type -> Type).
   MonadReader CompileEnv m =>
@@ -395,6 +413,23 @@ doFixpointAnalysis = NEVector.ifoldl' go Set.empty
       ANFFix {} -> Set.insert pos acc
       _ -> acc
 
+-- Check every bind to see if it's a composition, and if it is, record its
+-- position.
+--
+-- We need this for two reasons:
+--
+-- 1. To know if there are any compositions at all; and
+-- 2. How many we have, so we can apply the composition transform safely.
+doCompositionAnalysis ::
+  forall (ann :: Type).
+  NonEmptyVector (ANFBind ann) -> Set Int
+doCompositionAnalysis = NEVector.ifoldl' go Set.empty
+  where
+    go :: Set Int -> Int -> ANFBind ann -> Set Int
+    go acc pos = \case
+      ANFCompose {} -> Set.insert pos acc
+      _ -> acc
+
 mkFixpointNames ::
   Map Int (PLC.Name, PLC.Name) ->
   Int ->
@@ -405,15 +440,31 @@ mkFixpointNames acc i = do
   let names = (mkName "mArg" freshForM, mkName "functionalArg" freshForFunctional)
   pure . Map.insert i names $ acc
 
+mkCompositionName ::
+  Map Int PLC.Name ->
+  Int ->
+  RWS (Set Int) () Int (Map Int PLC.Name)
+mkCompositionName acc i = do
+  freshForZ <- untilM getFresh (asks . Set.notMember)
+  let name = mkName "compArg" freshForZ
+  pure . Map.insert i name $ acc
+
 -- A read-only environment for compilation. Contains:
 --
--- - All ANF binds (with demand analysis)
--- - All unique names reserved for these binds, in the same order
--- - Unique name pairs for each fixpoint we have to compile
+
+-- * All ANF binds (with demand analysis)
+
+-- * All unique names reserved for these binds, in the same order
+
+-- * Unique name pairs for each fixpoint we have to compile
+
+-- * A unique name for each composition we have to compile
+
 -- - A unique name for unused function parameters
 data CompileEnv = CompileEnv
   { ceBinds :: NonEmptyVector (PLC.Name, ANFBind Demand)
   , ceFPNameMap :: Map Int (PLC.Name, PLC.Name)
+  , ceCompNameMap :: Map Int PLC.Name
   , ceUnusedParamName :: PLC.Name
   , ceTheIdentity :: Maybe Id
   }

--- a/Plutarch/Backend/Compile.hs
+++ b/Plutarch/Backend/Compile.hs
@@ -225,7 +225,11 @@ compileWithCache cache i (bindName, bind) = do
             then (j, Nothing)
             else (j, Just bindName)
   (toBind, code) <- compileBind cache i bind
-  let codeWithBinds = foldl' doLetBind code toBind
+  -- In some cases (most notably compositions), we can end up with duplicate
+  -- `let`-bind requests. Thus, we first isolate uniquely named binds before
+  -- doing them.
+  let uniqueBinds = Map.fromList toBind
+  let codeWithBinds = Map.foldlWithKey' doLetBind code uniqueBinds
   -- We only store the name of a compiled bind if we'd need to `let`-bind it
   -- later.
   MVector.write cache i (firstDemanded, mName, codeWithBinds)
@@ -356,8 +360,8 @@ multToName = \case
   Just (MultiplicityOne (Hash h)) -> pure . mkName "arg" $ h
   Just (MultiplicityMany (Hash h)) -> pure . mkName "arg" $ h
 
-doLetBind :: UPLCTerm -> (PLC.Name, UPLCTerm) -> UPLCTerm
-doLetBind f (name, v) = uplcLet name v f
+doLetBind :: UPLCTerm -> PLC.Name -> UPLCTerm -> UPLCTerm
+doLetBind f name v = uplcLet name v f
 
 compileLeaf :: Leaf ann -> UPLCTerm
 compileLeaf = \case

--- a/Plutarch/Backend/Compile.hs
+++ b/Plutarch/Backend/Compile.hs
@@ -453,24 +453,18 @@ mkCompositionName acc i = do
   let name = mkName "compArg" freshForZ
   pure . Map.insert i name $ acc
 
--- A read-only environment for compilation. Contains:
---
-
--- * All ANF binds (with demand analysis)
-
--- * All unique names reserved for these binds, in the same order
-
--- * Unique name pairs for each fixpoint we have to compile
-
--- * A unique name for each composition we have to compile
-
--- - A unique name for unused function parameters
+-- A read-only environment for compilation.
 data CompileEnv = CompileEnv
-  { ceBinds :: NonEmptyVector (PLC.Name, ANFBind Demand)
-  , ceFPNameMap :: Map Int (PLC.Name, PLC.Name)
-  , ceCompNameMap :: Map Int PLC.Name
-  , ceUnusedParamName :: PLC.Name
-  , ceTheIdentity :: Maybe Id
+  { -- All ANF binds, with demand analysis, together with their unique names
+    ceBinds :: NonEmptyVector (PLC.Name, ANFBind Demand)
+  , -- Unique name pairs for each fixpoint we have to compile
+    ceFPNameMap :: Map Int (PLC.Name, PLC.Name)
+  , -- A unique name for each composition we have to compile
+    ceCompNameMap :: Map Int PLC.Name
+  , -- A unique name for unused function parameters
+    ceUnusedParamName :: PLC.Name
+  , -- Whether the identify functions occurs, and if so, where
+    ceTheIdentity :: Maybe Id
   }
 
 untilM ::

--- a/Plutarch/Backend/PosTree.hs
+++ b/Plutarch/Backend/PosTree.hs
@@ -16,11 +16,13 @@ module Plutarch.Backend.PosTree (
   isLinear,
 ) where
 
+import Control.Monad (guard)
 import Data.Foldable (sequenceA_)
 import Data.Hashable (
   Hashable (hash, hashWithSalt),
   defaultHashWithSalt,
  )
+import Data.Maybe (isJust, isNothing)
 import Data.These (These (That, These, This))
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
@@ -128,26 +130,26 @@ isLinear = \case
     These _ _ -> False
   PMany ts -> case Vector.uncons ts of
     Nothing -> True
-    Just (x, xs) -> case Vector.foldl' go (fmap isLinear x) xs of
-      Nothing -> False -- impossible
-      Just linearity -> linearity
+    Just (x, xs) -> case x of
+      Nothing -> maybe False isLinear (findOnlyJust xs)
+      Just t -> isLinear t && Vector.all isNothing xs
   PCase t ts -> case fmap isLinear t of
     Nothing -> case NEVector.uncons ts of
-      (x, xs) -> case Vector.foldl' go (fmap isLinear x) xs of
-        Nothing -> False -- impossible
-        Just linearity -> linearity
+      (x, xs) -> case x of
+        Nothing -> maybe False isLinear (findOnlyJust xs)
+        Just t -> isLinear t && Vector.all isNothing xs
     Just tLinearity -> case sequenceA_ ts of
       Nothing -> tLinearity
       Just _ -> False
   PCompose ts -> case NEVector.uncons ts of
-    (x, xs) -> case Vector.foldl' go (fmap isLinear x) xs of
-      Nothing -> False -- impossible
-      Just linearity -> linearity
+    (x, xs) -> case x of
+      Nothing -> maybe False isLinear (findOnlyJust xs)
+      Just t -> isLinear t && Vector.all isNothing xs
   where
-    go :: Maybe Bool -> Maybe PosTree -> Maybe Bool
-    go acc x = case acc of
-      Nothing -> fmap isLinear x
-      Just False -> Just False
-      Just True -> case fmap isLinear x of
-        Nothing -> Just True
-        Just _ -> Just False
+    -- Note (Koz, 23/06/2026): This works because we assume we never pass any
+    -- collection to this function that could be `Nothing` everywhere.
+    findOnlyJust :: Vector (Maybe PosTree) -> Maybe PosTree
+    findOnlyJust v = do
+      (i, is) <- Vector.uncons . Vector.findIndices isJust $ v
+      guard (Vector.null is)
+      v Vector.! i

--- a/Plutarch/Backend/PosTree.hs
+++ b/Plutarch/Backend/PosTree.hs
@@ -68,8 +68,8 @@ data PosTree
     This structure must maintain the implicit invariant that at least one of
     the following always holds:
 
-    - The scrutinee 'PosTree' is not 'Nothing'; or
-    - At least one of the 'NonEmptyVector' entries is not 'Nothing'.
+    * The scrutinee 'PosTree' is not 'Nothing'; or
+    * At least one of the 'NonEmptyVector' entries is not 'Nothing'.
 
     All operations we provide over 'PosTree' maintain this invariant, but if
     you build these yourself, ensure you also maintain it.
@@ -77,6 +77,21 @@ data PosTree
     @since wip
     -}
     PCase (Maybe PosTree) (NonEmptyVector (Maybe PosTree))
+  | {- | The variable of interest occurs in a composition.
+
+    = Note
+
+    This structure must maintain the following implicit invariants:
+
+    * The 'NonEmptyVector' has at least two elements; and
+    * At least one of the 'NonEmptyVector' entries is not 'Nothing'.
+
+    All operations we provide over 'PosTree' maintain this invariant, but if
+    you build these yourself, ensure you also maintain these.
+
+    @since wip
+    -}
+    PCompose (NonEmptyVector (Maybe PosTree))
   deriving stock
     ( -- | @since wip
       Show
@@ -95,6 +110,7 @@ instance Hashable PosTree where
     PTwo ts -> hash (2 :: Int, ts)
     PMany ts -> hash (3 :: Int, Vector.toList ts)
     PCase t ts -> hash (4 :: Int, t, NEVector.toList ts)
+    PCompose ts -> hash (5 :: Int, NEVector.toList ts)
 
 {- | Checks if a 'PosTree' corresponds to a non-branching path. In the context
 of variables, checks whether the variable's use is linear (no more than
@@ -123,6 +139,10 @@ isLinear = \case
     Just tLinearity -> case sequenceA_ ts of
       Nothing -> tLinearity
       Just _ -> False
+  PCompose ts -> case NEVector.uncons ts of
+    (x, xs) -> case Vector.foldl' go (fmap isLinear x) xs of
+      Nothing -> False -- impossible
+      Just linearity -> linearity
   where
     go :: Maybe Bool -> Maybe PosTree -> Maybe Bool
     go acc x = case acc of

--- a/Plutarch/Backend/RawTerm.hs
+++ b/Plutarch/Backend/RawTerm.hs
@@ -150,6 +150,11 @@ data RawTerm (ann :: Type)
     @since wip
     -}
     RFix ann PosTree (RawTerm ann)
+  | {- | A composition of two or more things that can have an argument applied.
+
+    @since wip
+    -}
+    RCompose ann (NonEmptyVector (RawTerm ann))
   deriving stock
     ( -- | @since wip
       Eq
@@ -181,3 +186,4 @@ getRawTermAnn = \case
   RCase x _ _ -> x
   RLet x _ _ _ -> x
   RFix x _ _ -> x
+  RCompose x _ -> x

--- a/Plutarch/Backend/Term.hs
+++ b/Plutarch/Backend/Term.hs
@@ -321,6 +321,25 @@ pcompose f g = Term $ do
       let extendedGVM = vmMap (PCompose . NEVector.cons Nothing . NEVector.singleton . Just) gvm
       vm <- vmMergeM mergeCompose extendedFVM extendedGVM
       pure (vm, RCompose () . NEVector.cons ft . NEVector.singleton $ gt)
+  where
+    -- Construct a brand new composition position tree, with all elements `Nothing`
+    -- except the last
+    mkNewComposeEnd :: Int -> PosTree -> PosTree
+    mkNewComposeEnd len = PCompose . NEVector.snoc (NEVector.replicate1 len Nothing) . Just
+    -- Construct a brand new composition position tree, with all elements `Nothing`
+    -- except the first
+    mkNewComposeStart :: Int -> PosTree -> PosTree
+    mkNewComposeStart len pt = PCompose . NEVector.cons (Just pt) . NEVector.replicate1 len $ Nothing
+    -- Adds `Nothing` elements on the end of a composition position tree
+    extendComposeEnd :: Int -> PosTree -> PosTree
+    extendComposeEnd count = \case
+      PCompose pts -> PCompose $ pts <> NEVector.replicate1 count Nothing
+      pt -> pt
+    -- Adds `Nothing` elements at the start of a composition position tree
+    extendComposeStart :: Int -> PosTree -> PosTree
+    extendComposeStart count = \case
+      PCompose pts -> PCompose $ NEVector.replicate1 count Nothing <> pts
+      pt -> pt
 
 {- | Abort generating code and signal a user-specified error.
 
@@ -541,28 +560,6 @@ punsafeCompiled ::
 punsafeCompiled t = Term . pure $ (vmEmpty, RCompiled () t)
 
 -- Helpers
-
--- Construct a brand new composition position tree, with all elements `Nothing`
--- except the last
-mkNewComposeEnd :: Int -> PosTree -> PosTree
-mkNewComposeEnd len = PCompose . NEVector.snoc (NEVector.replicate1 len Nothing) . Just
-
--- Construct a brand new composition position tree, with all elements `Nothing`
--- except the first
-mkNewComposeStart :: Int -> PosTree -> PosTree
-mkNewComposeStart len pt = PCompose . NEVector.cons (Just pt) . NEVector.replicate1 len $ Nothing
-
--- Adds `Nothing` elements on the end of a composition position tree
-extendComposeEnd :: Int -> PosTree -> PosTree
-extendComposeEnd count = \case
-  PCompose pts -> PCompose $ pts <> NEVector.replicate1 count Nothing
-  pt -> pt
-
--- Adds `Nothing` elements at the start of a composition position tree
-extendComposeStart :: Int -> PosTree -> PosTree
-extendComposeStart count = \case
-  PCompose pts -> PCompose $ NEVector.replicate1 count Nothing <> pts
-  pt -> pt
 
 -- Helper for extending position trees for `case`s
 toCase :: Int -> Int -> PosTree -> PosTree

--- a/Plutarch/Backend/Term.hs
+++ b/Plutarch/Backend/Term.hs
@@ -39,6 +39,7 @@ module Plutarch.Backend.Term (
   pplaceholder,
   pcompiled,
   pfix,
+  pcompose,
   punsafeCoerce,
   punsafeBuiltin,
   punsafeConstant,
@@ -77,6 +78,7 @@ import Plutarch.Backend.Compile (toUPLCTerm)
 import Plutarch.Backend.PosTree (
   PosTree (
     PCase,
+    PCompose,
     PHere,
     PMany,
     POne,
@@ -89,6 +91,7 @@ import Plutarch.Backend.RawTerm (
     RBuiltin,
     RCase,
     RCompiled,
+    RCompose,
     RConstant,
     RConstr,
     RDelay,
@@ -164,6 +167,13 @@ data TermError
     @since wip
     -}
     BadMergeConstr Word64 PosTree PosTree
+  | {- | A composition construction caused a bad position tree merge. This
+    is something that should not happen normally, and is /definitely/ a
+    bug!
+
+    @since wip
+    -}
+    BadMergeCompose Word64 PosTree PosTree
   deriving stock
     ( -- | @since wip
       Show
@@ -267,6 +277,50 @@ pfix f = Term $ do
   case mpt of
     Nothing -> throwError UnusedSelfArgument
     Just pt -> pure (vmMap POne vm', RFix () pt t)
+
+{- | Given two 'Term's that both generate functions, construct the 'Term' that
+is their composition.
+
+= Note
+
+Prefer this to composing functions using a fresh lambda. Plutarch's back-end
+can emit much better code from a 'pcompose', especially if the chain is long.
+
+@since wip
+-}
+pcompose ::
+  forall (a :: S -> Type) (b :: S -> Type) (c :: S -> Type) (s :: S).
+  Term s (a :--> b) ->
+  Term s (c :--> a) ->
+  Term s (c :--> b)
+pcompose f g = Term $ do
+  (fvm, ft) <- asRawTerm f
+  (gvm, gt) <- asRawTerm g
+  case (ft, gt) of
+    (RCompose _ compsF, RCompose _ compsG) -> do
+      let lenFs = NEVector.length compsF
+      let lenGs = NEVector.length compsG
+      let extendedFVM = vmMap (extendComposeEnd lenGs) fvm
+      let extendedGVM = vmMap (extendComposeStart lenFs) gvm
+      vm <- vmMergeM mergeCompose extendedFVM extendedGVM
+      pure (vm, RCompose () $ compsF <> compsG)
+    (RCompose _ compsF, _) -> do
+      let lenFs = NEVector.length compsF
+      let extendedFVM = vmMap (extendComposeEnd 1) fvm
+      let extendedGVM = vmMap (mkNewComposeEnd lenFs) gvm
+      vm <- vmMergeM mergeCompose extendedFVM extendedGVM
+      pure (vm, RCompose () . NEVector.snoc compsF $ gt)
+    (_, RCompose _ compsG) -> do
+      let lenGs = NEVector.length compsG
+      let extendedFVM = vmMap (mkNewComposeStart lenGs) fvm
+      let extendedGVM = vmMap (extendComposeStart 1) gvm
+      vm <- vmMergeM mergeCompose extendedFVM extendedGVM
+      pure (vm, RCompose () . NEVector.cons ft $ compsG)
+    _ -> do
+      let extendedFVM = vmMap (\pt -> PCompose . NEVector.cons (Just pt) . NEVector.singleton $ Nothing) fvm
+      let extendedGVM = vmMap (PCompose . NEVector.cons Nothing . NEVector.singleton . Just) gvm
+      vm <- vmMergeM mergeCompose extendedFVM extendedGVM
+      pure (vm, RCompose () . NEVector.cons ft . NEVector.singleton $ gt)
 
 {- | Abort generating code and signal a user-specified error.
 
@@ -488,6 +542,28 @@ punsafeCompiled t = Term . pure $ (vmEmpty, RCompiled () t)
 
 -- Helpers
 
+-- Construct a brand new composition position tree, with all elements `Nothing`
+-- except the last
+mkNewComposeEnd :: Int -> PosTree -> PosTree
+mkNewComposeEnd len = PCompose . NEVector.snoc (NEVector.replicate1 len Nothing) . Just
+
+-- Construct a brand new composition position tree, with all elements `Nothing`
+-- except the first
+mkNewComposeStart :: Int -> PosTree -> PosTree
+mkNewComposeStart len pt = PCompose . NEVector.cons (Just pt) . NEVector.replicate1 len $ Nothing
+
+-- Adds `Nothing` elements on the end of a composition position tree
+extendComposeEnd :: Int -> PosTree -> PosTree
+extendComposeEnd count = \case
+  PCompose pts -> PCompose $ pts <> NEVector.replicate1 count Nothing
+  pt -> pt
+
+-- Adds `Nothing` elements at the start of a composition position tree
+extendComposeStart :: Int -> PosTree -> PosTree
+extendComposeStart count = \case
+  PCompose pts -> PCompose $ NEVector.replicate1 count Nothing <> pts
+  pt -> pt
+
 -- Helper for extending position trees for `case`s
 toCase :: Int -> Int -> PosTree -> PosTree
 toCase len ix pt = PCase Nothing . NEVector.generate1 len $ \ix' -> if ix == ix' then Just pt else Nothing
@@ -508,6 +584,19 @@ mergeConstr = zipWithAMatched $ \k v1 v2 -> case v1 of
       PMany <$> traverse (mergeCanM (BadMergeConstr k v1 v2)) combined
     _ -> throwError . BadMergeConstr k v1 $ v2
   _ -> throwError . BadMergeConstr k v1 $ v2
+
+-- Handler for combining composition position trees
+mergeCompose ::
+  forall (m :: Type -> Type).
+  MonadError TermError m =>
+  WhenMatched m Word64 PosTree PosTree PosTree
+mergeCompose = zipWithAMatched $ \k v1 v2 -> case v1 of
+  PCompose xs -> case v2 of
+    PCompose ys -> do
+      let combined = NEVector.zipWith maybeToCan xs ys
+      PCompose <$> traverse (mergeCanM (BadMergeCompose k v1 v2)) combined
+    _ -> throwError . BadMergeCompose k v1 $ v2
+  _ -> throwError . BadMergeCompose k v1 $ v2
 
 -- Handler for combining `PTwo`s, needed in various places
 mergeTwo ::

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -22,11 +22,13 @@ import Plutarch.Backend.Term (
   TermError,
   papp,
   pcompiled,
+  pcompose,
   pdelay,
   perror,
   pforce,
   plam',
   punsafeCase,
+  punsafeConstant,
   punsafeConstr,
   toSomeTerm,
  )
@@ -38,12 +40,19 @@ import Plutarch.Primitive.Numeric (
   PInteger,
   paddInteger,
   pmultiplyInteger,
+  psubtractInteger,
  )
+import PlutusCore qualified as PLC
 import PlutusCore.Pretty (prettyPlcReadable)
 import Prettyprinter (defaultLayoutOptions, layoutSmart)
 import Prettyprinter.Render.String (renderString)
 import Test.Tasty (defaultMain, testGroup)
-import Test.Tasty.HUnit (assertBool, assertFailure, testCaseSteps)
+import Test.Tasty.HUnit (
+  assertBool,
+  assertEqual,
+  assertFailure,
+  testCaseSteps,
+ )
 import Text.Show.Pretty (ppShow)
 
 main :: IO ()
@@ -226,7 +235,7 @@ main =
           Left err -> assertFailure $ "Compile error: " <> show err
           Right (_, t) -> do
             step "Successfully compiled!"
-            step $ "AST:\n" <> ppShow t
+            step $ "RawTerm:\n" <> ppShow t
             let asAST = fromRawTerm t
             let anf@(ANF bm binds) = fromHashedAST asAST
             step $ "ANF bimap:\n" <> ppShow bm
@@ -236,6 +245,43 @@ main =
             step $ "ANF binds:\n" <> ppShow binds'
             let (UPLCTerm t) = toUPLCTerm anf'
             step $ "UPLC:\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
+            pure ()
+    , testCaseSteps "Cases 10 and 11" $ \step -> do
+        step "Case: \\x -> (compose [\\y -> y + 2, \\z -> x * z, \\z1 -> z1 - 5]) x"
+        step "1. Do both associativities compile?"
+        let compiledLA = compileTerm case10
+        let compiledRA = compileTerm case11
+        case (compiledLA, compiledRA) of
+          (Left err, _) -> assertFailure $ "Compile error: " <> show err
+          (_, Left err) -> assertFailure $ "Compile error: " <> show err
+          (Right (_, tla), Right (_, tra)) -> do
+            step "Successfully compiled!"
+            step $ "RawTerm (left associative):\n" <> ppShow tla
+            step $ "RawTerm (right associative):\n" <> ppShow tra
+            step "2. Are both RawTerms the same?"
+            assertEqual "RawTerms differ" tla tra
+            step "RawTerms are the same!"
+            let tlaAST = fromRawTerm tla
+            let traAST = fromRawTerm tra
+            step $ "AST (left associative):\n" <> ppShow tlaAST
+            step $ "AST (right associative):\n" <> ppShow traAST
+            step "3. Are both ASTs the same?"
+            assertEqual "ASTs differ" tlaAST traAST
+            step "ASTs are the same!"
+            let anfLA@(ANF tlaBM tlaANF) = fromHashedAST tlaAST
+            let anfRA@(ANF traBM traANF) = fromHashedAST traAST
+            step $ "ANF bimap (left associative):\n" <> ppShow tlaBM
+            step $ "ANF bimap (right associative):\n" <> ppShow traBM
+            step $ "ANF binds (left associative):\n" <> ppShow tlaANF
+            step $ "ANF binds (right associative):\n" <> ppShow traANF
+            step "4. Are both ANFs the same?"
+            assertEqual "ANF bimaps differ" tlaBM traBM
+            assertEqual "ANF binds differ" tlaANF traANF
+            step "ANFs are the same!"
+            let (UPLCTerm ttla) = toUPLCTerm . analyzeDemand $ anfLA
+            let (UPLCTerm ttra) = toUPLCTerm . analyzeDemand $ anfRA
+            step $ "UPLC (left associative):\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ ttla)
+            step $ "UPLC (right associative):\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ ttra)
             pure ()
     ]
 
@@ -285,6 +331,28 @@ case8 = plam' $ \x -> punsafeConstr 0 [toSomeTerm x, toSomeTerm perror]
 -- Case 9: \x -> case error of [x]
 case9 :: forall (a :: S -> Type) (s :: S). Term s (a :--> a)
 case9 = plam' $ \x -> punsafeCase perror . NEVector.singleton . toSomeTerm $ x
+
+-- Case 10: \x -> (compose [\y -> y + 2, \z -> x * z, \z1 -> z1 - 5]) x
+--
+-- Constructed left associatively
+case10 :: forall (s :: S). Term s (PInteger :--> PInteger)
+case10 =
+  let fun1 = plam' $ \y -> papp (papp paddInteger y) (punsafeConstant $ PLC.someValue @Integer 2)
+      fun3 = plam' $ \z1 -> papp (papp psubtractInteger z1) (punsafeConstant $ PLC.someValue @Integer 5)
+   in plam' $ \x ->
+        let fun2 = plam' $ \z -> papp (papp pmultiplyInteger x) z
+         in papp (pcompose (pcompose fun1 fun2) fun3) x
+
+-- Case 11: \x -> (compose [\y -> y + 2, \z -> x * z, \z1 -> z1 - 5]) x
+--
+-- Constructed right associatively
+case11 :: forall (s :: S). Term s (PInteger :--> PInteger)
+case11 =
+  let fun1 = plam' $ \y -> papp (papp paddInteger y) (punsafeConstant $ PLC.someValue @Integer 2)
+      fun3 = plam' $ \z1 -> papp (papp psubtractInteger z1) (punsafeConstant $ PLC.someValue @Integer 5)
+   in plam' $ \x ->
+        let fun2 = plam' $ \z -> papp (papp pmultiplyInteger x) z
+         in papp (pcompose fun1 . pcompose fun2 $ fun3) x
 
 -- Helpers
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -283,6 +283,25 @@ main =
             step $ "UPLC (left associative):\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ ttla)
             step $ "UPLC (right associative):\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ ttra)
             pure ()
+    , testCaseSteps "Case 12" $ \step -> do
+        step "Case: \\x -> (compose [\\y -> y + 2, \\z -> z + 2, \\z1 -> z1 + 2]) x"
+        step "1. Does Case 12 compile?"
+        let compiled = compileTerm case12
+        case compiled of
+          Left err -> assertFailure $ "Compile error: " <> show err
+          Right (_, t) -> do
+            step "Successfully compiled!"
+            step $ "RawTerm:\n" <> ppShow t
+            let asAST = fromRawTerm t
+            let anf@(ANF bm binds) = fromHashedAST asAST
+            step $ "ANF bimap:\n" <> ppShow bm
+            step $ "ANF binds:\n" <> ppShow binds
+            let anf'@(ANF bm' binds') = analyzeDemand anf
+            step $ "ANF bimap:\n" <> ppShow bm'
+            step $ "ANF binds:\n" <> ppShow binds'
+            let (UPLCTerm t) = toUPLCTerm anf'
+            step $ "UPLC:\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
+            pure ()
     ]
 
 -- Cases
@@ -353,6 +372,12 @@ case11 =
    in plam' $ \x ->
         let fun2 = plam' $ \z -> papp (papp pmultiplyInteger x) z
          in papp (pcompose fun1 . pcompose fun2 $ fun3) x
+
+-- Case 12: \x -> (compose [\y -> y + 2, \z -> z + 2, \z1 -> z1 + 2]) x
+case12 :: forall (s :: S). Term s (PInteger :--> PInteger)
+case12 =
+  let fun = plam' $ \y -> papp (papp paddInteger y) (punsafeConstant $ PLC.someValue @Integer 2)
+   in plam' $ \x -> papp (pcompose fun . pcompose fun $ fun) x
 
 -- Helpers
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -302,6 +302,25 @@ main =
             let (UPLCTerm t) = toUPLCTerm anf'
             step $ "UPLC:\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
             pure ()
+    , testCaseSteps "Case 13" $ \step -> do
+        step "Case: \\x -> (compose [\\y -> y * y, \\z -> z + 2]) x"
+        step "1. Does Case 13 compile?"
+        let compiled = compileTerm case13
+        case compiled of
+          Left err -> assertFailure $ "Compile error: " <> show err
+          Right (_, t) -> do
+            step "Successfully compiled!"
+            step $ "RawTerm:\n" <> ppShow t
+            let asAST = fromRawTerm t
+            let anf@(ANF bm binds) = fromHashedAST asAST
+            step $ "ANF bimap:\n" <> ppShow bm
+            step $ "ANF binds:\n" <> ppShow binds
+            let anf'@(ANF bm' binds') = analyzeDemand anf
+            step $ "ANF bimap:\n" <> ppShow bm'
+            step $ "ANF binds:\n" <> ppShow binds'
+            let (UPLCTerm t) = toUPLCTerm anf'
+            step $ "UPLC:\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
+            pure ()
     ]
 
 -- Cases
@@ -378,6 +397,13 @@ case12 :: forall (s :: S). Term s (PInteger :--> PInteger)
 case12 =
   let fun = plam' $ \y -> papp (papp paddInteger y) (punsafeConstant $ PLC.someValue @Integer 2)
    in plam' $ \x -> papp (pcompose fun . pcompose fun $ fun) x
+
+-- Case 13: \x -> (compose [\y -> y * y, \z -> z + 2]) x
+case13 :: forall (s :: S). Term s (PInteger :--> PInteger)
+case13 =
+  let f = plam' $ \y -> papp (papp pmultiplyInteger y) y
+      g = plam' $ \z -> papp (papp paddInteger z) (punsafeConstant $ PLC.someValue @Integer 2)
+   in plam' $ \x -> papp (pcompose f g) x
 
 -- Helpers
 


### PR DESCRIPTION
Closes #999 . The pipeline is currently rather crude, but it's there, and is _technically_ a bit better than defining composition manually.

This also fixes a bug in the code generator where, if we ended up needing the same `let`-bind more than once in a single ANF bind, the generator would emit multiple identical `let`-bind transforms.