### PR TITLE
Koz/1017

### DIFF
--- a/Plutarch/Backend/ANF.hs
+++ b/Plutarch/Backend/ANF.hs
@@ -23,7 +23,7 @@ module Plutarch.Backend.ANF (
   getANFBindAnn,
 ) where
 
-import Control.Monad.ST (runST)
+import Control.Monad.ST (ST, runST)
 import Control.Monad.State.Strict (
   State,
   execStateT,
@@ -366,75 +366,7 @@ analyzeDemand (ANF bm binds) = runST $ do
   countMV <- MVector.replicate len (0 :: Int)
   neededVarsMV <- MVector.replicate len Set.empty
   -- Collect 'raw' statistics on use count, needed variables and binding sites
-  bindingSites <- flip execStateT Map.empty $
-    for_ [0, 1 .. len - 1] $ \i -> case binds NEVector.! i of
-      ANFLeaf ell -> MVector.write countMV i $ case ell of
-        LConstant _ c ->
-          if smallEnoughToInline c
-            then (-1)
-            else 0
-        LBuiltin _ _ -> (-1)
-        LError _ -> (-1)
-        _ -> 0
-      ANFForce _ r -> do
-        updateCountAt countMV r
-        neededVars <- getNeededFrom neededVarsMV r
-        MVector.write countMV i 0
-        MVector.write neededVarsMV i neededVars
-      ANFDelay _ r -> do
-        updateCountAt countMV r
-        neededVars <- getNeededFrom neededVarsMV r
-        MVector.write countMV i 0
-        MVector.write neededVarsMV i neededVars
-      ANFLam _ mults r -> do
-        updateCountAt countMV r
-        neededVars <- getNeededFrom neededVarsMV r
-        -- Lambdas act as binding sites, so they only need variables bound
-        -- 'above' them. Thus, we remove any used bound vars, but also note
-        -- that this is where said variables get bound.
-        let multsAsSet = multsToSet mults
-        let neededVars' = Set.difference neededVars multsAsSet
-        MVector.write countMV i 0
-        MVector.write neededVarsMV i neededVars'
-        modify (\acc -> Set.foldr (`Map.insert` i) acc multsAsSet)
-      ANFFix _ mult r -> do
-        updateCountAt countMV r
-        neededVars <- getNeededFrom neededVarsMV r
-        -- Fixpoint self arguments aren't needed by fixes themselves. Thus, we
-        -- remove it from used vars, but also note that it was bound here.
-        let varHash = case mult of
-              MultiplicityOne h -> h
-              MultiplicityMany h -> h
-        let neededVars' = Set.delete varHash neededVars
-        MVector.write countMV i 0
-        MVector.write neededVarsMV i neededVars'
-        modify (Map.insert varHash i)
-      ANFApply _ f xs -> do
-        updateCountAt countMV f
-        traverse_ (updateCountAt countMV) xs
-        neededF <- getNeededFrom neededVarsMV f
-        neededXs <- traverse (getNeededFrom neededVarsMV) xs
-        let neededVars = NEVector.foldl' Set.union neededF neededXs
-        MVector.write countMV i 0
-        MVector.write neededVarsMV i neededVars
-      ANFConstr _ _ fields -> do
-        traverse_ (updateCountAt countMV) fields
-        neededFields <- traverse (getNeededFrom neededVarsMV) fields
-        MVector.write countMV i 0
-        MVector.write neededVarsMV i . fold $ neededFields
-      ANFCase _ scrut handlers -> do
-        updateCountAt countMV scrut
-        traverse_ (updateCountAt countMV) handlers
-        neededScrut <- getNeededFrom neededVarsMV scrut
-        neededHandlers <- traverse (getNeededFrom neededVarsMV) handlers
-        let neededVars = NEVector.foldl' Set.union neededScrut neededHandlers
-        MVector.write countMV i 0
-        MVector.write neededVarsMV i neededVars
-      ANFCompose _ components -> do
-        traverse_ (updateCountAt countMV) components
-        neededComponents <- traverse (getNeededFrom neededVarsMV) components
-        MVector.write countMV i 0
-        MVector.write neededVarsMV i . fold $ neededComponents
+  bindingSites <- collectRawStatistics len countMV neededVarsMV
   -- At this stage, we know:
   --
   -- 1. Every (useful) use count of every bind
@@ -487,6 +419,81 @@ analyzeDemand (ANF bm binds) = runST $ do
       Nothing -> acc
       Just (MultiplicityOne h) -> Set.insert h acc
       Just (MultiplicityMany h) -> Set.insert h acc
+    collectRawStatistics ::
+      forall (s :: Type).
+      Int ->
+      MVector s Int ->
+      MVector s (Set Hash) ->
+      ST s (Map Hash Int)
+    collectRawStatistics len countMV neededVarsMV = flip execStateT Map.empty $
+      for_ [0, 1 .. len - 1] $ \i -> case binds NEVector.! i of
+        ANFLeaf ell -> MVector.write countMV i $ case ell of
+          LConstant _ c ->
+            if smallEnoughToInline c
+              then (-1)
+              else 0
+          LBuiltin _ _ -> (-1)
+          LError _ -> (-1)
+          _ -> 0
+        ANFForce _ r -> do
+          updateCountAt countMV r
+          neededVars <- getNeededFrom neededVarsMV r
+          MVector.write countMV i 0
+          MVector.write neededVarsMV i neededVars
+        ANFDelay _ r -> do
+          updateCountAt countMV r
+          neededVars <- getNeededFrom neededVarsMV r
+          MVector.write countMV i 0
+          MVector.write neededVarsMV i neededVars
+        ANFLam _ mults r -> do
+          updateCountAt countMV r
+          neededVars <- getNeededFrom neededVarsMV r
+          -- Lambdas act as binding sites, so they only need variables bound
+          -- 'above' them. Thus, we remove any used bound vars, but also note
+          -- that this is where said variables get bound.
+          let multsAsSet = multsToSet mults
+          let neededVars' = Set.difference neededVars multsAsSet
+          MVector.write countMV i 0
+          MVector.write neededVarsMV i neededVars'
+          modify (\acc -> Set.foldr (`Map.insert` i) acc multsAsSet)
+        ANFFix _ mult r -> do
+          updateCountAt countMV r
+          neededVars <- getNeededFrom neededVarsMV r
+          -- Fixpoint self arguments aren't needed by fixes themselves. Thus, we
+          -- remove it from used vars, but also note that it was bound here.
+          let varHash = case mult of
+                MultiplicityOne h -> h
+                MultiplicityMany h -> h
+          let neededVars' = Set.delete varHash neededVars
+          MVector.write countMV i 0
+          MVector.write neededVarsMV i neededVars'
+          modify (Map.insert varHash i)
+        ANFApply _ f xs -> do
+          updateCountAt countMV f
+          traverse_ (updateCountAt countMV) xs
+          neededF <- getNeededFrom neededVarsMV f
+          neededXs <- traverse (getNeededFrom neededVarsMV) xs
+          let neededVars = NEVector.foldl' Set.union neededF neededXs
+          MVector.write countMV i 0
+          MVector.write neededVarsMV i neededVars
+        ANFConstr _ _ fields -> do
+          traverse_ (updateCountAt countMV) fields
+          neededFields <- traverse (getNeededFrom neededVarsMV) fields
+          MVector.write countMV i 0
+          MVector.write neededVarsMV i . fold $ neededFields
+        ANFCase _ scrut handlers -> do
+          updateCountAt countMV scrut
+          traverse_ (updateCountAt countMV) handlers
+          neededScrut <- getNeededFrom neededVarsMV scrut
+          neededHandlers <- traverse (getNeededFrom neededVarsMV) handlers
+          let neededVars = NEVector.foldl' Set.union neededScrut neededHandlers
+          MVector.write countMV i 0
+          MVector.write neededVarsMV i neededVars
+        ANFCompose _ components -> do
+          traverse_ (updateCountAt countMV) components
+          neededComponents <- traverse (getNeededFrom neededVarsMV) components
+          MVector.write countMV i 0
+          MVector.write neededVarsMV i . fold $ neededComponents
 
 -- Pretty Printer Helpers
 

--- a/Plutarch/Backend/ANF.hs
+++ b/Plutarch/Backend/ANF.hs
@@ -23,9 +23,10 @@ module Plutarch.Backend.ANF (
   getANFBindAnn,
 ) where
 
-import Control.Monad.ST (ST, runST)
+import Control.Monad.ST (runST)
 import Control.Monad.State.Strict (
   State,
+  execStateT,
   gets,
   modify,
   runState,
@@ -33,13 +34,18 @@ import Control.Monad.State.Strict (
 import Data.Bifunctor (bimap)
 import Data.Bimap (Bimap)
 import Data.Bimap qualified as Bimap
-import Data.Foldable (for_, traverse_)
+import Data.Foldable (fold, for_, traverse_)
 import Data.IntMap.Strict (IntMap)
 import Data.IntMap.Strict qualified as IntMap
 import Data.Kind (Type)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Vector (MVector, Vector)
 import Data.Vector qualified as Vector
+import Data.Vector.Mutable (PrimMonad (PrimState))
 import Data.Vector.Mutable qualified as MVector
 import Data.Vector.NonEmpty (NonEmptyVector)
 import Data.Vector.NonEmpty qualified as NEVector
@@ -57,7 +63,7 @@ import Plutarch.Backend.AST (
     ASTLeaf
   ),
   Hash,
-  Multiplicity,
+  Multiplicity (MultiplicityMany, MultiplicityOne),
  )
 import Plutarch.Backend.AST qualified as AST
 import Plutarch.Backend.UPLC (UPLCTerm)
@@ -319,27 +325,26 @@ fromHashedAST ast = case runState (go ast) (Bimap.empty, IntMap.empty) of
       modify (bimap (Bimap.insert asId h) (IntMap.insert firstAvailable bind))
       pure . AnId $ asId
 
-{- | A custom monoid for demand analysis. This is designed to fuse both
-determining how often a bind is needed, and where it should be @let@-bound,
-into a single monoidal traversal.
+{- | A type to indicate how often a (sub) computation is needed as part of an
+entire translation unit, as well as where it should be @let@ bound if needed.
 
 @since wip
 -}
 data Demand
-  = {- | The 'mempty' starting point.
+  = {- | This computation is not needed anywhere. This typically indicates the
+    top-level computation in any translation unit.
 
     @since wip
     -}
     NeverDemanded
-  | {- | The 'Id' corresponds to the last bind (thus, the first demand site) of
-    the given bind, and the 'Word64' is the count of how many times the bind
-    is demanded.
+  | {- | This computation is needed at least once (exact use count indicated
+    by 'Word64'), and if it needs to be @let@-bound, where this can be
+    done (indicated by 'Id').
 
     @since wip
     -}
     Demanded Id Word64
-  | {- | Some things should never be @let@-bound. This means their demand
-    analysis is trivial.
+  | {- | Should never be @let@-bound. Thus, its use count is not needed.
 
     @since wip
     -}
@@ -352,81 +357,136 @@ data Demand
     )
 
 -- | @since wip
-instance Semigroup Demand where
-  NeverDemanded <> x = x
-  x <> NeverDemanded = x
-  Demanded (Id i) count1 <> Demanded (Id j) count2 =
-    Demanded (Id $ max i j) (count1 + count2)
-  Trivial <> _ = Trivial
-  _ <> Trivial = Trivial
-
--- | @since wip
 instance Pretty Demand where
   pretty = viaShow
-
--- | @since wip
-instance Monoid Demand where
-  mempty = NeverDemanded
 
 analyzeDemand :: forall (ann :: Type). ANF ann -> ANF Demand
 analyzeDemand (ANF bm binds) = runST $ do
   let len = NEVector.length binds
-  -- Note (Koz, 05/06/2026): We're working with a possibly-empty mutable vector
-  -- here as currently, there is no way to 'freeze' a mutable non-empty vector.
-  mv <- MVector.new len
-  for_ [0, 1 .. len - 1] $ \i -> case binds NEVector.! i of
-    ANFLeaf ell -> MVector.write mv i . ANFLeaf $ case ell of
-      LConstant _ c ->
-        if smallEnoughToInline c
-          then LConstant Trivial c
-          else LConstant mempty c
-      LBuiltin _ f -> LBuiltin Trivial f
-      LCompiled _ code -> LCompiled mempty code
-      LError _ -> LError Trivial
-    ANFForce _ r -> do
-      updateDemandAt mv i r
-      MVector.write mv i . ANFForce mempty $ r
-    ANFDelay _ r -> do
-      updateDemandAt mv i r
-      MVector.write mv i . ANFDelay mempty $ r
-    ANFLam _ mults r -> do
-      updateDemandAt mv i r
-      MVector.write mv i . ANFLam mempty mults $ r
-    ANFFix _ mult r -> do
-      updateDemandAt mv i r
-      MVector.write mv i . ANFFix mempty mult $ r
-    ANFApply _ f xs -> do
-      updateDemandAt mv i f
-      traverse_ (updateDemandAt mv i) xs
-      MVector.write mv i . ANFApply mempty f $ xs
-    ANFConstr _ tag fields -> do
-      traverse_ (updateDemandAt mv i) fields
-      MVector.write mv i . ANFConstr mempty tag $ fields
-    ANFCase _ scrut handlers -> do
-      updateDemandAt mv i scrut
-      traverse_ (updateDemandAt mv i) handlers
-      MVector.write mv i . ANFCase mempty scrut $ handlers
-    ANFCompose _ components -> do
-      traverse_ (updateDemandAt mv i) components
-      MVector.write mv i . ANFCompose mempty $ components
-  v <- Vector.unsafeFreeze mv
-  pure . ANF bm . NEVector.unsafeFromVector $ v
+  countMV <- MVector.replicate len (0 :: Int)
+  neededVarsMV <- MVector.replicate len Set.empty
+  -- Collect 'raw' statistics on use count, needed variables and binding sites
+  bindingSites <- flip execStateT Map.empty $
+    for_ [0, 1 .. len - 1] $ \i -> case binds NEVector.! i of
+      ANFLeaf ell -> MVector.write countMV i $ case ell of
+        LConstant _ c ->
+          if smallEnoughToInline c
+            then (-1)
+            else 0
+        LBuiltin _ _ -> (-1)
+        LError _ -> (-1)
+        _ -> 0
+      ANFForce _ r -> do
+        updateCountAt countMV r
+        neededVars <- getNeededFrom neededVarsMV r
+        MVector.write countMV i 0
+        MVector.write neededVarsMV i neededVars
+      ANFDelay _ r -> do
+        updateCountAt countMV r
+        neededVars <- getNeededFrom neededVarsMV r
+        MVector.write countMV i 0
+        MVector.write neededVarsMV i neededVars
+      ANFLam _ mults r -> do
+        updateCountAt countMV r
+        neededVars <- getNeededFrom neededVarsMV r
+        -- Lambdas act as binding sites, so they only need variables bound
+        -- 'above' them. Thus, we remove any used bound vars, but also note
+        -- that this is where said variables get bound.
+        let multsAsSet = multsToSet mults
+        let neededVars' = Set.difference neededVars multsAsSet
+        MVector.write countMV i 0
+        MVector.write neededVarsMV i neededVars'
+        modify (\acc -> Set.foldr (`Map.insert` i) acc multsAsSet)
+      ANFFix _ mult r -> do
+        updateCountAt countMV r
+        neededVars <- getNeededFrom neededVarsMV r
+        -- Fixpoint self arguments aren't needed by fixes themselves. Thus, we
+        -- remove it from used vars, but also note that it was bound here.
+        let varHash = case mult of
+              MultiplicityOne h -> h
+              MultiplicityMany h -> h
+        let neededVars' = Set.delete varHash neededVars
+        MVector.write countMV i 0
+        MVector.write neededVarsMV i neededVars'
+        modify (Map.insert varHash i)
+      ANFApply _ f xs -> do
+        updateCountAt countMV f
+        traverse_ (updateCountAt countMV) xs
+        neededF <- getNeededFrom neededVarsMV f
+        neededXs <- traverse (getNeededFrom neededVarsMV) xs
+        let neededVars = NEVector.foldl' Set.union neededF neededXs
+        MVector.write countMV i 0
+        MVector.write neededVarsMV i neededVars
+      ANFConstr _ _ fields -> do
+        traverse_ (updateCountAt countMV) fields
+        neededFields <- traverse (getNeededFrom neededVarsMV) fields
+        MVector.write countMV i 0
+        MVector.write neededVarsMV i . fold $ neededFields
+      ANFCase _ scrut handlers -> do
+        updateCountAt countMV scrut
+        traverse_ (updateCountAt countMV) handlers
+        neededScrut <- getNeededFrom neededVarsMV scrut
+        neededHandlers <- traverse (getNeededFrom neededVarsMV) handlers
+        let neededVars = NEVector.foldl' Set.union neededScrut neededHandlers
+        MVector.write countMV i 0
+        MVector.write neededVarsMV i neededVars
+      ANFCompose _ components -> do
+        traverse_ (updateCountAt countMV) components
+        neededComponents <- traverse (getNeededFrom neededVarsMV) components
+        MVector.write countMV i 0
+        MVector.write neededVarsMV i . fold $ neededComponents
+  -- At this stage, we know:
+  --
+  -- 1. Every (useful) use count of every bind
+  -- 2. What variables must be in scope for any given bind to be meaningful
+  -- 3. For every variable, where that variable was bound
+  --
+  -- Knowing all these, we can now construct a brand-new ANF with full demand
+  -- analysis.
+  newBinds <- NEVector.generate1M len $ \i -> do
+    let oldBind = binds NEVector.! i
+    uses <- MVector.read countMV i
+    case uses of
+      (-1) -> pure (Trivial <$ oldBind)
+      0 -> pure (NeverDemanded <$ oldBind)
+      _ -> do
+        neededVars <- MVector.read neededVarsMV i
+        let lowestSite = Set.foldl' (siteMin bindingSites) (len - 1) neededVars
+        pure (Demanded (Id lowestSite) (fromIntegral uses) <$ oldBind)
+  pure . ANF bm $ newBinds
   where
+    siteMin :: Map Hash Int -> Int -> Hash -> Int
+    siteMin bindingSites acc varHash = case Map.lookup varHash bindingSites of
+      -- Technically impossible
+      Nothing -> acc
+      Just site -> min acc site
     smallEnoughToInline :: Some (ValueOf PLC.DefaultUni) -> Bool
     smallEnoughToInline = \case
       Some (ValueOf PLC.DefaultUniBool _) -> True
       Some (ValueOf PLC.DefaultUniUnit _) -> True
       Some (ValueOf PLC.DefaultUniInteger n) -> abs n < 256
       _ -> False
-    updateDemandAt ::
-      forall (s :: Type).
-      MVector s (ANFBind Demand) ->
-      Int ->
-      Ref ->
-      ST s ()
-    updateDemandAt mv i = \case
-      AnId (Id j) -> MVector.modify mv (fmap (<> Demanded (Id i) 1)) j
+    updateCountAt ::
+      forall (m :: Type -> Type).
+      PrimMonad m =>
+      MVector (PrimState m) Int -> Ref -> m ()
+    updateCountAt mv = \case
+      AnId (Id i) -> MVector.modify mv (\case (-1) -> (-1); old -> old + 1) i
       AVar _ -> pure ()
+    getNeededFrom ::
+      forall (m :: Type -> Type).
+      PrimMonad m =>
+      MVector (PrimState m) (Set Hash) -> Ref -> m (Set Hash)
+    getNeededFrom mv = \case
+      AnId (Id i) -> MVector.read mv i
+      AVar v -> pure . Set.singleton $ v
+    multsToSet :: NonEmptyVector (Maybe Multiplicity) -> Set Hash
+    multsToSet = NEVector.foldl' go Set.empty
+    go :: Set Hash -> Maybe Multiplicity -> Set Hash
+    go acc = \case
+      Nothing -> acc
+      Just (MultiplicityOne h) -> Set.insert h acc
+      Just (MultiplicityMany h) -> Set.insert h acc
 
 -- Pretty Printer Helpers
 

--- a/Plutarch/Backend/Compile.hs
+++ b/Plutarch/Backend/Compile.hs
@@ -8,7 +8,7 @@ module Plutarch.Backend.Compile (
   toUPLCTerm,
 ) where
 
-import Control.Monad (foldM, guard)
+import Control.Monad (foldM, when)
 import Control.Monad.RWS.CPS (
   MonadState (get),
   RWS,
@@ -17,20 +17,22 @@ import Control.Monad.RWS.CPS (
   modify,
   runRWS,
  )
-import Control.Monad.Reader (MonadReader, runReaderT)
+import Control.Monad.Reader (MonadReader)
 import Control.Monad.ST (runST)
-import Control.Monad.State.Strict (put, runStateT)
+import Control.Monad.State.Strict (gets, put, runStateT)
 import Data.Foldable (foldl', for_)
 import Data.Kind (Type)
+import Data.List.NonEmpty qualified as NEList
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (fromJust, maybeToList)
+import Data.Maybe (fromJust)
 import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Set.NonEmpty (NESet)
+import Data.Set.NonEmpty qualified as NESet
 import Data.Text (Text)
-import Data.Vector (MVector)
 import Data.Vector qualified as Vector
-import Data.Vector.Mutable (PrimMonad, PrimState)
+import Data.Vector.Mutable (PrimMonad)
 import Data.Vector.Mutable qualified as MVector
 import Data.Vector.NonEmpty (NonEmptyVector)
 import Data.Vector.NonEmpty qualified as NEVector
@@ -123,9 +125,12 @@ toUPLCTerm (ANF _ binds) =
       namedBinds = fst . evalRWS (NEVector.mapM nameBind rewrittenBinds) usedNames $ lastFresh''
       -- Set up our compilation environment with everything we just put together
       compileEnv = CompileEnv namedBinds fixpointNameMap compositionNameMap unusedParamName mIdentity
+      compileState = CompileState Map.empty Map.empty
    in -- Use our demand analysis to compile everything.
-      runST $ runReaderT compile compileEnv
+      runCompileM compile compileEnv compileState
   where
+    -- runST $ runReaderT compile compileEnv
+
     collectVarName :: Set Int -> ANFBind ann -> Set Int
     collectVarName acc = \case
       ANFLeaf _ -> acc
@@ -151,6 +156,210 @@ toUPLCTerm (ANF _ binds) =
       pure (mkName "bind" fresh, bind)
 
 -- Helpers
+
+compile ::
+  forall (m :: Type -> Type).
+  (MonadState CompileState m, MonadReader CompileEnv m) =>
+  m UPLCTerm
+compile = do
+  binds <- asks (NEVector.map snd . ceBinds)
+  NEVector.imapM_ compileWithCache binds
+  let topNodeIx = NEVector.length binds - 1
+  -- This cannot 'miss', as we have compiled every node, and the top node is
+  -- always the last bind.
+  fromJust <$> gets (Map.lookup (Id topNodeIx) . csCache)
+  where
+    compileWithCache :: Int -> ANFBind Demand -> m ()
+    compileWithCache ix bind = do
+      -- First, determine if this will be bound at some future stage. If so,
+      -- record it now as we're seeing this bind for the first time.
+      case getANFBindAnn bind of
+        -- This is the top-level node.
+        NeverDemanded -> pure ()
+        -- This node is always inlined.
+        Trivial -> pure ()
+        -- If we need this more than once, record this fact.
+        Demanded letBindLoc useCount -> when (useCount > 1) (modify (recordLetBind letBindLoc ix))
+      -- Check if we have to `let`-bind anything here.
+      letBindsRequired <- do
+        mBinds <- gets (Map.lookup (Id ix) . csBindRequirements)
+        case mBinds of
+          Nothing -> pure []
+          Just ess -> traverse lookupBindName . NEList.toList . NESet.toList $ ess
+      -- Compile the bind, doing any `let`-binds we need, and cache.
+      compileAndCache ix letBindsRequired bind
+
+compileAndCache ::
+  forall (m :: Type -> Type).
+  (MonadState CompileState m, MonadReader CompileEnv m) =>
+  Int -> [(PLC.Name, UPLCTerm)] -> ANFBind Demand -> m ()
+compileAndCache ix requiredLetBinds = \case
+  -- Leaves can never require any `let`-bindings, so we just compile and cache
+  -- the bind and move on. Furthermore, leaves can never reference anything, so
+  -- we don't have to namecheck.
+  ANFLeaf ell -> modify (writeToCache (Id ix) . compileLeaf $ ell)
+  -- For `force` and `delay`, we have to namecheck their bodies. We also have to
+  -- potentially resolve some `let`-binds.
+  ANFForce _ body -> do
+    bodyCode <- checkCache body
+    modify (writeToCache (Id ix) . doLetBinds requiredLetBinds . uplcForce $ bodyCode)
+  ANFDelay _ body -> do
+    bodyCode <- checkCache body
+    modify (writeToCache (Id ix) . doLetBinds requiredLetBinds . uplcDelay $ bodyCode)
+  -- Fixpoint nodes require considerable additional work. Given the body `F`, we
+  -- want to generate `M (\r -> F (r r))`. We have two names set aside for this:
+  -- one for the argument of `M`, the other for `r`. As `M` is small, it's
+  -- cheaper to inline than `let`-bind it. We also don't bother `let`-binding
+  -- `(\r -> F (r r))`: it is a small computation, and if `F` is unique (up to
+  -- alpha renaming), so is `(\r -> F (r r))`.
+  --
+  -- Furthermore, `let`-bind requirements have to be done carefully. Like with
+  -- lambdas, our analysis detects _binding_ sites, which means that we have to
+  -- resolve `let`-bindings required here 'around' `F`, not the result!
+  ANFFix _ _ body -> do
+    -- Might as well resolve `let`-binds _now_.
+    bodyCode <- doLetBinds requiredLetBinds <$> checkCache body
+    -- This cannot 'miss', as we checked before for all fixpoint sites and made
+    -- a name pair for each.
+    (mArgName, functionalArgName) <- asks (fromJust . Map.lookup ix . ceFPNameMap)
+    -- `M = \x -> x x`, using the reserved name.
+    let m = uplcMCombinator mArgName
+    -- `r`, using the reserved name.
+    let funcArg = uplcVar functionalArgName
+    -- `r r`
+    let funcSelfApp = uplcApply1 funcArg funcArg
+    -- Assemble everything.
+    let finalCode = uplcApply1 m . uplcLam1 functionalArgName . uplcApply1 bodyCode $ funcSelfApp
+    modify (writeToCache (Id ix) finalCode)
+  ANFConstr _ tag fields -> do
+    fieldCodes <- traverse checkCache fields
+    modify (writeToCache (Id ix) . doLetBinds requiredLetBinds . uplcConstr tag $ fieldCodes)
+  ANFCase _ scrut handlers -> do
+    scrutCode <- checkCache scrut
+    handlerCodes <- traverse checkCache handlers
+    modify (writeToCache (Id ix) . doLetBinds requiredLetBinds . uplcCase scrutCode $ handlerCodes)
+  ANFApply _ f xs -> do
+    -- Check if `f` is the identity
+    applyingToId <- isTheIdentity f
+    xsCode <- traverse checkCache xs
+    -- If `f` is the identity, then we already for certain know there's only one
+    -- argument, so we can just compile that instead.
+    if applyingToId
+      then modify (writeToCache (Id ix) . doLetBinds requiredLetBinds . NEVector.head $ xsCode)
+      else do
+        fCode <- checkCache f
+        let xsLen = NEVector.length xsCode
+        -- If we have two or fewer applications, we can compile an `app` chain.
+        -- However, for three or more, it's more efficient to 'pack' the `xs`
+        -- into a `constr`, then `case` on it immediately using `f` as the sole
+        -- handler.
+        if xsLen <= 2
+          then modify (writeToCache (Id ix) . doLetBinds requiredLetBinds . uplcApply fCode $ xsCode)
+          else do
+            let constrCall = uplcConstr 0 . NEVector.toVector $ xsCode
+            let soleHandler = NEVector.singleton fCode
+            modify (writeToCache (Id ix) . doLetBinds requiredLetBinds . uplcCase constrCall $ soleHandler)
+  -- As with fixpoints, our analysis detects _binding_ sites, we have to
+  -- resolve `let`-binds 'around' the _body_ of the lambda, not the lambda
+  -- itself!
+  ANFLam _ params body -> do
+    bodyCode <- doLetBinds requiredLetBinds <$> checkCache body
+    asParamNames <- NEVector.mapM multToName params
+    modify (writeToCache (Id ix) . uplcLam asParamNames $ bodyCode)
+  -- For compositions, given components `[f_1, f_2, ... , f_k]`, we want to
+  -- generate `\z -> f_1 (f_2 ( ... (f_k z) ... )`. We have a name set aside for
+  -- `z` to ensure it's unique.
+  ANFCompose _ components -> do
+    componentCodes <- traverse checkCache components
+    -- This cannot 'miss', as we have checked every site of a composition and
+    -- set aside an argument for it specifically.
+    compArgName <- asks (fromJust . Map.lookup ix . ceCompNameMap)
+    -- We have to fold 'backwards' here, as application order would apply the
+    -- _last_ item in the composition first. We could reverse the vector, but
+    -- this would require copying it, so we don't.
+    let len = NEVector.length componentCodes
+    let reverseIxes = [len - 1, len - 2 .. 0]
+    let asCompArg = uplcVar compArgName
+    let finalCode = foldl' (\acc i -> uplcApply1 (componentCodes NEVector.! i) acc) asCompArg reverseIxes
+    modify (writeToCache (Id ix) . uplcLam1 compArgName . doLetBinds requiredLetBinds $ finalCode)
+
+multToName ::
+  forall (m :: Type -> Type).
+  MonadReader CompileEnv m =>
+  Maybe Multiplicity -> m PLC.Name
+multToName = \case
+  Nothing -> asks ceUnusedParamName
+  Just (MultiplicityOne (Hash h)) -> pure . mkName "arg" $ h
+  Just (MultiplicityMany (Hash h)) -> pure . mkName "arg" $ h
+
+isTheIdentity ::
+  forall (m :: Type -> Type).
+  MonadReader CompileEnv m =>
+  Ref -> m Bool
+isTheIdentity = \case
+  AnId i -> asks ((== Just i) . ceTheIdentity)
+  _ -> pure False
+
+doLetBinds :: [(PLC.Name, UPLCTerm)] -> UPLCTerm -> UPLCTerm
+doLetBinds requiredLetBinds t =
+  foldl' (\acc (name, bind) -> uplcLet name bind acc) t requiredLetBinds
+
+checkCache ::
+  forall (m :: Type -> Type).
+  (MonadReader CompileEnv m, MonadState CompileState m) =>
+  Ref -> m UPLCTerm
+checkCache = \case
+  -- Variables always inline, so we don't even need to check the cache for them.
+  AVar (Hash h) -> pure . uplcVar . mkName "arg" $ h
+  -- Depending on the demand analysis, we might need to refer to this code by
+  -- name instead of by its literal compilation. We check this first.
+  AnId asId@(Id i) -> do
+    (name, bind) <- asks (\env -> ceBinds env NEVector.! i)
+    -- Due to compilation order (from dependencies to dependents), we can never
+    -- require code of a subcomputation that we haven't already compiled. Thus,
+    -- this cannot 'miss'.
+    code <- gets (fromJust . Map.lookup asId . csCache)
+    pure $ case getANFBindAnn bind of
+      Demanded _ useCount ->
+        if useCount > 1
+          -- Use name
+          then uplcVar name
+          -- Use code
+          else code
+      -- Use code unconditionally
+      _ -> code
+
+writeToCache :: Id -> UPLCTerm -> CompileState -> CompileState
+writeToCache i code = \case
+  CompileState cache reqs -> CompileState (Map.insert i code cache) reqs
+
+compileLeaf :: Leaf ann -> UPLCTerm
+compileLeaf = \case
+  LConstant _ c -> uplcConstant c
+  LBuiltin _ f -> uplcBuiltin f
+  LCompiled _ code -> code
+  LError _ -> uplcError
+
+lookupBindName ::
+  forall (m :: Type -> Type).
+  (MonadReader CompileEnv m, MonadState CompileState m) =>
+  Id -> m (PLC.Name, UPLCTerm)
+lookupBindName i@(Id asIx) = do
+  name <- asks (\env -> fst $ ceBinds env NEVector.! asIx)
+  -- Due to the order we compile in, we can never require something to be
+  -- `let`-bound before it's been compiled. Thus, this cannot 'miss'.
+  code <- gets (fromJust . Map.lookup i . csCache)
+  pure (name, code)
+
+recordLetBind :: Id -> Int -> CompileState -> CompileState
+recordLetBind letBindLoc whatToBind = \case
+  CompileState cache reqs -> CompileState cache . Map.alter go letBindLoc $ reqs
+  where
+    go :: Maybe (NESet Id) -> Maybe (NESet Id)
+    go =
+      Just . \case
+        Nothing -> NESet.singleton (Id whatToBind)
+        Just ess -> NESet.insert (Id whatToBind) ess
 
 fixPrecompiled ::
   NonEmptyVector (ANFBind Demand) ->
@@ -182,223 +391,18 @@ fixPrecompiled binds usedNames = runST $ runStateT go usedNames
       v <- Vector.unsafeFreeze mv
       pure . NEVector.unsafeFromVector $ v
 
-compile ::
-  forall (m :: Type -> Type).
-  (MonadReader CompileEnv m, PrimMonad m) =>
-  m UPLCTerm
-compile = do
-  binds <- asks ceBinds
-  let len = NEVector.length binds
-  -- Mutable compile cache. This stores (and incrementally updates), for each
-  -- bind:
-  --
-  -- \* When it is first demanded (as an index, -1 means 'never demanded')
-  -- \* Its name (if it should be referred to via variable)
-  -- \* Its code
-  --
-  -- Because we compile from dependencies to dependents, we can do this in one
-  -- pass: we can never be forced to compile a dependency before all its
-  -- dependents are already cached.
-  mv <- MVector.new len
-  NEVector.imapM_ (compileWithCache mv) binds
-  (\(_, _, x) -> x) <$> MVector.read mv (len - 1)
-
-compileWithCache ::
-  forall (m :: Type -> Type).
-  (PrimMonad m, MonadReader CompileEnv m) =>
-  MVector (PrimState m) (Int, Maybe PLC.Name, UPLCTerm) ->
-  Int ->
-  (PLC.Name, ANFBind Demand) ->
-  m ()
-compileWithCache cache i (bindName, bind) = do
-  -- We only store the name of a compiled bind if we need to `let`-bind it
-  -- later.
-  let (firstDemanded, mName) = case getANFBindAnn bind of
-        -- Top-level node, nothing to do.
-        NeverDemanded -> (-1, Nothing)
-        -- Something we should always inline.
-        Trivial -> (-1, Nothing)
-        -- Check use count: if it's greater than 1, we have to let-bind;
-        -- otherwise, we inline.
-        Demanded (Id j) useCount ->
-          if useCount <= 1
-            then (j, Nothing)
-            else (j, Just bindName)
-  (toBind, code) <- compileBind cache i bind
-  -- In some cases (most notably compositions), we can end up with duplicate
-  -- `let`-bind requests. Thus, we first isolate uniquely named binds before
-  -- doing them.
-  let uniqueBinds = Map.fromList toBind
-  let codeWithBinds = Map.foldlWithKey' doLetBind code uniqueBinds
-  -- We only store the name of a compiled bind if we'd need to `let`-bind it
-  -- later.
-  MVector.write cache i (firstDemanded, mName, codeWithBinds)
-
-compileBind ::
-  forall (m :: Type -> Type).
-  (PrimMonad m, MonadReader CompileEnv m) =>
-  MVector (PrimState m) (Int, Maybe PLC.Name, UPLCTerm) ->
-  Int ->
-  ANFBind Demand ->
-  m ([(PLC.Name, UPLCTerm)], UPLCTerm)
-compileBind cache i = \case
-  ANFLeaf ell -> pure ([], compileLeaf ell)
-  ANFForce _ body -> do
-    (firstDemandedBody, mNameBody, codeBody) <- checkCache cache body
-    case mNameBody of
-      Nothing -> pure ([], uplcForce codeBody)
-      Just nameBody -> do
-        let forceBinds = [(nameBody, codeBody) | firstDemandedBody == i]
-        pure (forceBinds, uplcForce . uplcVar $ nameBody)
-  ANFDelay _ body -> do
-    (firstDemandedBody, mNameBody, codeBody) <- checkCache cache body
-    case mNameBody of
-      Nothing -> pure ([], uplcForce codeBody)
-      Just nameBody -> do
-        let delayBinds = [(nameBody, codeBody) | firstDemandedBody == i]
-        pure (delayBinds, uplcDelay . uplcVar $ nameBody)
-  ANFFix _ _ body -> do
-    (firstDemandedBody, mNameBody, codeBody) <- checkCache cache body
-    -- For fixed points, given the body `F`, we want to generate `M (\r -> F (r
-    -- r))`. We have two names set aside for this: one for the argument of `M`,
-    -- the other for `r`. As `M` is small, it's cheaper to inline than
-    -- `let`-bind it. We also don't bother `let`-binding `(\r -> F (r r))`: it
-    -- is a small computation, and if `F` is unique (up to alpha renaming), so
-    -- is `(\r -> F (r r))`.
-    (mArgName, functionalArgName) <- asks (fromJust . Map.lookup i . ceFPNameMap)
-    -- `M = \x -> x x`, using the reserved name.
-    let m = uplcMCombinator mArgName
-    -- `r`, using the reserved name.
-    let funcArg = uplcVar functionalArgName
-    -- `r r`
-    let funcSelfApp = uplcApply1 funcArg funcArg
-    -- Helper for code generation for fixpoint
-    let mkFixBody code = uplcApply1 m . uplcLam1 functionalArgName . uplcApply1 code $ funcSelfApp
-    case mNameBody of
-      -- Generate `M (\r -> F (r r))`
-      Nothing -> pure ([], mkFixBody codeBody)
-      Just nameBody -> do
-        let fixBinds = [(nameBody, codeBody) | firstDemandedBody == i]
-        pure (fixBinds, mkFixBody (uplcVar nameBody))
-  ANFConstr _ tag fields -> do
-    fields' <- traverse (checkCache cache) fields
-    let constrBinds = Vector.toList . Vector.mapMaybe (toBind i) $ fields'
-    let constrArgs = Vector.map (\(_, mName, code) -> maybe code uplcVar mName) fields'
-    pure (constrBinds, uplcConstr tag constrArgs)
-  ANFCase _ scrut handlers -> do
-    (firstDemandedScrut, mNameScrut, codeScrut) <- checkCache cache scrut
-    handlers' <- traverse (checkCache cache) handlers
-    let (mScrutBind, scrutArg) = case mNameScrut of
-          Nothing -> (Nothing, codeScrut)
-          Just scrutName ->
-            if firstDemandedScrut == i
-              then (Just (scrutName, codeScrut), uplcVar scrutName)
-              else (Nothing, uplcVar scrutName)
-    let caseBinds = NEVector.foldl' (extendBinds i) (maybeToList mScrutBind) handlers'
-    let handlerArgs = NEVector.map (\(_, mName, code) -> maybe code uplcVar mName) handlers'
-    pure (caseBinds, uplcCase scrutArg handlerArgs)
-  ANFApply _ f xs -> do
-    applyingToId <- isTheIdentity f
-    if applyingToId
-      -- Since applying anything to the identity is just itself, and we already
-      -- know for certain that there's exactly one argument, we can just compile
-      -- it instead.
-      then do
-        (firstDemandedX, mNameX, codeX) <- checkCache cache . NEVector.head $ xs
-        let (mXBind, xArg) = case mNameX of
-              Nothing -> (Nothing, codeX)
-              Just xName ->
-                if firstDemandedX == i
-                  then (Just (xName, codeX), uplcVar xName)
-                  else (Nothing, uplcVar xName)
-        pure (maybeToList mXBind, xArg)
-      else do
-        (firstDemandedF, mNameF, codeF) <- checkCache cache f
-        xs' <- traverse (checkCache cache) xs
-        let (mFBind, fArg) = case mNameF of
-              Nothing -> (Nothing, codeF)
-              Just fName ->
-                if firstDemandedF == i
-                  then (Just (fName, codeF), uplcVar fName)
-                  else (Nothing, uplcVar fName)
-        let applyBinds = NEVector.foldl' (extendBinds i) (maybeToList mFBind) xs'
-        let xsArgs = NEVector.map (\(_, mName, code) -> maybe code uplcVar mName) xs'
-        if NEVector.length xs' <= 2
-          -- Compile a regular chain of `apply`
-          then pure (applyBinds, uplcApply fArg xsArgs)
-          -- 'Pack' everything into a `constr`, then `case` it immediately using `f`
-          -- as the sole handler.
-          else do
-            let constrCall = uplcConstr 0 . NEVector.toVector $ xsArgs
-            let soleHandler = NEVector.singleton fArg
-            pure (applyBinds, uplcCase constrCall soleHandler)
-  ANFLam _ params body -> do
-    (firstDemandedBody, mNameBody, codeBody) <- checkCache cache body
-    asParamNames <- NEVector.mapM multToName params
-    case mNameBody of
-      Nothing -> pure ([], uplcLam asParamNames codeBody)
-      Just nameBody -> do
-        let lamBinds = [(nameBody, codeBody) | firstDemandedBody == i]
-        pure (lamBinds, uplcLam asParamNames . uplcVar $ nameBody)
-  ANFCompose _ components -> do
-    components' <- traverse (checkCache cache) components
-    let componentBinds = Vector.toList . NEVector.mapMaybe (toBind i) $ components'
-    let componentArgs = NEVector.map (\(_, mName, code) -> maybe code uplcVar mName) components'
-    -- For compositions, given components `[f_1, f_2, .. , f_k]`, we want to
-    -- generate `\z -> f_1 (f_2 ( ... (f_k z) ... )`. We have a name set aside
-    -- for `z` to ensure it's unique.
-    compArgName <- asks (fromJust . Map.lookup i . ceCompNameMap)
-    let len = NEVector.length components'
-    let body = foldl' (\acc i -> uplcApply1 (componentArgs NEVector.! i) acc) (uplcVar compArgName) [len - 1, len - 2 .. 0]
-    pure (componentBinds, uplcLam1 compArgName body)
-multToName ::
-  forall (m :: Type -> Type).
-  MonadReader CompileEnv m =>
-  Maybe Multiplicity -> m PLC.Name
-multToName = \case
-  Nothing -> asks ceUnusedParamName
-  Just (MultiplicityOne (Hash h)) -> pure . mkName "arg" $ h
-  Just (MultiplicityMany (Hash h)) -> pure . mkName "arg" $ h
-
-doLetBind :: UPLCTerm -> PLC.Name -> UPLCTerm -> UPLCTerm
-doLetBind f name v = uplcLet name v f
-
-compileLeaf :: Leaf ann -> UPLCTerm
-compileLeaf = \case
-  LConstant _ c -> uplcConstant c
-  LBuiltin _ f -> uplcBuiltin f
-  LCompiled _ code -> code
-  LError _ -> uplcError
-
-checkCache ::
-  forall (m :: Type -> Type).
-  PrimMonad m =>
-  MVector (PrimState m) (Int, Maybe PLC.Name, UPLCTerm) ->
-  Ref ->
-  m (Int, Maybe PLC.Name, UPLCTerm)
-checkCache compiled = \case
-  -- Variables are always just inlined, so we don't need to even check the
-  -- cache for them
-  AVar (Hash h) -> pure (-1, Nothing, uplcVar . mkName "arg" $ h)
-  AnId (Id j) -> MVector.read compiled j
-
-toBind :: Int -> (Int, Maybe PLC.Name, UPLCTerm) -> Maybe (PLC.Name, UPLCTerm)
-toBind i (firstDemanded, mName, code) = do
-  name <- mName
-  guard (firstDemanded == i)
-  pure (name, code)
-
-extendBinds ::
-  Int ->
-  [(PLC.Name, UPLCTerm)] ->
-  (Int, Maybe PLC.Name, UPLCTerm) ->
-  [(PLC.Name, UPLCTerm)]
-extendBinds i acc (firstDemanded, mName, code) = case mName of
-  Nothing -> acc
-  Just name ->
-    if firstDemanded == i
-      then (name, code) : acc
-      else acc
+findIdentity :: NonEmptyVector (ANFBind Demand) -> Maybe Id
+findIdentity binds = Id <$> NEVector.findIndex go binds
+  where
+    go :: ANFBind Demand -> Bool
+    go = \case
+      ANFLam _ mults r -> case NEVector.uncons mults of
+        (arg, rest) -> case fmap (\case MultiplicityOne h -> h; MultiplicityMany h -> h) arg of
+          Nothing -> False
+          Just h -> case r of
+            AVar h' -> Vector.null rest && h == h'
+            _ -> False
+      _ -> False
 
 -- Check every bind to see if it's a fixpoint, and if it is, record its
 -- position.
@@ -417,6 +421,16 @@ doFixpointAnalysis = NEVector.ifoldl' go Set.empty
       ANFFix {} -> Set.insert pos acc
       _ -> acc
 
+mkFixpointNames ::
+  Map Int (PLC.Name, PLC.Name) ->
+  Int ->
+  RWS (Set Int) () Int (Map Int (PLC.Name, PLC.Name))
+mkFixpointNames acc i = do
+  freshForM <- untilM getFresh (asks . Set.notMember)
+  freshForFunctional <- untilM getFresh (asks . Set.notMember)
+  let names = (mkName "mArg" freshForM, mkName "functionalArg" freshForFunctional)
+  pure . Map.insert i names $ acc
+
 -- Check every bind to see if it's a composition, and if it is, record its
 -- position.
 --
@@ -433,16 +447,6 @@ doCompositionAnalysis = NEVector.ifoldl' go Set.empty
     go acc pos = \case
       ANFCompose {} -> Set.insert pos acc
       _ -> acc
-
-mkFixpointNames ::
-  Map Int (PLC.Name, PLC.Name) ->
-  Int ->
-  RWS (Set Int) () Int (Map Int (PLC.Name, PLC.Name))
-mkFixpointNames acc i = do
-  freshForM <- untilM getFresh (asks . Set.notMember)
-  freshForFunctional <- untilM getFresh (asks . Set.notMember)
-  let names = (mkName "mArg" freshForM, mkName "functionalArg" freshForFunctional)
-  pure . Map.insert i names $ acc
 
 mkCompositionName ::
   Map Int PLC.Name ->
@@ -467,6 +471,29 @@ data CompileEnv = CompileEnv
     ceTheIdentity :: Maybe Id
   }
 
+data CompileState = CompileState
+  { csCache :: Map Id UPLCTerm
+  , csBindRequirements :: Map Id (NESet Id)
+  }
+
+newtype CompileM (a :: Type) = CompileM (RWS CompileEnv () CompileState a)
+  deriving
+    ( Functor
+    , Applicative
+    , Monad
+    , MonadReader CompileEnv
+    , MonadState CompileState
+    )
+    via (RWS CompileEnv () CompileState)
+
+runCompileM ::
+  forall (a :: Type).
+  CompileM a ->
+  CompileEnv ->
+  CompileState ->
+  a
+runCompileM (CompileM comp) env = fst . evalRWS comp env
+
 untilM ::
   forall (a :: Type) (m :: Type -> Type).
   Monad m =>
@@ -486,24 +513,3 @@ getFresh = do
 
 mkName :: Text -> Int -> PLC.Name
 mkName t = PLC.Name t . PLC.Unique
-
-findIdentity :: NonEmptyVector (ANFBind Demand) -> Maybe Id
-findIdentity binds = Id <$> NEVector.findIndex go binds
-  where
-    go :: ANFBind Demand -> Bool
-    go = \case
-      ANFLam _ mults r -> case NEVector.uncons mults of
-        (arg, rest) -> case fmap (\case MultiplicityOne h -> h; MultiplicityMany h -> h) arg of
-          Nothing -> False
-          Just h -> case r of
-            AVar h' -> Vector.null rest && h == h'
-            _ -> False
-      _ -> False
-
-isTheIdentity ::
-  forall (m :: Type -> Type).
-  MonadReader CompileEnv m =>
-  Ref -> m Bool
-isTheIdentity = \case
-  AnId i -> asks ((== Just i) . ceTheIdentity)
-  _ -> pure False

--- a/Plutarch/Primitive/Con.hs
+++ b/Plutarch/Primitive/Con.hs
@@ -11,13 +11,21 @@ module Plutarch.Primitive.Con (
 
 import Data.Kind (Type)
 import Plutarch.Backend.S (S)
-import Plutarch.Backend.Term (Term, punsafeBuiltin, punsafeCoerce)
+import Plutarch.Backend.Term (
+  Term,
+  punsafeCoerce,
+  punsafeConstant,
+ )
 import Plutarch.Primitive.Apply (
   PCanRepresent,
   PlutarchType (PRepresentation),
+  pcoerce,
   (#),
  )
+import Plutarch.Primitive.BuiltinFun (pmkCons, pmkPairData)
 import Plutarch.Primitive.Data (PAsData, PData)
+import Plutarch.Primitive.Liftable (AsPlutus, PLiftable (AsHaskell))
+import Plutarch.Primitive.List (PBList (PBCons, PBNil))
 import Plutarch.Primitive.Match (PMatch)
 import Plutarch.Primitive.Pair (PBPair (PBPair))
 import PlutusCore qualified as PLC
@@ -41,7 +49,13 @@ instance
   ) =>
   PCon (PBPair (PAsData a) (PAsData b))
   where
-  pcon' (PBPair x y) = punsafeBuiltin PLC.MkPairData # x # y
+  pcon' (PBPair x y) = pmkPairData # pcoerce x # pcoerce y
+
+-- | @since wip
+instance PLiftable a => PCon (PBList a) where
+  pcon' = \case
+    PBNil -> punsafeConstant (PLC.someValue @[AsPlutus (AsHaskell a)] [])
+    PBCons x xs -> pmkCons # pcoerce x # pcoerce xs
 
 -- | @since wip
 pcon ::

--- a/Plutarch/Primitive/SOP.hs
+++ b/Plutarch/Primitive/SOP.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE UndecidableInstances #-}
+
+module Plutarch.Primitive.SOP (
+  PSOP,
+) where
+
+import Plutarch.Backend.S (S)
+import Plutarch.Primitive.Apply (
+  PlutarchType,
+  PlutarchTypeRep (PlutarchTypeRep),
+ )
+
+-- | @since wip
+data PSOP (s :: S)
+
+type role PSOP nominal
+
+-- | @since wip
+deriving via (PlutarchTypeRep PSOP PSOP) instance PlutarchType PSOP

--- a/Plutarch/TH/Helpers.hs
+++ b/Plutarch/TH/Helpers.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE NoPartialTypeSignatures #-}
+
+module Plutarch.TH.Helpers (
+  checkTyName,
+  getArity,
+  conToName,
+  hasNoFields,
+  bindToName,
+  checkFieldsAreTerms,
+  fullTypeName,
+  mkContextOf,
+) where
+
+import Data.Foldable (foldl', for_)
+import Data.Kind qualified as GHC
+import Data.Vector (Vector)
+import Data.Vector qualified as Vector
+import Language.Haskell.TH (
+  Bang,
+  BndrVis,
+  Con (ForallC, GadtC, InfixC, NormalC, RecC, RecGadtC),
+  Dec,
+  Info (TyConI),
+  Name,
+  Q,
+  TyVarBndr (KindedTV, PlainTV),
+  Type (AppT, ConT, TupleT, VarT),
+  reify,
+ )
+import Plutarch.Backend.Term (Term)
+
+{- | Return the declaration of a type given its name, or error out if the name
+does not name a type.
+
+@since wip
+-}
+checkTyName :: Name -> Q Dec
+checkTyName tyName = do
+  tyInfo <- reify tyName
+  case tyInfo of
+    TyConI tyDec -> pure tyDec
+    _ -> fail $ show tyName <> " does not name a type."
+
+{- | Given a data constructor, state how many fields it has.
+
+@since wip
+-}
+getArity :: Con -> Word
+getArity = \case
+  NormalC _ fields -> fromIntegral . length $ fields
+  RecC _ fields -> fromIntegral . length $ fields
+  InfixC {} -> 2
+  ForallC _ _ con -> getArity con
+  GadtC _ fields _ -> fromIntegral . length $ fields
+  RecGadtC _ fields _ -> fromIntegral . length $ fields
+
+{- | Get the name of a non-GADT constructor. Error out if given a GADT
+constructor.
+
+@since wip
+-}
+conToName :: Con -> Q Name
+conToName = \case
+  NormalC name _ -> pure name
+  RecC name _ -> pure name
+  InfixC _ name _ -> pure name
+  ForallC _ _ con -> conToName con
+  GadtC {} -> fail "Derivation does not work on GADTs."
+  RecGadtC {} -> fail "Derivation does not work on GADTs."
+
+{- | Check that a data constructor has no fields.
+
+@since wip
+-}
+hasNoFields :: Con -> Bool
+hasNoFields = \case
+  NormalC _ fields -> null fields
+  RecC _ fields -> null fields
+  InfixC {} -> False
+  ForallC _ _ con -> hasNoFields con
+  GadtC _ fields _ -> null fields
+  RecGadtC _ fields _ -> null fields
+
+{- | Given a binder, yield the name it binds.
+
+@since wip
+-}
+bindToName :: TyVarBndr BndrVis -> Name
+bindToName = \case
+  PlainTV n _ -> n
+  KindedTV n _ _ -> n
+
+{- | Check that every field of the given data constructor is @'Term'@-wrapped.
+Error if not, or if given a nested @forall@ or GADT.
+
+@since wip
+-}
+checkFieldsAreTerms :: Con -> Q ()
+checkFieldsAreTerms = \case
+  NormalC name fields -> for_ fields (go name)
+  RecC name fields -> for_ fields (goNamed name)
+  InfixC lhs name rhs -> do
+    go name lhs
+    go name rhs
+  ForallC {} -> fail "Derivation does not work on nested foralls."
+  GadtC {} -> fail "Derivation does not work on GADTs."
+  RecGadtC {} -> fail "Derivation does not work on GADTs."
+  where
+    go :: Name -> (Bang, Type) -> Q ()
+    go conName (_, t) =
+      let errMsg =
+            "Constructor "
+              <> show conName
+              <> " has a field whose type is not wrapped in 'Term'."
+       in dig errMsg t
+    goNamed :: Name -> (Name, Bang, Type) -> Q ()
+    goNamed conName (fieldName, _, t) =
+      let errMsg =
+            "Constructor "
+              <> show conName
+              <> " has a field whose type is not wrapped in 'Term', specifically "
+              <> show fieldName
+              <> "."
+       in dig errMsg t
+    dig :: String -> Type -> Q ()
+    dig errMsg = \case
+      AppT x _ -> case x of
+        ConT n ->
+          if n == ''Term
+            then pure ()
+            else fail errMsg
+        _ -> dig errMsg x
+      _ -> fail errMsg
+
+{- | Given a \'base\' type name, and a list of type variable binds, construct
+the type name with all those binds applied.
+
+@since wip
+-}
+fullTypeName ::
+  forall (f :: GHC.Type -> GHC.Type).
+  Foldable f => Name -> f (TyVarBndr BndrVis) -> Type
+fullTypeName tyName = foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName)
+
+{- | Given a 'Vector' of type variables, and the name of a single-parameter type
+class, construct a context asserting all of these type variables are
+instances of that type class.
+
+@since wip
+-}
+mkContextOf :: Name -> Vector (TyVarBndr BndrVis) -> Type
+mkContextOf tyClassName tyVars =
+  let len = Vector.length tyVars
+      varNames = fmap (AppT (ConT tyClassName) . VarT . bindToName) tyVars
+   in foldl' AppT (TupleT len) varNames

--- a/Plutarch/TH/SOP.hs
+++ b/Plutarch/TH/SOP.hs
@@ -1,0 +1,173 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE NoPartialTypeSignatures #-}
+
+module Plutarch.TH.SOP (
+  deriveSOP,
+) where
+
+import Data.Foldable (foldl', foldlM, foldrM)
+import Data.Traversable.WithIndex (itraverse)
+import Data.Vector (Vector)
+import Data.Vector qualified as Vector
+import Data.Vector.NonEmpty qualified as NEVector
+import Language.Haskell.TH (
+  BndrVis,
+  Body (NormalB),
+  Con,
+  Dec,
+  Exp (AppE, CaseE, ConE, LamE, LitE, VarE),
+  Lit (IntegerL),
+  Match (Match),
+  Name,
+  Pat (ConP, VarP, WildP),
+  Q,
+  TyVarBndr,
+  Type,
+  newName,
+ )
+import Plutarch.Backend.Term (plam')
+import Plutarch.Primitive.Apply (PlutarchType (PRepresentation))
+import Plutarch.Primitive.Con (PCon (pcon'))
+import Plutarch.Primitive.Eq (PEq (peq))
+import Plutarch.Primitive.Match (PMatch (pmatch'))
+import Plutarch.Primitive.SOP (PSOP)
+import Plutarch.TH.Helpers (
+  conToName,
+  fullTypeName,
+  getArity,
+  hasNoFields,
+  mkContextOf,
+ )
+
+-- | @since wip
+deriveSOP :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
+deriveSOP tvbs name constructors = case Vector.unsnoc constructors of
+  Nothing -> fail "SOP derivation is not possible for nullary types."
+  Just (cs, c) ->
+    if Vector.all hasNoFields constructors
+      then fail "Use the Enum strategy for types with no fields in any 'arm'."
+      else do
+        plutarchTypeDec <- derivePlutarchType tvbs name
+        pmatchDec <- derivePMatch tvbs name cs c
+        pconDec <- derivePCon tvbs name constructors
+        peqDec <- derivePEq tvbs name constructors
+        pure $ plutarchTypeDec <> pmatchDec <> pconDec <> peqDec
+
+-- Helpers
+
+derivePlutarchType :: Vector (TyVarBndr BndrVis) -> Name -> Q [Dec]
+derivePlutarchType tyVars tyName =
+  [d|
+    instance $ctx => PlutarchType $name where
+      type PRepresentation $name = PSOP
+    |]
+  where
+    name :: Q Type
+    name = pure . fullTypeName tyName $ tyVars
+    ctx :: Q Type
+    ctx = pure . mkContextOf ''PlutarchType $ tyVars
+
+derivePMatch :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Con -> Q [Dec]
+derivePMatch tyVars tyName cs c =
+  [d|
+    instance $ctx => PMatch $name where
+      pmatch' x f = let handlers = $(mkHandlers 'f) in punsafeCase x handlers
+    |]
+  where
+    name :: Q Type
+    name = pure . fullTypeName tyName $ tyVars
+    ctx :: Q Type
+    ctx = pure . mkContextOf ''PlutarchType $ tyVars
+    -- We need one handler for each 'arm', of appropriate arity for the field
+    -- counts.
+    --
+    -- We know there's at least one arm because we checked before we made it
+    -- here.
+    mkHandlers :: Name -> Q Exp
+    mkHandlers contName = do
+      let arityLast = getArity c
+      nameLast <- conToName c
+      let aritiesRest = fmap getArity cs
+      namesRest <- traverse conToName cs
+      handlerLast <- mkHandler contName (nameLast, arityLast)
+      handlersRest <- traverse (mkHandler contName) (Vector.zip namesRest aritiesRest)
+      start <- [e|NEVector.singleton (toSomeTerm $(pure handlerLast))|]
+      foldrM (\e acc -> [e|NEVector.cons (toSomeTerm $(pure e)) $(pure acc)|]) start handlersRest
+    mkHandler :: Name -> (Name, Word) -> Q Exp
+    mkHandler contName (conName, arity) = do
+      argNames <- case arity of
+        0 -> pure []
+        n -> traverse (\i -> newName $ "x" <> show i) [0, 1 .. n - 1]
+      let conCallExp = AppE (VarE contName) . foldl' (\acc -> AppE acc . VarE) (ConE conName) $ argNames
+      pure . foldr (\name -> AppE (VarE 'plam') . LamE [VarP name]) conCallExp $ argNames
+
+derivePCon :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
+derivePCon tyVars tyName constructors =
+  [d|
+    instance $ctx => PCon $name where
+      pcon' x = $(matches 'x)
+    |]
+  where
+    name :: Q Type
+    name = pure . fullTypeName tyName $ tyVars
+    ctx :: Q Type
+    ctx = pure . mkContextOf ''PlutarchType $ tyVars
+    matches :: Name -> Q Exp
+    matches bindName = CaseE (VarE bindName) . Vector.toList <$> itraverse mkMatch constructors
+    mkMatch :: Int -> Con -> Q Match
+    mkMatch conIx con = do
+      let arity = getArity con
+      conName <- conToName con
+      fieldNames <- case arity of
+        0 -> pure []
+        n -> traverse (\i -> newName $ "f" <> show i) [0, 1 .. n - 1]
+      let conMatchPat = ConP conName [] . fmap VarP $ fieldNames
+      let constrIx = LitE . IntegerL . fromIntegral $ conIx
+      constrVec <- foldrM (\n acc -> [e|Vector.cons (toSomeTerm $(pure (VarE n))) $(pure acc)|]) (VarE 'Vector.empty) fieldNames
+      matchBody <- [e|punsafeConstr $(pure constrIx) $(pure constrVec)|]
+      pure . Match conMatchPat (NormalB matchBody) $ []
+
+derivePEq :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
+derivePEq tyVars tyName constructors =
+  [d|
+    instance $ctx => PEq $name where
+      peq = plam' $ \x -> plam' $ \y -> pmatch x $ \xInner ->
+        pmatch y $ \yInner ->
+          $(peqImpl 'xInner 'yInner)
+    |]
+  where
+    name :: Q Type
+    name = pure . fullTypeName tyName $ tyVars
+    ctx :: Q Type
+    ctx = pure . mkContextOf ''PEq $ tyVars
+    peqImpl :: Name -> Name -> Q Exp
+    peqImpl xName yName = do
+      matches <- Vector.toList <$> traverse (mkMatch yName) constructors
+      pure . CaseE (VarE xName) $ matches
+    mkMatch :: Name -> Con -> Q Match
+    mkMatch yName con = do
+      let arity = getArity con
+      conName <- conToName con
+      fieldNamesX <- case arity of
+        0 -> pure []
+        n -> traverse (\i -> newName $ "x" <> show i) [0, 1 .. n - 1]
+      fieldNamesY <- case arity of
+        0 -> pure []
+        n -> traverse (\i -> newName $ "y" <> show i) [0, 1 .. n - 1]
+      let xMatchPat = ConP conName [] . fmap VarP $ fieldNamesX
+      let yMatchPat = ConP conName [] . fmap VarP $ fieldNamesY
+      hitExp <- case zip fieldNamesX fieldNamesY of
+        [] -> [e|ptrue|]
+        (xField, yField) : fields -> do
+          let xVar = VarE xField
+          let yVar = VarE yField
+          start <- [e|peq # $(pure xVar) # $(pure yVar)|]
+          foldlM mkPand start fields
+      missExp <- [e|pfalse|]
+      let matchBody = CaseE (VarE yName) [Match yMatchPat (NormalB hitExp) [], Match WildP (NormalB missExp) []]
+      pure . Match xMatchPat (NormalB matchBody) $ []
+    mkPand :: Exp -> (Name, Name) -> Q Exp
+    mkPand acc (xName, yName) = do
+      let xVar = VarE xName
+      let yVar = VarE yName
+      [e|pand (peq # $(pure xVar) # $(pure yVar)) $(pure acc)|]

--- a/Plutarch/TH/Strategy.hs
+++ b/Plutarch/TH/Strategy.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+
+module Plutarch.TH.Strategy (
+  Strategy (..),
+  deriveFor,
+) where
+
+import Data.Foldable (foldl')
+import Data.Vector (Vector)
+import Data.Vector qualified as Vector
+import Language.Haskell.TH (
+  BndrVis,
+  Con (ForallC, GadtC, InfixC, NormalC, RecC, RecGadtC),
+  Dec (DataD, NewtypeD, TySynD),
+  Info (TyConI),
+  Name,
+  Q,
+  TyVarBndr (KindedTV, PlainTV),
+  Type (AppT, ConT, TupleT, VarT),
+  reify,
+ )
+import Plutarch.Primitive.Apply (PlutarchType (PRepresentation))
+import Plutarch.Primitive.SOP (PSOP)
+
+-- | @since wip
+data Strategy = SOP
+
+-- | @since wip
+deriveFor :: Name -> Strategy -> Q [Dec]
+deriveFor tyName strat = do
+  tyDec <- checkTyName tyName
+  case tyDec of
+    DataD _ name tyVarBinds _ constructors _ -> case strat of
+      SOP -> do
+        let tvbAsVec = Vector.fromList tyVarBinds
+        case Vector.unsnoc tvbAsVec of
+          Nothing -> fail "Types must have an s :: S type parameter in last position."
+          Just (tvbs, _) -> case constructors of
+            [] -> fail "Nullary types do not support an SOP derivation strategy."
+            (_ : _) ->
+              if all hasNoFields constructors
+                then fail "Use the Enum strategy for types with no fields in any 'arm'."
+                else derivePlutarchType tvbs name
+    NewtypeD {} -> case strat of
+      SOP -> fail "Use the Newtype strategy for newtypes."
+    TySynD {} -> fail "Type synonyms are not supported. Use the underlying type."
+    _ -> fail "Not a valid type name."
+
+-- Helpers
+
+derivePlutarchType :: Vector (TyVarBndr BndrVis) -> Name -> Q [Dec]
+derivePlutarchType tyVars tyName =
+  [d|
+    instance $ctx => PlutarchType $name where
+      type PRepresentation $name = PSOP
+    |]
+  where
+    name :: Q Type
+    name = pure $ foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName) tyVars
+    ctx :: Q Type
+    ctx = do
+      let len = Vector.length tyVars
+      let varNames = fmap (AppT (ConT ''PlutarchType) . VarT . bindToName) tyVars
+      pure $ foldl' AppT (TupleT len) varNames
+
+checkTyName :: Name -> Q Dec
+checkTyName tyName = do
+  tyInfo <- reify tyName
+  case tyInfo of
+    TyConI tyDec -> pure tyDec
+    _ -> fail $ show tyName <> " does not name a type."
+
+hasNoFields :: Con -> Bool
+hasNoFields = \case
+  NormalC _ fields -> null fields
+  RecC _ fields -> null fields
+  InfixC {} -> False
+  ForallC _ _ con -> hasNoFields con
+  GadtC _ fields _ -> null fields
+  RecGadtC _ fields _ -> null fields
+
+bindToName :: TyVarBndr BndrVis -> Name
+bindToName = \case
+  PlainTV n _ -> n
+  KindedTV n _ _ -> n

--- a/Plutarch/TH/Strategy.hs
+++ b/Plutarch/TH/Strategy.hs
@@ -1,293 +1,58 @@
-{-# LANGUAGE TemplateHaskellQuotes #-}
-
 module Plutarch.TH.Strategy (
   Strategy (..),
   deriveFor,
 ) where
 
-import Data.Foldable (foldl', foldlM, foldrM, for_)
-import Data.Traversable.WithIndex (itraverse)
-import Data.Vector (Vector)
+import Data.Foldable (traverse_)
 import Data.Vector qualified as Vector
-import Data.Vector.NonEmpty qualified as NEVector
 import Language.Haskell.TH (
-  Bang,
-  BndrVis,
-  Body (NormalB),
-  Con (ForallC, GadtC, InfixC, NormalC, RecC, RecGadtC),
   Dec (DataD, NewtypeD, TySynD),
-  Exp (AppE, CaseE, ConE, LamE, LitE, VarE),
-  Info (TyConI),
-  Lit (IntegerL),
-  Match (Match),
   Name,
-  Pat (ConP, VarP, WildP),
   Q,
-  TyVarBndr (KindedTV, PlainTV),
-  Type (AppT, ConT, TupleT, VarT),
-  newName,
-  reify,
  )
-import Plutarch.Backend.Term (Term, plam', punsafeConstr)
-import Plutarch.Primitive.Apply (PlutarchType (PRepresentation))
-import Plutarch.Primitive.Bool (pand)
-import Plutarch.Primitive.Con (PCon (pcon'))
-import Plutarch.Primitive.Eq (PEq (peq))
-import Plutarch.Primitive.Match (PMatch (pmatch'))
-import Plutarch.Primitive.SOP (PSOP)
+import Plutarch.TH.Helpers (checkFieldsAreTerms, checkTyName)
+import Plutarch.TH.SOP (deriveSOP)
 
--- | @since wip
-data Strategy = SOP
+{- | Specifies a representation choice for the data type you want derivations
+for. This will determine both what instances are generated, and also what the
+generated instances will look like.
 
--- | @since wip
+@since wip
+-}
+data Strategy
+  = {- | Use UPLC's built-in @SOP@ as the representation. This strategy derives
+    'PlutarchType', 'PMatch', 'PCon' and 'PEq' instances.
+
+    @since wip
+    -}
+    SOP
+
+{- | Given a type name, and a 'Strategy', derive all possible instances for that
+type as allowed by that 'Strategy'.
+
+= Important note
+
+All 'Strategy' choices assume that the type is formed correctly to be a
+Plutarch type. This means the following in practice:
+
+* The type's /last/ type parameter must be of kind 'S'.
+* Every field of every \'arm\' must be wrapped in @'Term' s@, where @s@ is
+  the type parameter of kind 'S'.
+
+@since wip
+-}
 deriveFor :: Name -> Strategy -> Q [Dec]
 deriveFor tyName strat = do
   tyDec <- checkTyName tyName
   case tyDec of
-    DataD _ name tyVarBinds _ constructors _ -> case strat of
-      SOP -> do
-        let tvbAsVec = Vector.fromList tyVarBinds
-        let consAsVec = Vector.fromList constructors
-        for_ consAsVec checkFieldsAreTermsSOP
-        case Vector.unsnoc tvbAsVec of
-          Nothing -> fail "Types must have an s :: S type parameter in last position."
-          Just (tvbs, _) -> case Vector.unsnoc consAsVec of
-            Nothing -> fail "Nullary types do not support an SOP derivation strategy."
-            Just (cs, c) ->
-              if all hasNoFields constructors
-                then fail "Use the Enum strategy for types with no fields in any 'arm'."
-                else do
-                  plutarchTypeDec <- deriveSOPPlutarchType tvbs name
-                  pmatchDec <- deriveSOPPMatch tvbs name cs c
-                  pconDec <- deriveSOPPCon tvbs name consAsVec
-                  peqDec <- deriveSOPPEq tvbs name consAsVec
-                  pure $ plutarchTypeDec <> pmatchDec <> pconDec <> peqDec
-    NewtypeD {} -> case strat of
-      SOP -> fail "Use the Newtype strategy for newtypes."
-    TySynD {} -> fail "Type synonyms are not supported. Use the underlying type."
-    _ -> fail "Not a valid type name."
-
--- Helpers
-
-deriveSOPPEq :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
-deriveSOPPEq tyVars tyName constructors =
-  [d|
-    instance $ctx => PEq $name where
-      peq = plam' $ \x -> plam' $ \y -> pmatch x $ \xInner ->
-        pmatch y $ \yInner ->
-          $(peqImpl 'xInner 'yInner)
-    |]
-  where
-    name :: Q Type
-    name = pure $ foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName) tyVars
-    ctx :: Q Type
-    ctx = do
-      let len = Vector.length tyVars
-      let varNames = fmap (AppT (ConT ''PEq) . VarT . bindToName) tyVars
-      pure $ foldl' AppT (TupleT len) varNames
-    peqImpl :: Name -> Name -> Q Exp
-    peqImpl xName yName = do
-      matches <- Vector.toList <$> traverse (mkMatch yName) constructors
-      pure . CaseE (VarE xName) $ matches
-    mkMatch :: Name -> Con -> Q Match
-    mkMatch yName con = do
-      let arity = getArity con
-      conName <- conToName con
-      fieldNamesX <- case arity of
-        0 -> pure []
-        n -> traverse (\i -> newName $ "x" <> show i) [0, 1 .. n - 1]
-      fieldNamesY <- case arity of
-        0 -> pure []
-        n -> traverse (\i -> newName $ "y" <> show i) [0, 1 .. n - 1]
-      let xMatchPat = ConP conName [] . fmap VarP $ fieldNamesX
-      let yMatchPat = ConP conName [] . fmap VarP $ fieldNamesY
-      hitExp <- case zip fieldNamesX fieldNamesY of
-        [] -> [e|ptrue|]
-        (xField, yField) : fields -> do
-          let xVar = VarE xField
-          let yVar = VarE yField
-          start <- [e|peq # $(pure xVar) # $(pure yVar)|]
-          foldlM mkPand start fields
-      missExp <- [e|pfalse|]
-      let matchBody = CaseE (VarE yName) [Match yMatchPat (NormalB hitExp) [], Match WildP (NormalB missExp) []]
-      pure . Match xMatchPat (NormalB matchBody) $ []
-    mkPand :: Exp -> (Name, Name) -> Q Exp
-    mkPand acc (xName, yName) = do
-      let xVar = VarE xName
-      let yVar = VarE yName
-      [e|pand (peq # $(pure xVar) # $(pure yVar)) $(pure acc)|]
-
-deriveSOPPCon :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
-deriveSOPPCon tyVars tyName constructors =
-  [d|
-    instance $ctx => PCon $name where
-      pcon' x = $(matches 'x)
-    |]
-  where
-    name :: Q Type
-    name = pure $ foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName) tyVars
-    ctx :: Q Type
-    ctx = do
-      let len = Vector.length tyVars
-      let varNames = fmap (AppT (ConT ''PlutarchType) . VarT . bindToName) tyVars
-      pure $ foldl' AppT (TupleT len) varNames
-    matches :: Name -> Q Exp
-    matches bindName = CaseE (VarE bindName) . Vector.toList <$> itraverse mkMatch constructors
-    mkMatch :: Int -> Con -> Q Match
-    mkMatch conIx con = do
-      let arity = getArity con
-      conName <- conToName con
-      fieldNames <- case arity of
-        0 -> pure []
-        n -> traverse (\i -> newName $ "f" <> show i) [0, 1 .. n - 1]
-      let conMatchPat = ConP conName [] . fmap VarP $ fieldNames
-      let constrIx = LitE . IntegerL . fromIntegral $ conIx
-      constrVec <- foldrM (\n acc -> [e|Vector.cons (toSomeTerm $(pure (VarE n))) $(pure acc)|]) (VarE 'Vector.empty) fieldNames
-      matchBody <- [e|punsafeConstr $(pure constrIx) $(pure constrVec)|]
-      pure . Match conMatchPat (NormalB matchBody) $ []
-
-deriveSOPPlutarchType :: Vector (TyVarBndr BndrVis) -> Name -> Q [Dec]
-deriveSOPPlutarchType tyVars tyName =
-  [d|
-    instance $ctx => PlutarchType $name where
-      type PRepresentation $name = PSOP
-    |]
-  where
-    name :: Q Type
-    name = pure $ foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName) tyVars
-    ctx :: Q Type
-    ctx = do
-      let len = Vector.length tyVars
-      let varNames = fmap (AppT (ConT ''PlutarchType) . VarT . bindToName) tyVars
-      pure $ foldl' AppT (TupleT len) varNames
-
-deriveSOPPMatch :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Con -> Q [Dec]
-deriveSOPPMatch tyVars tyName cs c =
-  [d|
-    instance $ctx => PMatch $name where
-      pmatch' x f = let handlers = $(mkHandlers 'f) in punsafeCase x handlers
-    |]
-  where
-    name :: Q Type
-    name = pure $ foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName) tyVars
-    ctx :: Q Type
-    ctx = do
-      let len = Vector.length tyVars
-      let varNames = fmap (AppT (ConT ''PlutarchType) . VarT . bindToName) tyVars
-      pure $ foldl' AppT (TupleT len) varNames
-    -- We need one handler for each 'arm', of appropriate arity for the field
-    -- counts.
-    --
-    -- We know there's at least one arm because we checked before we made it
-    -- here.
-    mkHandlers :: Name -> Q Exp
-    mkHandlers contName = do
-      let arityLast = getArity c
-      nameLast <- conToName c
-      let aritiesRest = fmap getArity cs
-      namesRest <- traverse conToName cs
-      handlerLast <- mkHandler contName (nameLast, arityLast)
-      handlersRest <- traverse (mkHandler contName) (Vector.zip namesRest aritiesRest)
-      start <- [e|NEVector.singleton (toSomeTerm $(pure handlerLast))|]
-      foldrM (\e acc -> [e|NEVector.cons (toSomeTerm $(pure e)) $(pure acc)|]) start handlersRest
-    mkHandler :: Name -> (Name, Word) -> Q Exp
-    mkHandler contName (conName, arity) = do
-      argNames <- case arity of
-        0 -> pure []
-        n -> traverse (\i -> newName $ "x" <> show i) [0, 1 .. n - 1]
-      let conCallExp = AppE (VarE contName) . foldl' (\acc -> AppE acc . VarE) (ConE conName) $ argNames
-      pure . foldr (\name -> AppE (VarE 'plam') . LamE [VarP name]) conCallExp $ argNames
-
-getArity :: Con -> Word
-getArity = \case
-  NormalC _ fields -> fromIntegral . length $ fields
-  RecC _ fields -> fromIntegral . length $ fields
-  InfixC {} -> 2
-  ForallC _ _ con -> getArity con
-  GadtC _ fields _ -> fromIntegral . length $ fields
-  RecGadtC _ fields _ -> fromIntegral . length $ fields
-
-conToName :: Con -> Q Name
-conToName = \case
-  NormalC name _ -> pure name
-  RecC name _ -> pure name
-  InfixC _ name _ -> pure name
-  ForallC _ _ con -> conToName con
-  GadtC {} -> fail "SOP derivation strategy does not work on GADTs."
-  RecGadtC {} -> fail "SOP derivation strategy does not work on GADTs."
-
-checkTyName :: Name -> Q Dec
-checkTyName tyName = do
-  tyInfo <- reify tyName
-  case tyInfo of
-    TyConI tyDec -> pure tyDec
-    _ -> fail $ show tyName <> " does not name a type."
-
-checkFieldsAreTermsSOP :: Con -> Q ()
-checkFieldsAreTermsSOP = \case
-  NormalC name fields -> for_ fields (checkFieldIsTerm name)
-  RecC name fields -> for_ fields (checkNamedFieldIsTerm name)
-  InfixC lhs name rhs -> do
-    checkFieldIsTerm name lhs
-    checkFieldIsTerm name rhs
-  ForallC {} -> fail "SOP derivation strategy does not work on nested foralls."
-  GadtC {} -> fail "SOP derivation strategy does not work on GADTs."
-  RecGadtC {} -> fail "SOP derivation strategy does not work on GADTs."
-
-checkFieldIsTerm :: Name -> (Bang, Type) -> Q ()
-checkFieldIsTerm conName (_, t) = digForTerm t
-  where
-    digForTerm :: Type -> Q ()
-    digForTerm = \case
-      AppT x _ -> case x of
-        ConT n ->
-          if n == ''Term
-            then pure ()
-            else
-              fail $
-                "Constructor "
-                  <> show conName
-                  <> " has a field whose type is not wrapped in 'Term'."
-        _ -> digForTerm x
-      _ ->
-        fail $
-          "Constructor "
-            <> show conName
-            <> " has a field whose type is not wrapped in 'Term'."
-
-checkNamedFieldIsTerm :: Name -> (Name, Bang, Type) -> Q ()
-checkNamedFieldIsTerm conName (fieldName, _, t) = digForTerm t
-  where
-    digForTerm :: Type -> Q ()
-    digForTerm = \case
-      AppT x _ -> case x of
-        ConT n ->
-          if n == ''Term
-            then pure ()
-            else
-              fail $
-                "Constructor "
-                  <> show conName
-                  <> " has a field whose type is not wrapped in 'Term', specifically "
-                  <> show fieldName
-        _ -> digForTerm x
-      _ ->
-        fail $
-          "Constructor "
-            <> show conName
-            <> " has a field whose type is not wrapped in 'Term', specifically "
-            <> show fieldName
-
-hasNoFields :: Con -> Bool
-hasNoFields = \case
-  NormalC _ fields -> null fields
-  RecC _ fields -> null fields
-  InfixC {} -> False
-  ForallC _ _ con -> hasNoFields con
-  GadtC _ fields _ -> null fields
-  RecGadtC _ fields _ -> null fields
-
-bindToName :: TyVarBndr BndrVis -> Name
-bindToName = \case
-  PlainTV n _ -> n
-  KindedTV n _ _ -> n
+    DataD _ name tyVarBinds _ constructors _ -> do
+      let tvbAsVec = Vector.fromList tyVarBinds
+      let consAsVec = Vector.fromList constructors
+      traverse_ checkFieldsAreTerms consAsVec
+      case Vector.unsnoc tvbAsVec of
+        Nothing -> fail "Types must have an s :: S type parameter in last position."
+        Just (tvbs, _) -> case strat of
+          SOP -> deriveSOP tvbs name consAsVec
+    NewtypeD {} -> fail "Newtype derivations not supported at present."
+    TySynD {} -> fail "Type synonym derivations are not supported. Define using the underlying type."
+    _ -> fail $ "Not a valid type name: " <> show tyName

--- a/Plutarch/TH/Strategy.hs
+++ b/Plutarch/TH/Strategy.hs
@@ -6,26 +6,31 @@ module Plutarch.TH.Strategy (
 ) where
 
 import Data.Foldable (foldl', foldrM, for_)
+import Data.Traversable.WithIndex (itraverse)
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
 import Data.Vector.NonEmpty qualified as NEVector
 import Language.Haskell.TH (
   Bang,
   BndrVis,
+  Body (NormalB),
   Con (ForallC, GadtC, InfixC, NormalC, RecC, RecGadtC),
   Dec (DataD, NewtypeD, TySynD),
-  Exp (AppE, ConE, LamE, VarE),
+  Exp (AppE, CaseE, ConE, LamE, LitE, VarE),
   Info (TyConI),
+  Lit (IntegerL),
+  Match (Match),
   Name,
-  Pat (VarP),
+  Pat (ConP, VarP),
   Q,
   TyVarBndr (KindedTV, PlainTV),
   Type (AppT, ConT, TupleT, VarT),
   newName,
   reify,
  )
-import Plutarch.Backend.Term (Term, plam')
+import Plutarch.Backend.Term (Term, plam', punsafeConstr)
 import Plutarch.Primitive.Apply (PlutarchType (PRepresentation))
+import Plutarch.Primitive.Con (PCon (pcon'))
 import Plutarch.Primitive.Match (PMatch (pmatch'))
 import Plutarch.Primitive.SOP (PSOP)
 
@@ -52,13 +57,43 @@ deriveFor tyName strat = do
                 else do
                   plutarchTypeDec <- deriveSOPPlutarchType tvbs name
                   pmatchDec <- deriveSOPPMatch tvbs name cs c
-                  pure $ plutarchTypeDec <> pmatchDec
+                  pconDec <- deriveSOPPCon tvbs name consAsVec
+                  pure $ plutarchTypeDec <> pmatchDec <> pconDec
     NewtypeD {} -> case strat of
       SOP -> fail "Use the Newtype strategy for newtypes."
     TySynD {} -> fail "Type synonyms are not supported. Use the underlying type."
     _ -> fail "Not a valid type name."
 
 -- Helpers
+
+deriveSOPPCon :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
+deriveSOPPCon tyVars tyName constructors =
+  [d|
+    instance $ctx => PCon $name where
+      pcon' x = $(matches 'x)
+    |]
+  where
+    name :: Q Type
+    name = pure $ foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName) tyVars
+    ctx :: Q Type
+    ctx = do
+      let len = Vector.length tyVars
+      let varNames = fmap (AppT (ConT ''PlutarchType) . VarT . bindToName) tyVars
+      pure $ foldl' AppT (TupleT len) varNames
+    matches :: Name -> Q Exp
+    matches bindName = CaseE (VarE bindName) . Vector.toList <$> itraverse mkMatch constructors
+    mkMatch :: Int -> Con -> Q Match
+    mkMatch conIx con = do
+      let arity = getArity con
+      conName <- conToName con
+      fieldNames <- case arity of
+        0 -> pure []
+        n -> traverse (\i -> newName $ "f" <> show i) [0, 1 .. n - 1]
+      let conMatchPat = ConP conName [] . fmap VarP $ fieldNames
+      let constrIx = LitE . IntegerL . fromIntegral $ conIx
+      constrVec <- foldrM (\n acc -> [e|Vector.cons (toSomeTerm $(pure (VarE n))) $(pure acc)|]) (VarE 'Vector.empty) fieldNames
+      matchBody <- [e|punsafeConstr $(pure constrIx) $(pure constrVec)|]
+      pure . Match conMatchPat (NormalB matchBody) $ []
 
 deriveSOPPlutarchType :: Vector (TyVarBndr BndrVis) -> Name -> Q [Dec]
 deriveSOPPlutarchType tyVars tyName =

--- a/Plutarch/TH/Strategy.hs
+++ b/Plutarch/TH/Strategy.hs
@@ -5,21 +5,28 @@ module Plutarch.TH.Strategy (
   deriveFor,
 ) where
 
-import Data.Foldable (foldl')
+import Data.Foldable (foldl', foldrM, for_)
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
+import Data.Vector.NonEmpty qualified as NEVector
 import Language.Haskell.TH (
+  Bang,
   BndrVis,
   Con (ForallC, GadtC, InfixC, NormalC, RecC, RecGadtC),
   Dec (DataD, NewtypeD, TySynD),
+  Exp (AppE, ConE, LamE, VarE),
   Info (TyConI),
   Name,
+  Pat (VarP),
   Q,
   TyVarBndr (KindedTV, PlainTV),
   Type (AppT, ConT, TupleT, VarT),
+  newName,
   reify,
  )
+import Plutarch.Backend.Term (Term, plam')
 import Plutarch.Primitive.Apply (PlutarchType (PRepresentation))
+import Plutarch.Primitive.Match (PMatch (pmatch'))
 import Plutarch.Primitive.SOP (PSOP)
 
 -- | @since wip
@@ -33,14 +40,19 @@ deriveFor tyName strat = do
     DataD _ name tyVarBinds _ constructors _ -> case strat of
       SOP -> do
         let tvbAsVec = Vector.fromList tyVarBinds
+        let consAsVec = Vector.fromList constructors
+        for_ consAsVec checkFieldsAreTermsSOP
         case Vector.unsnoc tvbAsVec of
           Nothing -> fail "Types must have an s :: S type parameter in last position."
-          Just (tvbs, _) -> case constructors of
-            [] -> fail "Nullary types do not support an SOP derivation strategy."
-            (_ : _) ->
+          Just (tvbs, _) -> case Vector.unsnoc consAsVec of
+            Nothing -> fail "Nullary types do not support an SOP derivation strategy."
+            Just (cs, c) ->
               if all hasNoFields constructors
                 then fail "Use the Enum strategy for types with no fields in any 'arm'."
-                else derivePlutarchType tvbs name
+                else do
+                  plutarchTypeDec <- deriveSOPPlutarchType tvbs name
+                  pmatchDec <- deriveSOPPMatch tvbs name cs c
+                  pure $ plutarchTypeDec <> pmatchDec
     NewtypeD {} -> case strat of
       SOP -> fail "Use the Newtype strategy for newtypes."
     TySynD {} -> fail "Type synonyms are not supported. Use the underlying type."
@@ -48,8 +60,8 @@ deriveFor tyName strat = do
 
 -- Helpers
 
-derivePlutarchType :: Vector (TyVarBndr BndrVis) -> Name -> Q [Dec]
-derivePlutarchType tyVars tyName =
+deriveSOPPlutarchType :: Vector (TyVarBndr BndrVis) -> Name -> Q [Dec]
+deriveSOPPlutarchType tyVars tyName =
   [d|
     instance $ctx => PlutarchType $name where
       type PRepresentation $name = PSOP
@@ -63,12 +75,122 @@ derivePlutarchType tyVars tyName =
       let varNames = fmap (AppT (ConT ''PlutarchType) . VarT . bindToName) tyVars
       pure $ foldl' AppT (TupleT len) varNames
 
+deriveSOPPMatch :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Con -> Q [Dec]
+deriveSOPPMatch tyVars tyName cs c =
+  [d|
+    instance $ctx => PMatch $name where
+      pmatch' x f = let handlers = $(mkHandlers 'f) in punsafeCase x handlers
+    |]
+  where
+    name :: Q Type
+    name = pure $ foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName) tyVars
+    ctx :: Q Type
+    ctx = do
+      let len = Vector.length tyVars
+      let varNames = fmap (AppT (ConT ''PlutarchType) . VarT . bindToName) tyVars
+      pure $ foldl' AppT (TupleT len) varNames
+    -- We need one handler for each 'arm', of appropriate arity for the field
+    -- counts.
+    --
+    -- We know there's at least one arm because we checked before we made it
+    -- here.
+    mkHandlers :: Name -> Q Exp
+    mkHandlers contName = do
+      let arityLast = getArity c
+      nameLast <- conToName c
+      let aritiesRest = fmap getArity cs
+      namesRest <- traverse conToName cs
+      handlerLast <- mkHandler contName (nameLast, arityLast)
+      handlersRest <- traverse (mkHandler contName) (Vector.zip namesRest aritiesRest)
+      start <- [e|NEVector.singleton (toSomeTerm $(pure handlerLast))|]
+      foldrM (\e acc -> [e|NEVector.cons (toSomeTerm $(pure e)) $(pure acc)|]) start handlersRest
+    mkHandler :: Name -> (Name, Word) -> Q Exp
+    mkHandler contName (conName, arity) = do
+      argNames <- case arity of
+        0 -> pure []
+        n -> traverse (\i -> newName $ "x" <> show i) [0, 1 .. n - 1]
+      let conCallExp = AppE (VarE contName) . foldl' (\acc -> AppE acc . VarE) (ConE conName) $ argNames
+      pure . foldr (\name -> AppE (VarE 'plam') . LamE [VarP name]) conCallExp $ argNames
+
+getArity :: Con -> Word
+getArity = \case
+  NormalC _ fields -> fromIntegral . length $ fields
+  RecC _ fields -> fromIntegral . length $ fields
+  InfixC {} -> 2
+  ForallC _ _ con -> getArity con
+  GadtC _ fields _ -> fromIntegral . length $ fields
+  RecGadtC _ fields _ -> fromIntegral . length $ fields
+
+conToName :: Con -> Q Name
+conToName = \case
+  NormalC name _ -> pure name
+  RecC name _ -> pure name
+  InfixC _ name _ -> pure name
+  ForallC _ _ con -> conToName con
+  GadtC {} -> fail "SOP derivation strategy does not work on GADTs."
+  RecGadtC {} -> fail "SOP derivation strategy does not work on GADTs."
+
 checkTyName :: Name -> Q Dec
 checkTyName tyName = do
   tyInfo <- reify tyName
   case tyInfo of
     TyConI tyDec -> pure tyDec
     _ -> fail $ show tyName <> " does not name a type."
+
+checkFieldsAreTermsSOP :: Con -> Q ()
+checkFieldsAreTermsSOP = \case
+  NormalC name fields -> for_ fields (checkFieldIsTerm name)
+  RecC name fields -> for_ fields (checkNamedFieldIsTerm name)
+  InfixC lhs name rhs -> do
+    checkFieldIsTerm name lhs
+    checkFieldIsTerm name rhs
+  ForallC {} -> fail "SOP derivation strategy does not work on nested foralls."
+  GadtC {} -> fail "SOP derivation strategy does not work on GADTs."
+  RecGadtC {} -> fail "SOP derivation strategy does not work on GADTs."
+
+checkFieldIsTerm :: Name -> (Bang, Type) -> Q ()
+checkFieldIsTerm conName (_, t) = digForTerm t
+  where
+    digForTerm :: Type -> Q ()
+    digForTerm = \case
+      AppT x _ -> case x of
+        ConT n ->
+          if n == ''Term
+            then pure ()
+            else
+              fail $
+                "Constructor "
+                  <> show conName
+                  <> " has a field whose type is not wrapped in 'Term'."
+        _ -> digForTerm x
+      _ ->
+        fail $
+          "Constructor "
+            <> show conName
+            <> " has a field whose type is not wrapped in 'Term'."
+
+checkNamedFieldIsTerm :: Name -> (Name, Bang, Type) -> Q ()
+checkNamedFieldIsTerm conName (fieldName, _, t) = digForTerm t
+  where
+    digForTerm :: Type -> Q ()
+    digForTerm = \case
+      AppT x _ -> case x of
+        ConT n ->
+          if n == ''Term
+            then pure ()
+            else
+              fail $
+                "Constructor "
+                  <> show conName
+                  <> " has a field whose type is not wrapped in 'Term', specifically "
+                  <> show fieldName
+        _ -> digForTerm x
+      _ ->
+        fail $
+          "Constructor "
+            <> show conName
+            <> " has a field whose type is not wrapped in 'Term', specifically "
+            <> show fieldName
 
 hasNoFields :: Con -> Bool
 hasNoFields = \case

--- a/Plutarch/TH/Strategy.hs
+++ b/Plutarch/TH/Strategy.hs
@@ -39,6 +39,10 @@ Plutarch type. This means the following in practice:
 * Every field of every \'arm\' must be wrapped in @'Term' s@, where @s@ is
   the type parameter of kind 'S'.
 
+While 'deriveFor' will check for all of these, it cannot \'look through\' type
+synonyms. Please make sure that you do not use a type synonym as a field of any data
+type that you wish to use 'deriveFor' with.
+
 @since wip
 -}
 deriveFor :: Name -> Strategy -> Q [Dec]

--- a/Plutarch/TH/Strategy.hs
+++ b/Plutarch/TH/Strategy.hs
@@ -5,7 +5,7 @@ module Plutarch.TH.Strategy (
   deriveFor,
 ) where
 
-import Data.Foldable (foldl', foldrM, for_)
+import Data.Foldable (foldl', foldlM, foldrM, for_)
 import Data.Traversable.WithIndex (itraverse)
 import Data.Vector (Vector)
 import Data.Vector qualified as Vector
@@ -21,7 +21,7 @@ import Language.Haskell.TH (
   Lit (IntegerL),
   Match (Match),
   Name,
-  Pat (ConP, VarP),
+  Pat (ConP, VarP, WildP),
   Q,
   TyVarBndr (KindedTV, PlainTV),
   Type (AppT, ConT, TupleT, VarT),
@@ -30,7 +30,9 @@ import Language.Haskell.TH (
  )
 import Plutarch.Backend.Term (Term, plam', punsafeConstr)
 import Plutarch.Primitive.Apply (PlutarchType (PRepresentation))
+import Plutarch.Primitive.Bool (pand)
 import Plutarch.Primitive.Con (PCon (pcon'))
+import Plutarch.Primitive.Eq (PEq (peq))
 import Plutarch.Primitive.Match (PMatch (pmatch'))
 import Plutarch.Primitive.SOP (PSOP)
 
@@ -58,13 +60,62 @@ deriveFor tyName strat = do
                   plutarchTypeDec <- deriveSOPPlutarchType tvbs name
                   pmatchDec <- deriveSOPPMatch tvbs name cs c
                   pconDec <- deriveSOPPCon tvbs name consAsVec
-                  pure $ plutarchTypeDec <> pmatchDec <> pconDec
+                  peqDec <- deriveSOPPEq tvbs name consAsVec
+                  pure $ plutarchTypeDec <> pmatchDec <> pconDec <> peqDec
     NewtypeD {} -> case strat of
       SOP -> fail "Use the Newtype strategy for newtypes."
     TySynD {} -> fail "Type synonyms are not supported. Use the underlying type."
     _ -> fail "Not a valid type name."
 
 -- Helpers
+
+deriveSOPPEq :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
+deriveSOPPEq tyVars tyName constructors =
+  [d|
+    instance $ctx => PEq $name where
+      peq = plam' $ \x -> plam' $ \y -> pmatch x $ \xInner ->
+        pmatch y $ \yInner ->
+          $(peqImpl 'xInner 'yInner)
+    |]
+  where
+    name :: Q Type
+    name = pure $ foldl' (\acc -> AppT acc . VarT . bindToName) (ConT tyName) tyVars
+    ctx :: Q Type
+    ctx = do
+      let len = Vector.length tyVars
+      let varNames = fmap (AppT (ConT ''PEq) . VarT . bindToName) tyVars
+      pure $ foldl' AppT (TupleT len) varNames
+    peqImpl :: Name -> Name -> Q Exp
+    peqImpl xName yName = do
+      matches <- Vector.toList <$> traverse (mkMatch yName) constructors
+      pure . CaseE (VarE xName) $ matches
+    mkMatch :: Name -> Con -> Q Match
+    mkMatch yName con = do
+      let arity = getArity con
+      conName <- conToName con
+      fieldNamesX <- case arity of
+        0 -> pure []
+        n -> traverse (\i -> newName $ "x" <> show i) [0, 1 .. n - 1]
+      fieldNamesY <- case arity of
+        0 -> pure []
+        n -> traverse (\i -> newName $ "y" <> show i) [0, 1 .. n - 1]
+      let xMatchPat = ConP conName [] . fmap VarP $ fieldNamesX
+      let yMatchPat = ConP conName [] . fmap VarP $ fieldNamesY
+      hitExp <- case zip fieldNamesX fieldNamesY of
+        [] -> [e|ptrue|]
+        (xField, yField) : fields -> do
+          let xVar = VarE xField
+          let yVar = VarE yField
+          start <- [e|peq # $(pure xVar) # $(pure yVar)|]
+          foldlM mkPand start fields
+      missExp <- [e|pfalse|]
+      let matchBody = CaseE (VarE yName) [Match yMatchPat (NormalB hitExp) [], Match WildP (NormalB missExp) []]
+      pure . Match xMatchPat (NormalB matchBody) $ []
+    mkPand :: Exp -> (Name, Name) -> Q Exp
+    mkPand acc (xName, yName) = do
+      let xVar = VarE xName
+      let yVar = VarE yName
+      [e|pand (peq # $(pure xVar) # $(pure yVar)) $(pure acc)|]
 
 deriveSOPPCon :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
 deriveSOPPCon tyVars tyName constructors =

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -196,6 +196,7 @@ library
     , indexed-traversable
     , lens
     , mtl
+    , nonempty-containers
     , nonempty-vector
     , plutus-core           ==1.64.0.0
     , plutus-ledger-api

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -172,6 +172,7 @@ library
     Plutarch.Script
     Plutarch.String
     Plutarch.TermCont
+    Plutarch.TH.Strategy
     Plutarch.Trace
     Plutarch.Unroll
     Plutarch.Unsafe
@@ -199,6 +200,7 @@ library
     , semialign
     , smash
     , sop-core
+    , template-haskell
     , text
     , these
     , unordered-containers

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -178,6 +178,8 @@ library
     Plutarch.Script
     Plutarch.String
     Plutarch.TermCont
+    Plutarch.TH.Helpers
+    Plutarch.TH.SOP
     Plutarch.TH.Strategy
     Plutarch.Trace
     Plutarch.Unroll

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -187,6 +187,7 @@ library
     , data-default
     , generics-sop
     , hashable
+    , indexed-traversable
     , lens
     , mtl
     , nonempty-vector

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -158,6 +158,7 @@ library
     Plutarch.Primitive.Numeric
     Plutarch.Primitive.Ord
     Plutarch.Primitive.Pair
+    Plutarch.Primitive.SOP
     Plutarch.Primitive.String
     Plutarch.Primitive.Value
     Plutarch.Rational

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -40,6 +40,7 @@ import Plutarch.Numeric.Multiplicative (ppowNatural)
 import Plutarch.Primitive.Apply ((#), (#$))
 import Plutarch.Primitive.Bool (
   PBool,
+  pand,
   pfalse,
   pif,
   pnot,

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Main (main) where
 
@@ -36,16 +37,25 @@ import Plutarch.Backend.Term (
 import Plutarch.Backend.UPLC (UPLCTerm (UPLCTerm))
 import Plutarch.Backend.VarMap (VarMap, vmEmpty)
 import Plutarch.Primitive.Apply ((#), (#$))
-import Plutarch.Primitive.Bool (PBool, pif, pnot, por)
+import Plutarch.Primitive.Bool (
+  PBool,
+  pfalse,
+  pif,
+  pnot,
+  por,
+ )
 import Plutarch.Primitive.BuiltinFun (
   paddInteger,
   pmultiplyInteger,
   psubtractInteger,
  )
+import Plutarch.Primitive.Eq (peq)
 import Plutarch.Primitive.Function ((:-->))
 import Plutarch.Primitive.List (PBList)
+import Plutarch.Primitive.Match (pmatch)
 import Plutarch.Primitive.Numeric (PInteger)
 import Plutarch.Primitive.Pair (PBPair)
+import Plutarch.TH.Strategy (Strategy (SOP), deriveFor)
 import PlutusCore qualified as PLC
 import PlutusCore.Pretty (prettyPlcReadable)
 import Prettyprinter (
@@ -62,6 +72,13 @@ import Test.Tasty.HUnit (
   testCaseSteps,
  )
 import Text.Show.Pretty (ppShow)
+
+data PThese (a :: S -> Type) (b :: S -> Type) (s :: S)
+  = PThis (Term s a)
+  | PThat (Term s b)
+  | PThese (Term s a) (Term s b)
+
+deriveFor ''PThese SOP
 
 main :: IO ()
 main =
@@ -318,6 +335,23 @@ main =
             let asAST = fromRawTerm t
             let anf = fromHashedAST asAST
             step $ toPrettyString anf
+            pure ()
+    , testCaseSteps "Case 15" $ \step -> do
+        step "Case: peq @(PThese PInteger PInteger)"
+        step "1. Does Case 15 compile?"
+        let compiled = compileTerm (peq @(PThese PInteger PInteger))
+        case compiled of
+          Left err -> assertFailure $ "Compile error: " <> show err
+          Right (_, t) -> do
+            step "Successfully compiled!"
+            step $ "RawTerm:\n" <> ppShow t
+            let asAST = fromRawTerm t
+            let anf = fromHashedAST asAST
+            step $ toPrettyString anf
+            let anf' = analyzeDemand anf
+            step $ toPrettyString anf'
+            let (UPLCTerm t) = toUPLCTerm anf'
+            step $ "UPLC\n" <> (renderString . layoutSmart defaultLayoutOptions . prettyPlcReadable $ t)
             pure ()
     ]
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -50,6 +50,7 @@ import Plutarch.Primitive.BuiltinFun (
   pmultiplyInteger,
   psubtractInteger,
  )
+import Plutarch.Primitive.ByteString (PByteString)
 import Plutarch.Primitive.Eq (peq)
 import Plutarch.Primitive.Function ((:-->))
 import Plutarch.Primitive.List (PBList)
@@ -79,6 +80,12 @@ data PThese (a :: S -> Type) (b :: S -> Type) (s :: S)
   | PThese (Term s a) (Term s b)
 
 deriveFor ''PThese SOP
+
+data PEither (a :: S -> Type) (b :: S -> Type) (s :: S)
+  = PLeft (Term s a)
+  | PRight (Term s b)
+
+deriveFor ''PEither SOP
 
 main :: IO ()
 main =
@@ -380,6 +387,26 @@ main =
         step "Case: peq @(PThese PInteger PInteger)"
         step "1. Does Case 17 compile?"
         let compiled = compileTerm (peq @(PThese PInteger PInteger))
+        case compiled of
+          Left err -> assertFailure $ "Compile error: " <> show err
+          Right (_, t) -> do
+            step "Successfully compiled!"
+            step $ "RawTerm:\n" <> ppShow t
+            let asAST = fromRawTerm t
+            step $ "AST:\n" <> ppShow asAST
+            let anf = fromHashedAST asAST
+            step "ANF, no demand analysis"
+            step $ toPrettyString anf
+            let anf' = analyzeDemand anf
+            step "ANF, with demand analysis"
+            step $ toPrettyString anf'
+            let t = toUPLCTerm anf'
+            step $ "UPLC:\n" <> toPrettyString t
+            pure ()
+    , testCaseSteps "Case 18" $ \step -> do
+        step "Case: peq @(PThese PInteger PInteger)"
+        step "1. Does Case 18 compile?"
+        let compiled = compileTerm (peq @(PEither PInteger PByteString))
         case compiled of
           Left err -> assertFailure $ "Compile error: " <> show err
           Right (_, t) -> do


### PR DESCRIPTION
Closes #1017 . This provides `PSOP`, as well as TH derivations for SOP encodings that produce `PlutarchType`, `PMatch`, `PCon` and `PEq`, with some codegen tests.

As part of this, I also discovered a nasty code generator bug which could leave dangling references for `let`-binds. This required a change to how we do demand analysis, as well as modifications for the code generator. I deliberately didn't change any APIs (only implementations) to limit the damage.