### PR TITLE
Prettier UPLC

### DIFF
--- a/Plutarch/Backend/AST.hs
+++ b/Plutarch/Backend/AST.hs
@@ -101,6 +101,7 @@ import Prettyprinter (
   align,
   braces,
   brackets,
+  flatAlt,
   group,
   hardline,
   hsep,
@@ -248,30 +249,34 @@ instance {-# OVERLAPS #-} Pretty ann => Pretty (AST ann) where
   pretty = \case
     ASTLeaf l -> case l of
       LVar {} -> pretty l
-      _ -> taggedNode (pretty $ astLeafAnn l) $ pretty l
-    ASTForce ann arg -> taggedNode (pretty ann) $ "force" <+> pretty arg
-    ASTDelay ann arg -> taggedNode (pretty ann) $ "delay" <+> pretty arg
+      _ -> taggedNode "" (pretty $ astLeafAnn l) $ pretty l
+    ASTForce ann arg -> taggedNode "" (pretty ann) $ "force" <+> pretty arg
+    ASTDelay ann arg -> taggedNode "" (pretty ann) $ "delay" <+> pretty arg
     ASTLam ann vars body ->
-      taggedNode (pretty ann) $ "\\" <> mkArgs vars <+> "->" <> hardline <> indent 2 (pretty body)
+      let cxt = "\\" <> mkArgs vars <+> "-> "
+       in taggedNode cxt (pretty ann)
+            . align
+            . group
+            $ pretty body
     ASTFix ann self body ->
-      taggedNode (pretty ann) $ "Fix" <> brackets (pretty self) <+> pretty body
+      let oneLine = brackets (pretty self) <+> pretty body
+          multiLine = brackets (pretty self) <> hardline <> group (pretty body)
+       in taggedNode "Fix" (pretty ann) $ flatAlt multiLine oneLine
     ASTApply ann fun args ->
-      taggedNode (pretty ann) $
-        "Apply"
-          <+> hardline
-          <+> align (indent 2 (pretty fun))
-          <+> hardline
-          <+> align (indent 2 (blockList . map pretty . NEVector.toList $ args))
+      let oneLine = align (pretty fun) <+> align (blockList . map pretty . NEVector.toList $ args)
+          multiLine = align $ align (pretty fun) <> hardline <> align (blockList . map pretty . NEVector.toList $ args)
+       in taggedNode "Apply" (pretty ann) $ flatAlt multiLine oneLine
     ASTConstr ann cix args ->
-      taggedNode (pretty ann) $ "Constr" <> brackets (pretty cix) <+> blockList (pretty <$> Vector.toList args)
+      taggedNode "Constr " (pretty ann) $ brackets (pretty cix) <+> blockList (pretty <$> Vector.toList args)
     ASTCase ann scrut handlers ->
-      taggedNode (pretty ann) $
-        "case"
-          <+> pretty scrut
+      taggedNode "case" (pretty ann)
+        . align
+        . group
+        $ pretty scrut
           <+> hardline
-          <> indent 2 (blockList . map pretty . NEVector.toList $ handlers)
+          <> (blockList . map pretty . NEVector.toList $ handlers)
     ASTCompose ann args ->
-      taggedNode (pretty ann) $ "Compose" <+> align (blockList (pretty <$> NEVector.toList args))
+      taggedNode "Compose" (pretty ann) $ align (blockList (pretty <$> NEVector.toList args))
 
 {- | Given a 'RawTerm', construct its AST, using hashing to mark
 alpha-equivalent subcomputations.

--- a/Plutarch/Utils/Pretty.hs
+++ b/Plutarch/Utils/Pretty.hs
@@ -149,13 +149,18 @@ blockList = block "[" "]" . vcat . punctuate ", "
 customList :: forall (ann :: Type). [Doc ann] -> Doc ann
 customList = \case
   [] -> "[]"
-  (x : xs) -> flatAlt (go x xs) (list (x : xs))
+  (x : xs) -> group $ flatAlt (go x xs) (oneLineList (x : xs))
   where
     go :: Doc ann -> [Doc ann] -> Doc ann
     go headEl rest = align . group . vcat $ ["[" <+> headEl] <> map ("," <+>) rest <> ["]"]
 
-blockParens :: forall (ann :: Type). Doc ann -> Doc ann
-blockParens = block "(" ")"
+oneLineList :: forall (ann :: Type). [Doc ann] -> Doc ann
+oneLineList = \case
+  [] -> "[]"
+  xs -> "[" <> hcat (punctuate ", " xs) <> "]"
+
+_blockParens :: forall (ann :: Type). Doc ann -> Doc ann
+_blockParens = block "(" ")"
 
 taggedNode :: forall (ann :: Type). Doc ann -> Doc ann -> Doc ann -> Doc ann
 taggedNode lbl ann node = block' lbl "<" ">" node <> "@" <> ann
@@ -174,15 +179,21 @@ prettyAnnotated getAnn annHandler nodePrinter x = annHandler (pretty a) $ nodePr
     a = getAnn x
     childNodes = children x
 
+-- Yes there are probably a bunch of superfluous `align`s, not worth the trouble to sort out which are safe to remove tho
 prettyUPLC :: forall ann. Term Name DefaultUni DefaultFun () -> Doc ann
-prettyUPLC pt = case takeBindable ([], pt) of
-  ([], rest) -> prettyNoBind rest
+prettyUPLC pt = case takeBindable ([], topLevelBody) of
+  ([], rest) -> case topLevelArgs of
+    [] -> prettyNoBind rest
+    _ -> prettyLamNoBind topLevelArgs $ prettyNoBind rest
   (letBinds, rest) ->
     let pRest = "in" <+> prettyNoBind rest
-     in align . vsep . reverse $ (pRest : letBinds)
+        body = align . vsep . reverse $ (pRest : letBinds)
+     in prettyLamNoBind topLevelArgs body
   where
+    (topLevelArgs, topLevelBody) = takeLamArgs ([], pt)
     -- if it's `arg` it came from Plutarch code and we just use the "compact pretty hash" as the visible name directly,
-    -- but if it's something else then it came from a blob of compiled UPLC and we need to make the text part visible
+    -- but if it's something else then it came from a blob of compiled UPLC OR has a semantically meaningful text part
+    -- so we need to make the text part visible
     prettyName :: Name -> Doc ann
     prettyName (Name txt (Unique u))
       | txt == "arg" = pretty . compactReadableVar . fromIntegral $ u
@@ -200,14 +211,18 @@ prettyUPLC pt = case takeBindable ([], pt) of
       LamAbs () nm body -> takeLamArgs (prettyName nm : varAcc, body)
       _ -> (reverse varAcc, next)
 
+    prettyLamNoBind :: [Doc ann] -> Doc ann -> Doc ann
+    prettyLamNoBind vars body = align . group $ flatAlt multiLine oneLine
+      where
+        oneLine = "\\" <> hsep vars <+> "->" <+> body
+        multiLine = "\\" <> hsep vars <+> "->" <> hardline <> indent 2 body
+
     prettyNoBind :: Term Name DefaultUni DefaultFun () -> Doc ann
     prettyNoBind = \case
       Var () nm -> prettyName nm
       LamAbs () nm _body ->
         let (vars, body) = takeLamArgs ([prettyName nm], _body)
-            oneLine = "\\" <> hsep vars <+> "->" <+> prettyNoBind body
-            multiLine = "\\" <> hsep vars <+> "->" <> hardline <> indent 2 (prettyNoBind body)
-         in align . group $ flatAlt multiLine oneLine
+         in prettyLamNoBind vars (prettyNoBind body)
       Apply () f arg ->
         let fs = prettyAtomic <$> analyzeApp f
             allArgs = tail fs <> [prettyAtomic arg]
@@ -241,6 +256,10 @@ prettyUPLC pt = case takeBindable ([], pt) of
       Builtin {} -> True
       _ -> False
 
+    -- An "atom", here, is a representation of a term that we can put anywhere we want without causing ambiguity.
+    -- We need all the stupid helpers primarily to insert the "first element" (the lambda binds, the scrut in a case exp, etc)
+    -- on the same line as the enclosing left paren while ensuring the rest of the term renders in a
+    -- readable way
     prettyAtomic :: Term Name DefaultUni DefaultFun () -> Doc ann
     prettyAtomic = \case
       v@Var {} -> prettyNoBind v
@@ -256,7 +275,29 @@ prettyUPLC pt = case takeBindable ([], pt) of
             multiLine = align . vcat $ ["(" <> cxt, indent 2 (prettyNoBind body), ")"]
          in group $ flatAlt multiLine oneLine
       Apply () f arg -> prettyAtomicApp f arg
-      other -> blockParens . prettyNoBind $ other
+      -- TODO: Atomic Case
+      Case () scrut handlers -> prettyAtomicCase scrut (Vector.toList handlers)
+      Constr () cix args -> prettyAtomicCtor (pretty cix) (map prettyNoBind args)
+
+    prettyAtomicCtor :: Doc ann -> [Doc ann] -> Doc ann
+    prettyAtomicCtor cix args = align . group $ flatAlt multiLine oneLine
+      where
+        multiLine :: Doc ann
+        multiLine = align $ "(" <> "constr" <+> cix <> hardline <> customList args <> hardline <> ")"
+
+        oneLine :: Doc ann
+        oneLine = parens $ "constr" <+> cix <+> oneLineList args
+    prettyAtomicCase :: Term Name DefaultUni DefaultFun () -> [Term Name DefaultUni DefaultFun ()] -> Doc ann
+    prettyAtomicCase scrut (map prettyNoBind -> handlers)
+      | isAtom scrut = align . group $ flatAlt atomicMultiline defOneline
+      | otherwise = align . group $ flatAlt defMultiline defOneline
+      where
+        -- FIXME: koz doesn't like compressed sigs like this
+        atomicMultiline, defMultiline, defOneline, pscrut :: Doc ann
+        atomicMultiline = align $ "(case" <+> pscrut <> hardline <> indent 2 (customList handlers) <> hardline <> ")"
+        defMultiline = align . group $ "(case" <+> hardline <+> indent 2 (align . vcat $ [pscrut, customList handlers]) <> hardline <> ")"
+        defOneline = parens $ "case" <+> pscrut <+> oneLineList handlers
+        pscrut = prettyAtomic scrut
 
     -- This is annoying
     prettyAtomicApp :: Term Name DefaultUni DefaultFun () -> Term Name DefaultUni DefaultFun () -> Doc ann

--- a/Plutarch/Utils/Pretty.hs
+++ b/Plutarch/Utils/Pretty.hs
@@ -16,7 +16,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Vector qualified as Vector
 import Data.Vector.Strict qualified as SV
-import PlutusCore.Default (DefaultUni (..), Esc)
+import PlutusCore.Default (DefaultUni (..), Esc, Some (Some), ValueOf (ValueOf))
 import Prettyprinter (
   Doc,
   Pretty (pretty),
@@ -24,8 +24,10 @@ import Prettyprinter (
   angles,
   brackets,
   encloseSep,
+  flatAlt,
   group,
   hardline,
+  hcat,
   hsep,
   indent,
   list,
@@ -123,19 +125,40 @@ compactReadableVar n
 (<:=>) :: forall (ann :: Type). Doc ann -> Doc ann -> Doc ann
 d1 <:=> d2 = d1 <+> ":=" <+> d2
 
--- first two args are the left and right block separator
+_customLine :: Doc ann
+_customLine = flatAlt hardline ""
+
+-- arg is a "tag" for the AST node type, next two two args are the left and right block separator
+block' :: forall (ann :: Type). Doc ann -> Doc ann -> Doc ann -> Doc ann -> Doc ann
+block' lbl l' r d = group $ flatAlt multiLine oneLine
+  where
+    l = l' <> lbl
+    multiLine :: Doc ann
+    multiLine = align $ l <> hardline <> indent 2 (align . group $ d) <> hardline <> r
+
+    oneLine :: Doc ann
+    oneLine = align $ l <> align d <> r
+
 block :: forall (ann :: Type). Doc ann -> Doc ann -> Doc ann -> Doc ann
-block l r d = align . group $ l <> hardline <> indent 2 (align d) <> hardline <> r
+block = block' ""
 
 -- This aligns the `[` and `]` at the same indentation level to make this easier to read
 blockList :: forall (ann :: Type). [Doc ann] -> Doc ann
 blockList = block "[" "]" . vcat . punctuate ", "
 
+customList :: forall (ann :: Type). [Doc ann] -> Doc ann
+customList = \case
+  [] -> "[]"
+  (x : xs) -> flatAlt (go x xs) (list (x : xs))
+  where
+    go :: Doc ann -> [Doc ann] -> Doc ann
+    go headEl rest = align . group . vcat $ ["[" <+> headEl] <> map ("," <+>) rest <> ["]"]
+
 blockParens :: forall (ann :: Type). Doc ann -> Doc ann
 blockParens = block "(" ")"
 
-taggedNode :: forall (ann :: Type). Doc ann -> Doc ann -> Doc ann
-taggedNode ann node = align . group $ block "<" ">" node <> "@" <> ann
+taggedNode :: forall (ann :: Type). Doc ann -> Doc ann -> Doc ann -> Doc ann
+taggedNode lbl ann node = block' lbl "<" ">" node <> "@" <> ann
 
 prettyAnnotated ::
   forall f a ann.
@@ -171,35 +194,52 @@ prettyUPLC pt = case takeBindable ([], pt) of
         let here = "let" <+> prettyName nm <+> "=" <+> align (prettyNoBind arg)
          in takeBindable (here : acc, body)
       other -> (acc, other)
+
     takeLamArgs :: ([Doc ann], Term Name DefaultUni DefaultFun ()) -> ([Doc ann], Term Name DefaultUni DefaultFun ())
     takeLamArgs (varAcc, next) = case next of
       LamAbs () nm body -> takeLamArgs (prettyName nm : varAcc, body)
       _ -> (reverse varAcc, next)
+
     prettyNoBind :: Term Name DefaultUni DefaultFun () -> Doc ann
     prettyNoBind = \case
       Var () nm -> prettyName nm
       LamAbs () nm _body ->
         let (vars, body) = takeLamArgs ([prettyName nm], _body)
-         in align . group $
-              "\\" <> hsep vars <+> "->" <> hardline <> indent 2 (prettyNoBind body)
+            oneLine = "\\" <> hsep vars <+> "->" <+> prettyNoBind body
+            multiLine = "\\" <> hsep vars <+> "->" <> hardline <> indent 2 (prettyNoBind body)
+         in align . group $ flatAlt multiLine oneLine
       Apply () f arg ->
         let fs = prettyAtomic <$> analyzeApp f
-         in align . group . encloseSep "" "" " # " $ (fs <> [prettyAtomic arg])
+            allArgs = tail fs <> [prettyAtomic arg]
+            funPart = head fs
+            oneLine = parens $ funPart <> hcat (map (" # " <>) allArgs)
+            multiLine = funPart <> hardline <> vcat (map ("# " <>) allArgs)
+         in align . group $ flatAlt multiLine oneLine
       Force () inner -> "!" <> prettyAtomic inner
       Delay () inner -> angles $ prettyAtomic inner
-      c@(Constant _ _) -> pretty c
-      Builtin _ b -> pretty b
+      Constant _ (Some (ValueOf uni x)) -> parens (prettyValueOf uni x)
+      Builtin _ b -> viaShow b
       Error {} -> "ERROR"
-      Constr () cix args -> "constr" <+> pretty cix <+> align (group $ list (prettyNoBind <$> args))
+      Constr () cix args -> "constr" <+> pretty cix <+> align (group $ customList (prettyNoBind <$> args))
       Case () scrut handlers ->
-        group $
+        align . group $
           "case"
-            <+> blockParens (prettyNoBind scrut)
+            <+> prettyAtomic scrut
             <+> hardline
             <> align
               ( group
-                  (indent 2 . blockList . fmap prettyNoBind . Vector.toList $ handlers)
+                  (indent 2 . customList . fmap prettyNoBind . Vector.toList $ handlers)
               )
+
+    isAtom :: Term Name DefaultUni DefaultFun () -> Bool
+    isAtom = \case
+      Var {} -> True
+      Constant {} -> True
+      Error {} -> True
+      Delay {} -> True
+      Force {} -> True
+      Builtin {} -> True
+      _ -> False
 
     prettyAtomic :: Term Name DefaultUni DefaultFun () -> Doc ann
     prettyAtomic = \case
@@ -209,7 +249,30 @@ prettyUPLC pt = case takeBindable ([], pt) of
       d@Delay {} -> prettyNoBind d
       f@Force {} -> prettyNoBind f
       b@Builtin {} -> prettyNoBind b
+      LamAbs () nm _body ->
+        let (vars, body) = takeLamArgs ([prettyName nm], _body)
+            cxt = "\\" <> hsep vars <+> "->"
+            oneLine = align . parens $ cxt <+> prettyNoBind body
+            multiLine = align . vcat $ ["(" <> cxt, indent 2 (prettyNoBind body), ")"]
+         in group $ flatAlt multiLine oneLine
+      Apply () f arg -> prettyAtomicApp f arg
       other -> blockParens . prettyNoBind $ other
+
+    -- This is annoying
+    prettyAtomicApp :: Term Name DefaultUni DefaultFun () -> Term Name DefaultUni DefaultFun () -> Doc ann
+    prettyAtomicApp f arg
+      | isAtom funPart = align . group $ flatAlt atomicMultiline defOneline
+      | otherwise = align . group $ flatAlt defMultiline defOneline
+      where
+        funList = analyzeApp f <> [arg]
+        pfunList = prettyAtomic <$> funList
+        funPart = head funList
+        argsPart = tail funList
+        pfunPart = prettyAtomic funPart
+        pArgs = prettyAtomic <$> argsPart
+        defOneline = parens $ pfunPart <> hcat (map (" # " <>) pArgs)
+        defMultiline = align . group $ "(" <+> hardline <+> indent 2 (align $ encloseSep "" "" "# " pfunList) <> hardline <> ")"
+        atomicMultiline = align $ "(" <+> pfunPart <> hardline <> indent 2 (vcat (map ("# " <>) pArgs)) <> hardline <> ")"
 
     analyzeApp :: Term Name DefaultUni DefaultFun () -> [Term Name DefaultUni DefaultFun ()]
     analyzeApp = \case

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -329,7 +329,7 @@ main =
             step "Successfully compiled!"
             step $ "RawTerm:\n" <> ppShow t
             let asAST = fromRawTerm t
-            step $ "AST:\n" <> ppShow asAST
+            step $ "AST:\n" <> toPrettyString asAST
             let anf = fromHashedAST asAST
             step "ANF, no demand analysis"
             step $ toPrettyString anf
@@ -349,7 +349,7 @@ main =
             step "Successfully compiled!"
             step $ "RawTerm:\n" <> ppShow t
             let asAST = fromRawTerm t
-            step $ "AST:\n" <> ppShow asAST
+            step $ "AST:\n" <> toPrettyString asAST
             let anf = fromHashedAST asAST
             step "ANF, no demand analysis"
             step $ toPrettyString anf


### PR DESCRIPTION
I realized that I *can* use `flatAlt` and made things vastly prettier.  (It doesn't work well if you need to FORCE something to be on a single line, no matter what, or if you need to make calls to a pretty printer someone else wrote that contains hardlines). 

I'm opening this as a draft so you can look at the output. I could probably clean up the code a bit more but I don't wanna bother with that until the output gets the stamp of approval. 