### PR TITLE
Enum derivation strategy

### DIFF
--- a/Plutarch/Primitive/CanData.hs
+++ b/Plutarch/Primitive/CanData.hs
@@ -57,7 +57,7 @@ class PlutarchType a => PCanData (a :: S -> Type) where
     forall (s :: S).
     PCanData (PRepresentation a) =>
     Term s (PAsData a) -> Term s a
-  pfromData = punsafeCoerce
+  pfromData = punsafeCoerce . pfromData @(PRepresentation a) . punsafeCoerce
   ptoData ::
     forall (s :: S).
     Term s a -> Term s (PAsData a)
@@ -65,7 +65,7 @@ class PlutarchType a => PCanData (a :: S -> Type) where
     forall (s :: S).
     PCanData (PRepresentation a) =>
     Term s a -> Term s (PAsData a)
-  ptoData = punsafeCoerce
+  ptoData = punsafeCoerce . ptoData . pcoerce
 
 -- | @since wip
 instance PCanData PInteger where

--- a/Plutarch/TH/Enum.hs
+++ b/Plutarch/TH/Enum.hs
@@ -1,0 +1,121 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# LANGUAGE NoPartialTypeSignatures #-}
+
+module Plutarch.TH.Enum (
+  deriveEnum,
+) where
+
+import Data.Foldable (foldrM)
+import Data.Traversable.WithIndex (itraverse)
+import Data.Vector (Vector)
+import Data.Vector qualified as Vector
+import Data.Vector.NonEmpty qualified as NEVector
+import Language.Haskell.TH (
+  BndrVis,
+  Body (NormalB),
+  Con,
+  Dec,
+  Exp (CaseE, ConE, LitE, VarE),
+  Lit (IntegerL),
+  Match (Match),
+  Name,
+  Pat (ConP),
+  Q,
+  TyVarBndr,
+  Type,
+ )
+import Plutarch.Primitive.Apply (PlutarchType (PRepresentation))
+import Plutarch.Primitive.Con (PCon (pcon'))
+import Plutarch.Primitive.Eq (PEq (peq))
+import Plutarch.Primitive.Match (PMatch (pmatch'))
+import Plutarch.Primitive.Numeric (PInteger)
+import Plutarch.TH.Helpers (
+  conToName,
+  fullTypeName,
+  hasNoFields,
+  mkContextOf,
+ )
+import PlutusCore qualified as PLC
+
+-- | @since wip
+deriveEnum :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
+deriveEnum tvbs name constructors = case Vector.unsnoc constructors of
+  Nothing -> fail "Enum derivation is not possible for nullary types."
+  Just (cs, c) ->
+    if Vector.all hasNoFields constructors
+      then do
+        plutarchTypeDec <- derivePlutarchType tvbs name
+        pmatchDec <- derivePMatch tvbs name cs c
+        pconDec <- derivePCon tvbs name constructors
+        peqDec <- derivePEq tvbs name
+        pure $ plutarchTypeDec <> pmatchDec <> pconDec <> peqDec
+      else fail "Cannot derive using Enum strategy for types with fields in any 'arm'."
+
+-- Helpers
+
+derivePlutarchType :: Vector (TyVarBndr BndrVis) -> Name -> Q [Dec]
+derivePlutarchType tyVars tyName =
+  [d|
+    instance $ctx => PlutarchType $name where
+      type PRepresentation $name = PInteger
+    |]
+  where
+    name :: Q Type
+    name = pure . fullTypeName tyName $ tyVars
+    ctx :: Q Type
+    ctx = pure . mkContextOf ''PlutarchType $ tyVars
+
+derivePMatch :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Con -> Q [Dec]
+derivePMatch tyVars tyName cs c =
+  [d|
+    instance $ctx => PMatch $name where
+      pmatch' x f = punsafeCase x $(mkHandlers 'f)
+    |]
+  where
+    name :: Q Type
+    name = pure . fullTypeName tyName $ tyVars
+    ctx :: Q Type
+    ctx = pure . mkContextOf ''PlutarchType $ tyVars
+    mkHandlers :: Name -> Q Exp
+    mkHandlers contName = do
+      nameLast <- conToName c
+      namesRest <- traverse conToName cs
+      handlerLast <- mkHandler contName nameLast
+      handlersRest <- traverse (mkHandler contName) namesRest
+      start <- [e|NEVector.singleton (toSomeTerm $(pure handlerLast))|]
+      foldrM (\e acc -> [e|NEVector.cons (toSomeTerm $(pure e)) $(pure acc)|]) start handlersRest
+    mkHandler :: Name -> Name -> Q Exp
+    mkHandler contName conName = [e|$(pure (VarE contName)) $(pure (ConE conName))|]
+
+derivePCon :: Vector (TyVarBndr BndrVis) -> Name -> Vector Con -> Q [Dec]
+derivePCon tyVars tyName constructors =
+  [d|
+    instance $ctx => PCon $name where
+      pcon' x = $(matches 'x)
+    |]
+  where
+    name :: Q Type
+    name = pure . fullTypeName tyName $ tyVars
+    ctx :: Q Type
+    ctx = pure . mkContextOf ''PlutarchType $ tyVars
+    matches :: Name -> Q Exp
+    matches bindName = CaseE (VarE bindName) . Vector.toList <$> itraverse mkMatch constructors
+    mkMatch :: Int -> Con -> Q Match
+    mkMatch conIx con = do
+      conName <- conToName con
+      let conMatchPat = ConP conName [] []
+      let constrIx = LitE . IntegerL . fromIntegral $ conIx
+      constrE <- [e|punsafeConstant (PLC.someValue @Integer $(pure constrIx))|]
+      pure . Match conMatchPat (NormalB constrE) $ []
+
+derivePEq :: Vector (TyVarBndr BndrVis) -> Name -> Q [Dec]
+derivePEq tyVars tyName =
+  [d|
+    instance $ctx => PEq $name where
+      peq = plam' $ \x -> plam' $ \y -> pequalsInteger # pcoerce x # pcoerce y
+    |]
+  where
+    name :: Q Type
+    name = pure . fullTypeName tyName $ tyVars
+    ctx :: Q Type
+    ctx = pure . mkContextOf ''PlutarchType $ tyVars

--- a/Plutarch/TH/Strategy.hs
+++ b/Plutarch/TH/Strategy.hs
@@ -11,6 +11,7 @@ import Language.Haskell.TH (
   Q,
  )
 import Plutarch.TH.DataPlutus (deriveDataPlutus)
+import Plutarch.TH.Enum (deriveEnum)
 import Plutarch.TH.Helpers (checkFieldsAreTerms, checkTyName)
 import Plutarch.TH.SOP (deriveSOP)
 
@@ -27,7 +28,7 @@ data Strategy
     @since wip
     -}
     SOP
-  | {- | Use `PData` as the representation. This strategy derives
+  | {- | Use @PData@ as the representation. This strategy derives
     'PlutarchType', 'PMatch', 'PCon' and 'PEq' instances.
 
     This will use a PlutusTx-style sum-of-products encoding with @Constr@,
@@ -36,6 +37,12 @@ data Strategy
     @since wip
     -}
     DataPlutus
+  | {- | Uses an onchain @Integer@ as the representation. This strategy derives
+    'PlutarchType', 'PMatch', 'PCon' and 'PEq' instances.
+
+    @since wip
+    -}
+    Enum
 
 {- | Given a type name, and a 'Strategy', derive all possible instances for that
 type as allowed by that 'Strategy'.
@@ -68,6 +75,7 @@ deriveFor tyName strat = do
         Just (tvbs, _) -> case strat of
           SOP -> deriveSOP tvbs name consAsVec
           DataPlutus -> deriveDataPlutus tvbs name consAsVec
+          Enum -> deriveEnum tvbs name consAsVec
     NewtypeD {} -> fail "Newtype derivations not supported at present."
     TySynD {} -> fail "Type synonym derivations are not supported. Define using the underlying type."
     _ -> fail $ "Not a valid type name: " <> show tyName

--- a/plutarch.cabal
+++ b/plutarch.cabal
@@ -180,6 +180,7 @@ library
     Plutarch.String
     Plutarch.TermCont
     Plutarch.TH.DataPlutus
+    Plutarch.TH.Enum
     Plutarch.TH.Helpers
     Plutarch.TH.SOP
     Plutarch.TH.Strategy
@@ -225,6 +226,7 @@ test-suite tests
   main-is:        Main.hs
   other-modules:
     TH.Data
+    TH.Enum
     TH.SOP
 
   hs-source-dirs: test

--- a/test/TH/Enum.hs
+++ b/test/TH/Enum.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -ddump-splices #-}
+
+module TH.Enum (PColour (..)) where
+
+import Plutarch.Backend.S (S)
+import Plutarch.Backend.Term (
+  plam',
+  punsafeCase,
+  punsafeConstant,
+  toSomeTerm,
+ )
+import Plutarch.Primitive.Apply (pcoerce, (#))
+import Plutarch.Primitive.BuiltinFun (pequalsInteger)
+import Plutarch.TH.Strategy (deriveFor)
+import Plutarch.TH.Strategy qualified as Strategy
+
+data PColour (s :: S)
+  = PRed
+  | PGreen
+  | PBlue
+
+deriveFor ''PColour Strategy.Enum


### PR DESCRIPTION
Follow-on from #1024 , closes #1028 . Also fixes a bug in the `default` method implementations for `PCanData`.