### PR TITLE
Remove unused TypeAbstractions pragma from Plutarch.Internal.Parse

### DIFF
--- a/Plutarch/Internal/Parse.hs
+++ b/Plutarch/Internal/Parse.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeAbstractions #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoPartialTypeSignatures #-}
 -- Note (Koz, 25/08/2025): Needed to ensure that `pparseData` doesn't get used


### PR DESCRIPTION
`Plutarch/Internal/Parse.hs` opens with `{-# LANGUAGE TypeAbstractions #-}`, but `TypeAbstractions` is GHC 9.8+ and `plutarch.cabal` declares `tested-with: GHC ==9.6.4`. On 9.6 the pragma alone is a hard error, so the module cannot be compiled at the version the package claims to support.

The extension is also unused: every `@a` in the file is a type *application*, which needs no extension, not a type *abstraction* (a binder on the left of `=`, e.g. `f @a x = ...`).

Removing the line lets the module build on GHC 9.6 and changes nothing on newer compilers.

Verified: Plutarch's full test suite passes (1063/1063) on GHC 9.6.6 with this applied.
