### PR TITLE
Pin GHC back to 9.6

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -57,7 +57,7 @@
 
           project = pkgs.haskell-nix.cabalProject' {
             src = ./.;
-            compiler-nix-name = "ghc984";
+            compiler-nix-name = "ghc96";
             # NOTE(bladyjoker): Follow https://github.com/input-output-hk/plutus/blob/master/cabal.project
             index-state = "2026-05-21T11:15:00Z";
             inputMap = {


### PR DESCRIPTION
Follow-on from #1045 . The Cabal file specifies that we tested with GHC 9.6 (which is the lower bound for Plutus Core), but the pinned GHC in our flake was 9.8 instead.