### PR TITLE
Drop plutarch-orphanage's duplicate Arbitrary1 NonEmptyList instance

### DIFF
--- a/plutarch-orphanage/src/PlutusLedgerApi/V1/Orphans/Value.hs
+++ b/plutarch-orphanage/src/PlutusLedgerApi/V1/Orphans/Value.hs
@@ -29,7 +29,6 @@ import Test.QuickCheck (
   CoArbitrary,
   Function (function),
   Gen,
-  NonEmptyList (NonEmpty),
   NonZero (NonZero),
   Positive (Positive),
   chooseBoundedIntegral,
@@ -309,19 +308,11 @@ instance Function PLA.TokenName where
 
 -- Helpers
 
--- This is frankly a bizarre omission
-instance Arbitrary1 NonEmptyList where
-  {-# INLINEABLE liftArbitrary #-}
-  liftArbitrary genInner =
-    NonEmpty <$> do
-      x <- genInner
-      xs <- liftArbitrary genInner
-      pure $ x : xs
-  {-# INLINEABLE liftShrink #-}
-  liftShrink shrinkInner (NonEmpty ell) =
-    NonEmpty <$> case ell of
-      [] -> []
-      (x : xs) -> (:) <$> shrinkInner x <*> liftShrink shrinkInner xs
+-- Note: this module used to define `instance Arbitrary1 NonEmptyList`, calling
+-- its absence "frankly a bizarre omission". QuickCheck now provides that
+-- instance itself (Test.QuickCheck.Modifiers), so keeping this one is a
+-- duplicate-instance error. Removed rather than CPP-guarded because the
+-- upstream definition supersedes it.
 
 {- | A 'PLA.Value' containing only Ada, suitable for fees. Furthermore, the
 Ada quantity is positive.


### PR DESCRIPTION
`plutarch-orphanage`'s `PlutusLedgerApi.V1.Orphans.Value` defines:

```haskell
-- This is frankly a bizarre omission
instance Arbitrary1 NonEmptyList where
```

QuickCheck has since agreed with that comment and added the instance to `Test.QuickCheck.Modifiers`. With a current QuickCheck both exist, so the local definition is a duplicate-instance error and `plutarch-orphanage` fails to compile.

This removes the local instance (and the now-unused `NonEmptyList (NonEmpty)` import) rather than CPP-guarding it, on the grounds that the upstream definition supersedes it and the two are semantically the same.

**Trade-off worth a maintainer's call:** this makes QuickCheck's instance load-bearing, so it raises the effective minimum QuickCheck version. If you would rather keep a lower bound, the alternative is a CPP guard plus a `build-depends` constraint — happy to switch to that if preferred.

Verified: Plutarch's full test suite passes (1063/1063) on GHC 9.6.6 with this applied.
